### PR TITLE
Include cmath in functions.h so ceil is available to all callers

### DIFF
--- a/headers/instruction.h
+++ b/headers/instruction.h
@@ -2,6 +2,7 @@
 #define INSTRUCTION_H
 #include <QString>
 #include <QDebug>
+#include <cmath>
 #include "headers/operande.h"
 #include "headers/Builder.h"
 


### PR DESCRIPTION
Please verify that this builds on MSVC as well. Also check to see if
it's where you want this inclusion to be. It was needed in 3 separate
files that all included functions.h.