### PR TITLE
Pass native paths (with native separators) to qxsls's saveAs method

### DIFF
--- a/sources/decompiler.cpp
+++ b/sources/decompiler.cpp
@@ -223,10 +223,13 @@ bool Decompiler::WriteXLSX(QString output_folder){
             excel_row+=2;
         }
     }
-    display_text("File "+output_folder+"\\"+filename+" created.");
+
+    QString xlsx_output_file = QDir::toNativeSeparators(output_folder + "/" + filename);
+
+    display_text("File " +xlsx_output_file + " created.");
     QDir dir(output_folder);
     if (!dir.exists()) dir.mkpath(".");
-    excelScenarioSheet.saveAs(output_folder+"\\"+filename);
+    excelScenarioSheet.saveAs(xlsx_output_file);
     return true;
 }
 


### PR DESCRIPTION
Since Qsxls relies on QString for paths, we can't expect them to do
the right thing with it, so we pass an already fixed up native path.

This also makes the printed output file path correct for both windows and unix.