### PR TITLE
Only use /bigobj cxx flag on MSVC

### DIFF
--- a/SenScriptsDecompiler.pro
+++ b/SenScriptsDecompiler.pro
@@ -41,5 +41,8 @@ HEADERS += \
     headers/decompiler.h \
     headers/translationfile.h \
     headers/utilities.h
-QMAKE_CXXFLAGS += /bigobj
+
+win32-msvc* {
+    QMAKE_CXXFLAGS += /bigobj
+}
 


### PR DESCRIPTION
This uses a construct of qmake that should work, but i have no ability to test it.
Simply compiling it should prove that it works though.