### PR TITLE
Cleanup all currently visible warnings outside of Qxlsx

### DIFF
--- a/headers/Builder.h
+++ b/headers/Builder.h
@@ -63,6 +63,7 @@ error: the latest instruction/function was incorrect
 class Builder{
 public:
     Builder();
+    virtual ~Builder() = default;
     virtual std::shared_ptr<Instruction> CreateInstructionFromDAT(int &addr, QByteArray &dat_content, int function_type)=0;
     virtual std::shared_ptr<Instruction> CreateInstructionFromXLSX(int &addr, int row, QXlsx::Document &xls_content)=0;
 

--- a/headers/CS1InstructionsSet.h
+++ b/headers/CS1InstructionsSet.h
@@ -825,7 +825,7 @@ class CS1Builder : public Builder
         OPCode0():Instruction(-1,0,nullptr){}
         OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
         OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
+        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
             addr++;
 
         }
@@ -838,7 +838,7 @@ class CS1Builder : public Builder
         OPCode1():Instruction(-1,1,nullptr){}
         OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
         OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
             addr++;
         }
 
@@ -1906,7 +1906,7 @@ class CS1Builder : public Builder
         OPCode1B():Instruction(-1,0x1B,nullptr){}
         OPCode1B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1B,Maker){}
         OPCode1B(int addr, Builder *Maker):Instruction(addr,"???",0x1B,Maker){}
-        OPCode1B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1B,Maker){
+        OPCode1B(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1B,Maker){
             addr++;
         }
 
@@ -1917,7 +1917,7 @@ class CS1Builder : public Builder
         OPCode1C():Instruction(-1,0x1C,nullptr){}
         OPCode1C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1C,Maker){}
         OPCode1C(int addr, Builder *Maker):Instruction(addr,"???",0x1C,Maker){}
-        OPCode1C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
+        OPCode1C(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
             addr++;
         }
 
@@ -3696,7 +3696,7 @@ class CS1Builder : public Builder
         OPCode4E():Instruction(-1,0x4E,nullptr){}
         OPCode4E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4E,Maker){}
         OPCode4E(int addr, Builder *Maker):Instruction(addr,"???",0x4E,Maker){}
-        OPCode4E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4E,Maker){
+        OPCode4E(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4E,Maker){
             addr++;
         }
 
@@ -3821,7 +3821,7 @@ class CS1Builder : public Builder
         OPCode57():Instruction(-1,0x57,nullptr){}
         OPCode57(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x57,Maker){}
         OPCode57(int addr, Builder *Maker):Instruction(addr,"???",0x57,Maker){}
-        OPCode57(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x57,Maker){
+        OPCode57(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x57,Maker){
             addr++;
         }
 
@@ -4798,7 +4798,7 @@ class CS1Builder : public Builder
         OPCode84():Instruction(-1,0x84,nullptr){}
         OPCode84(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x84,Maker){}
         OPCode84(int addr, Builder *Maker):Instruction(addr,"???",0x84,Maker){}
-        OPCode84(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
+        OPCode84(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
             addr++;
 
        }
@@ -5038,7 +5038,7 @@ class CS1Builder : public Builder
         OPCode95():Instruction(-1,0x95,nullptr){}
         OPCode95(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x95,Maker){}
         OPCode95(int addr, Builder *Maker):Instruction(addr,"???",0x95,Maker){}
-        OPCode95(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x95,Maker){
+        OPCode95(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x95,Maker){
             addr++;
 
         }
@@ -5088,7 +5088,7 @@ class CS1Builder : public Builder
         OPCode99():Instruction(-1,0x99,nullptr){}
         OPCode99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x99,Maker){}
         OPCode99(int addr, Builder *Maker):Instruction(addr,"???",0x99,Maker){}
-        OPCode99(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
+        OPCode99(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
             addr++;
 
         }

--- a/headers/CS1InstructionsSet.h
+++ b/headers/CS1InstructionsSet.h
@@ -1772,7 +1772,6 @@ class CS1Builder : public Builder
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            QString fun_name = ReadStringFromByteArray(addr, content);
             this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
             this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
             this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//i think this one is the id of the battle function it triggers

--- a/headers/CS1InstructionsSet.h
+++ b/headers/CS1InstructionsSet.h
@@ -4697,7 +4697,7 @@ class CS1Builder : public Builder
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
             this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            switch(control_byte[0]){
             case 0x01   :
             case 0x00:{
                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));

--- a/headers/CS1InstructionsSet.h
+++ b/headers/CS1InstructionsSet.h
@@ -445,14 +445,12 @@ class CS1Builder : public Builder
         ActionTable(int addr, Builder *Maker):Instruction(addr,"ActionTable", 258, Maker){}
         ActionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ActionTable", 258,Maker){
 
-            short shrt = 0;
             unsigned char current_byte = content[addr];
             this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
             int cnt = 0;
             while(cnt < current_byte){
 
 
-                shrt = ReadShortFromByteArray(addr, content);
 
                 QByteArray short_bytes = ReadSubByteArray(content, addr,2);
                 this->AddOperande(operande(addr,"short", short_bytes));//2
@@ -730,8 +728,6 @@ class CS1Builder : public Builder
         FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
         FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
 
-            int first_integer;
-            first_integer = ReadIntegerFromByteArray(addr, content);
 
             QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
             this->AddOperande(operande(addr,"int", first_integer_bytes));

--- a/headers/CS1InstructionsSet.h
+++ b/headers/CS1InstructionsSet.h
@@ -141,7 +141,7 @@ class CS1Builder : public Builder
                               }
 
                            }
-                        else if(((current_byte + 0xb7 & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
+                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
                                  (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
                                  (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
                                  current_op_value.push_back(current_byte);

--- a/headers/CS2InstructionsSet.h
+++ b/headers/CS2InstructionsSet.h
@@ -1968,7 +1968,6 @@ class CS2Builder : public Builder
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            QString fun_name = ReadStringFromByteArray(addr, content);
             this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
             this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
 

--- a/headers/CS2InstructionsSet.h
+++ b/headers/CS2InstructionsSet.h
@@ -440,7 +440,6 @@ class CS2Builder : public Builder
         EffectsInstr(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"EffectsInstr", 257,Maker){}
         EffectsInstr(int addr, Builder *Maker):Instruction(addr,"EffectsInstr", 257, Maker){}
         EffectsInstr(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"EffectsInstr", 257,Maker){
-            unsigned char current_byte = content[addr];
             bool bytes_blocks_remain = Maker->goal >= addr+0x28;
 
             while (bytes_blocks_remain){
@@ -458,7 +457,6 @@ class CS2Builder : public Builder
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
-                current_byte = content[addr];
                 bytes_blocks_remain = Maker->goal >= addr+0x28;
 
             }
@@ -474,14 +472,12 @@ class CS2Builder : public Builder
         ActionTable(int addr, Builder *Maker):Instruction(addr,"ActionTable", 258, Maker){}
         ActionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ActionTable", 258,Maker){
 
-            short shrt = 0;
             unsigned char current_byte = content[addr];
             this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
             int cnt = 0;
             while(cnt < current_byte){
 
 
-                shrt = ReadShortFromByteArray(addr, content);
 
                 QByteArray short_bytes = ReadSubByteArray(content, addr,2);
                 this->AddOperande(operande(addr,"short", short_bytes));//2
@@ -617,7 +613,6 @@ class CS2Builder : public Builder
 
 
                 this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-                short shrt = ReadShortFromByteArray(0, short_bytes);
                 if (addr+0x20 > Maker->goal) return;
                 cnt++;
             }
@@ -812,8 +807,6 @@ class CS2Builder : public Builder
         FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
         FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
 
-            int first_integer;
-            first_integer = ReadIntegerFromByteArray(addr, content);
 
             QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
             this->AddOperande(operande(addr,"int", first_integer_bytes));

--- a/headers/CS2InstructionsSet.h
+++ b/headers/CS2InstructionsSet.h
@@ -5618,7 +5618,7 @@ class CS2Builder : public Builder
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
             this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            switch(control_byte[0]){
             case 0x01   :
             case 0x00:{
                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));

--- a/headers/CS2InstructionsSet.h
+++ b/headers/CS2InstructionsSet.h
@@ -139,7 +139,7 @@ class CS2Builder : public Builder
                               }
 
                            }
-                        else if(((current_byte + 0xb7 & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
+                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
                                  (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
                                  (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
                                  current_op_value.push_back(current_byte);

--- a/headers/CS2InstructionsSet.h
+++ b/headers/CS2InstructionsSet.h
@@ -904,7 +904,7 @@ class CS2Builder : public Builder
         OPCode0():Instruction(-1,0,nullptr){}
         OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
         OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
+        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
             addr++;
 
         }
@@ -917,7 +917,7 @@ class CS2Builder : public Builder
         OPCode1():Instruction(-1,1,nullptr){}
         OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
         OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
             addr++;
         }
 
@@ -2118,7 +2118,7 @@ class CS2Builder : public Builder
         OPCode1C():Instruction(-1,0x1C,nullptr){}
         OPCode1C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1C,Maker){}
         OPCode1C(int addr, Builder *Maker):Instruction(addr,"???",0x1C,Maker){}
-        OPCode1C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
+        OPCode1C(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
             addr++;
         }
 
@@ -4628,7 +4628,7 @@ class CS2Builder : public Builder
         OPCode58():Instruction(-1,0x58,nullptr){}
         OPCode58(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x58,Maker){}
         OPCode58(int addr, Builder *Maker):Instruction(addr,"???",0x58,Maker){}
-        OPCode58(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x58,Maker){
+        OPCode58(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x58,Maker){
             addr++;
         }
 
@@ -5741,7 +5741,7 @@ class CS2Builder : public Builder
         OPCode85():Instruction(-1,0x85,nullptr){}
         OPCode85(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x85,Maker){}
         OPCode85(int addr, Builder *Maker):Instruction(addr,"???",0x85,Maker){}
-        OPCode85(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x85,Maker){
+        OPCode85(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x85,Maker){
             addr++;
 
 
@@ -6032,7 +6032,7 @@ class CS2Builder : public Builder
         OPCode96():Instruction(-1,0x96,nullptr){}
         OPCode96(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x96,Maker){}
         OPCode96(int addr, Builder *Maker):Instruction(addr,"???",0x96,Maker){}
-        OPCode96(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x96,Maker){
+        OPCode96(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x96,Maker){
             addr++;
 
         }
@@ -6082,7 +6082,7 @@ class CS2Builder : public Builder
         OPCode99():Instruction(-1,0x99,nullptr){}
         OPCode99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x99,Maker){}
         OPCode99(int addr, Builder *Maker):Instruction(addr,"???",0x99,Maker){}
-        OPCode99(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
+        OPCode99(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
             addr++;
 
         }
@@ -6454,7 +6454,7 @@ class CS2Builder : public Builder
         OPCodeAA():Instruction(-1,0xAA,nullptr){}
         OPCodeAA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAA,Maker){}
         OPCodeAA(int addr, Builder *Maker):Instruction(addr,"???",0xAA,Maker){}
-        OPCodeAA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAA,Maker){
+        OPCodeAA(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAA,Maker){
             addr++;
         }
     };

--- a/headers/CS3InstructionsSet.h
+++ b/headers/CS3InstructionsSet.h
@@ -1238,7 +1238,6 @@ class CS3Builder : public Builder
                 this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x1A
                 this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x1E
                 this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x22
-                QString fun_name = ReadStringFromByteArray(addr, content);
                 this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
                 this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
 

--- a/headers/CS3InstructionsSet.h
+++ b/headers/CS3InstructionsSet.h
@@ -863,7 +863,7 @@ class CS3Builder : public Builder
         OPCode0():Instruction(-1,0,nullptr){}
         OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
         OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
+        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
             addr++;
 
         }
@@ -876,7 +876,7 @@ class CS3Builder : public Builder
         OPCode1():Instruction(-1,1,nullptr){}
         OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
         OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
             addr++;
         }
 
@@ -1426,7 +1426,7 @@ class CS3Builder : public Builder
         OPCode26():Instruction(-1,0x26,nullptr){}
         OPCode26(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x26,Maker){}
         OPCode26(int addr, Builder *Maker):Instruction(addr,"???",0x26,Maker){}
-        OPCode26(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
+        OPCode26(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
                 addr++;
         }
 
@@ -4011,7 +4011,7 @@ class CS3Builder : public Builder
         OPCode62():Instruction(-1,0x62,nullptr){}
         OPCode62(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x62,Maker){}
         OPCode62(int addr, Builder *Maker):Instruction(addr,"???",0x62,Maker){}
-        OPCode62(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x62,Maker){
+        OPCode62(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x62,Maker){
                 addr++;
         }
     };
@@ -5000,7 +5000,7 @@ class CS3Builder : public Builder
         OPCode8F():Instruction(-1,0x8F,nullptr){}
         OPCode8F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8F", 0x8F,Maker){}
         OPCode8F(int addr, Builder *Maker):Instruction(addr,"0x8F",0x8F,Maker){}
-        OPCode8F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8F", 0x8F, Maker){
+        OPCode8F(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0x8F", 0x8F, Maker){
                 addr++;
         }
     };
@@ -5282,7 +5282,7 @@ class CS3Builder : public Builder
         OPCodeA0():Instruction(-1,0xA0,nullptr){}
         OPCodeA0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA0", 0xA0,Maker){}
         OPCodeA0(int addr, Builder *Maker):Instruction(addr,"0xA0",0xA0,Maker){}
-        OPCodeA0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA0", 0xA0,Maker){
+        OPCodeA0(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xA0", 0xA0,Maker){
                 addr++;
         }
     };
@@ -5562,7 +5562,7 @@ class CS3Builder : public Builder
         OPCodeB4():Instruction(-1,0xB4,nullptr){}
         OPCodeB4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB4", 0xB4,Maker){}
         OPCodeB4(int addr, Builder *Maker):Instruction(addr,"0xB4",0xB4,Maker){}
-        OPCodeB4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB4", 0xB4,Maker){
+        OPCodeB4(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xB4", 0xB4,Maker){
                 addr++;
 
 

--- a/headers/CS3InstructionsSet.h
+++ b/headers/CS3InstructionsSet.h
@@ -150,7 +150,7 @@ class CS3Builder : public Builder
                               }
 
                            }
-                        else if(((current_byte + 0xb7 & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
+                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
                                  (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
                                  (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
                                  current_op_value.push_back(current_byte);

--- a/headers/CS3InstructionsSet.h
+++ b/headers/CS3InstructionsSet.h
@@ -766,8 +766,6 @@ class CS3Builder : public Builder
         FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
         FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
 
-            int first_integer;
-            first_integer = ReadIntegerFromByteArray(addr, content);
 
             QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
             this->AddOperande(operande(addr,"int", first_integer_bytes));

--- a/headers/CS4InstructionsSet.h
+++ b/headers/CS4InstructionsSet.h
@@ -427,7 +427,6 @@ class CS4Builder : public Builder
         EffectsInstr(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"EffectsInstr", 257,Maker){
 
             unsigned char current_byte = content[addr];
-            int initial_addr = addr;
             while (current_byte!=0x01){
 
                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
@@ -800,8 +799,6 @@ class CS4Builder : public Builder
         FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
         FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
 
-            int first_integer;
-            first_integer = ReadIntegerFromByteArray(addr, content);
 
             QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
             this->AddOperande(operande(addr,"int", first_integer_bytes));

--- a/headers/CS4InstructionsSet.h
+++ b/headers/CS4InstructionsSet.h
@@ -147,7 +147,7 @@ class CS4Builder : public Builder
                               }
 
                            }
-                        else if(((current_byte + 0xb7 & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
+                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
                                  (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
                                  (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
                                  current_op_value.push_back(current_byte);

--- a/headers/CS4InstructionsSet.h
+++ b/headers/CS4InstructionsSet.h
@@ -1331,7 +1331,6 @@ class CS4Builder : public Builder
                 this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x1A
                 this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x1E
                 this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x22
-                QString fun_name = ReadStringFromByteArray(addr, content);
                 this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
                 this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
 

--- a/headers/CS4InstructionsSet.h
+++ b/headers/CS4InstructionsSet.h
@@ -920,7 +920,7 @@ class CS4Builder : public Builder
         OPCode0():Instruction(-1,0,nullptr){}
         OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
         OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
+        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
             addr++;
 
         }
@@ -933,7 +933,7 @@ class CS4Builder : public Builder
         OPCode1():Instruction(-1,1,nullptr){}
         OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
         OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
             addr++;
         }
 
@@ -1490,7 +1490,7 @@ class CS4Builder : public Builder
         OPCode26():Instruction(-1,0x26,nullptr){}
         OPCode26(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x26,Maker){}
         OPCode26(int addr, Builder *Maker):Instruction(addr,"???",0x26,Maker){}
-        OPCode26(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
+        OPCode26(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
                 addr++;
         }
 
@@ -5449,7 +5449,7 @@ class CS4Builder : public Builder
         OPCode8F():Instruction(-1,0x8F,nullptr){}
         OPCode8F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8F", 0x8F,Maker){}
         OPCode8F(int addr, Builder *Maker):Instruction(addr,"0x8F",0x8F,Maker){}
-        OPCode8F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8F", 0x8F, Maker){
+        OPCode8F(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0x8F", 0x8F, Maker){
                 addr++;
         }
     };
@@ -5783,7 +5783,7 @@ class CS4Builder : public Builder
         OPCodeA0():Instruction(-1,0xA0,nullptr){}
         OPCodeA0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA0", 0xA0,Maker){}
         OPCodeA0(int addr, Builder *Maker):Instruction(addr,"0xA0",0xA0,Maker){}
-        OPCodeA0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA0", 0xA0,Maker){
+        OPCodeA0(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xA0", 0xA0,Maker){
                 addr++;
         }
     };
@@ -6072,7 +6072,7 @@ class CS4Builder : public Builder
         OPCodeB4():Instruction(-1,0xB4,nullptr){}
         OPCodeB4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB4", 0xB4,Maker){}
         OPCodeB4(int addr, Builder *Maker):Instruction(addr,"0xB4",0xB4,Maker){}
-        OPCodeB4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB4", 0xB4,Maker){
+        OPCodeB4(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xB4", 0xB4,Maker){
                 addr++;
 
 
@@ -6403,7 +6403,7 @@ class CS4Builder : public Builder
         OPCodeC1():Instruction(-1,0xC1,nullptr){}
         OPCodeC1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC1", 0xC1,Maker){}
         OPCodeC1(int addr, Builder *Maker):Instruction(addr,"0xC1",0xC1,Maker){}
-        OPCodeC1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC1", 0xC1,Maker){
+        OPCodeC1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xC1", 0xC1,Maker){
                 addr++;
 
         }

--- a/headers/CS4InstructionsSet.h
+++ b/headers/CS4InstructionsSet.h
@@ -1850,7 +1850,7 @@ class CS4Builder : public Builder
 
                 QByteArray control_byte = ReadSubByteArray(content, addr, 1);
                 this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char) control_byte[0] == 0){
+                switch((unsigned char) control_byte[0]){
                     case 0:
                     case 1:
                     case 2:

--- a/headers/TXInstructionsSet.h
+++ b/headers/TXInstructionsSet.h
@@ -6283,7 +6283,7 @@ class TXBuilder : public Builder
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
             this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            switch(control_byte[0]){
             case 0x01   :
             case 0x00:{
                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));

--- a/headers/TXInstructionsSet.h
+++ b/headers/TXInstructionsSet.h
@@ -8741,7 +8741,7 @@ class TXBuilder : public Builder
 
                 error = true;
                 std::string result( stream.str() );
-                qFatal(result.c_str());
+                qFatal("%s", result.c_str());
 
                 return std::shared_ptr<Instruction>();
             }

--- a/headers/TXInstructionsSet.h
+++ b/headers/TXInstructionsSet.h
@@ -1965,7 +1965,6 @@ class TXBuilder : public Builder
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            QString fun_name = ReadStringFromByteArray(addr, content);
             this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
             this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
 

--- a/headers/TXInstructionsSet.h
+++ b/headers/TXInstructionsSet.h
@@ -138,7 +138,7 @@ class TXBuilder : public Builder
                               }
 
                            }
-                        else if(((current_byte + 0xb7 & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
+                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
                                  (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
                                  (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
                                  current_op_value.push_back(current_byte);

--- a/headers/TXInstructionsSet.h
+++ b/headers/TXInstructionsSet.h
@@ -904,7 +904,7 @@ class TXBuilder : public Builder
         OPCode0():Instruction(-1,0,nullptr){}
         OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
         OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
+        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
             addr++;
 
         }
@@ -917,7 +917,7 @@ class TXBuilder : public Builder
         OPCode1():Instruction(-1,1,nullptr){}
         OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
         OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
             addr++;
         }
 
@@ -2112,7 +2112,7 @@ class TXBuilder : public Builder
         OPCode1C():Instruction(-1,0x1C,nullptr){}
         OPCode1C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1C,Maker){}
         OPCode1C(int addr, Builder *Maker):Instruction(addr,"???",0x1C,Maker){}
-        OPCode1C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
+        OPCode1C(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
             addr++;
         }
 
@@ -5069,7 +5069,7 @@ class TXBuilder : public Builder
         OPCode57():Instruction(-1,0x57,nullptr){}
         OPCode57(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x57,Maker){}
         OPCode57(int addr, Builder *Maker):Instruction(addr,"???",0x57,Maker){}
-        OPCode57(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x57,Maker){
+        OPCode57(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x57,Maker){
             addr++;
         }
 
@@ -6422,7 +6422,7 @@ class TXBuilder : public Builder
         OPCode84():Instruction(-1,0x84,nullptr){}
         OPCode84(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x84,Maker){}
         OPCode84(int addr, Builder *Maker):Instruction(addr,"???",0x84,Maker){}
-        OPCode84(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
+        OPCode84(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
             addr++;
 
 
@@ -6787,7 +6787,7 @@ class TXBuilder : public Builder
         OPCode95():Instruction(-1,0x95,nullptr){}
         OPCode95(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x95,Maker){}
         OPCode95(int addr, Builder *Maker):Instruction(addr,"???",0x95,Maker){}
-        OPCode95(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x95,Maker){
+        OPCode95(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x95,Maker){
             addr++;
 
         }
@@ -6837,7 +6837,7 @@ class TXBuilder : public Builder
         OPCode99():Instruction(-1,0x99,nullptr){}
         OPCode99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x99,Maker){}
         OPCode99(int addr, Builder *Maker):Instruction(addr,"???",0x99,Maker){}
-        OPCode99(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
+        OPCode99(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
             addr++;
 
         }
@@ -7229,7 +7229,7 @@ class TXBuilder : public Builder
         OPCodeA9():Instruction(-1,0xA9,nullptr){}
         OPCodeA9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA9,Maker){}
         OPCodeA9(int addr, Builder *Maker):Instruction(addr,"???",0xA9,Maker){}
-        OPCodeA9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA9,Maker){
+        OPCodeA9(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA9,Maker){
             addr++;
         }
     };
@@ -8523,7 +8523,7 @@ class TXBuilder : public Builder
         OPCodeCA():Instruction(-1,0xCA,nullptr){}
         OPCodeCA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xCA,Maker){}
         OPCodeCA(int addr, Builder *Maker):Instruction(addr,"???",0xCA,Maker){}
-        OPCodeCA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xCA,Maker){
+        OPCodeCA(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xCA,Maker){
             addr++;
             }
 

--- a/headers/TXInstructionsSet.h
+++ b/headers/TXInstructionsSet.h
@@ -437,7 +437,6 @@ class TXBuilder : public Builder
         EffectsInstr(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"EffectsInstr", 257,Maker){}
         EffectsInstr(int addr, Builder *Maker):Instruction(addr,"EffectsInstr", 257, Maker){}
         EffectsInstr(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"EffectsInstr", 257,Maker){
-            unsigned char current_byte = content[addr];
             bool bytes_blocks_remain = Maker->goal >= addr+0x28;
 
             while (bytes_blocks_remain){
@@ -455,7 +454,6 @@ class TXBuilder : public Builder
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
-                current_byte = content[addr];
                 bytes_blocks_remain = Maker->goal >= addr+0x28;
 
             }
@@ -472,14 +470,12 @@ class TXBuilder : public Builder
         ActionTable(int addr, Builder *Maker):Instruction(addr,"ActionTable", 258, Maker){}
         ActionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ActionTable", 258,Maker){
 
-            short shrt = 0;
             unsigned char current_byte = content[addr];
             this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
             int cnt = 0;
             while(cnt < current_byte){
 
 
-                shrt = ReadShortFromByteArray(addr, content);
 
                 QByteArray short_bytes = ReadSubByteArray(content, addr,2);
                 this->AddOperande(operande(addr,"short", short_bytes));//2
@@ -615,7 +611,6 @@ class TXBuilder : public Builder
 
 
                 this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-                short shrt = ReadShortFromByteArray(0, short_bytes);
                 if (addr+0x20 > Maker->goal) return;
                 cnt++;
             }
@@ -4091,7 +4086,6 @@ class TXBuilder : public Builder
             QByteArray control_short3 = ReadSubByteArray(content, addr, 2);
             this->AddOperande(operande(addr,"short", control_short3));
             ushort short1 = ReadShortFromByteArray(0, control_short);
-            ushort short2 = ReadShortFromByteArray(0, control_short2);
             QByteArray control_short4 = ReadSubByteArray(content, addr, 2);
             this->AddOperande(operande(addr,"short", control_short4));
 
@@ -5692,7 +5686,6 @@ class TXBuilder : public Builder
         OPCode67(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x67,Maker){
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
-            ushort control = ReadShortFromByteArray(0, control_short);
             this->AddOperande(operande(addr,"short", control_short));
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
@@ -7682,7 +7675,6 @@ class TXBuilder : public Builder
             ushort control = ReadShortFromByteArray(0,control_ba);
             this->AddOperande(operande(addr,"short", control_ba));
             QByteArray control_ba2 = ReadSubByteArray(content, addr, 2);
-            ushort control2 = ReadShortFromByteArray(0,control_ba2);
             this->AddOperande(operande(addr,"short", control_ba2));
             switch(control){
                 case 0x00:{
@@ -7735,7 +7727,6 @@ class TXBuilder : public Builder
             addr++;
 
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            ushort control = ReadShortFromByteArray(0,control_ba);
             this->AddOperande(operande(addr,"short", control_ba));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
 

--- a/headers/functions.h
+++ b/headers/functions.h
@@ -15,7 +15,7 @@ public:
     QString name;
     int declr_position; //covers the list of offsets at the beginning
     int actual_addr; //covers the pointers before that
-    int end_addr;
+    uint end_addr;
     int XLSX_row_index;
     bool called = false; //by default
     int ID;

--- a/headers/instruction.h
+++ b/headers/instruction.h
@@ -18,7 +18,7 @@ class Instruction{
         Instruction(int addr, uint OP, Builder *Maker);
         Instruction(int addr, QString name, uint OP,Builder *Maker);
         Instruction(int &addr, int idx_row, QXlsx::Document  &excelScenarioSheet, QString name, uint OP,Builder *Maker);
-        ~Instruction();
+        virtual ~Instruction();
         virtual int WriteXLSX(QXlsx::Document &excelScenarioSheet, std::vector<function> funs, int row, int &col);
         virtual void WriteDat();
         void AddOperande(operande op);

--- a/headers/operande.h
+++ b/headers/operande.h
@@ -53,7 +53,7 @@ public:
         if (Type=="string") size++;
         return size;
     }
-    int getAddr(){
+    uint getAddr(){
         return Position;
     }
     QString getType(){

--- a/headers/utilities.h
+++ b/headers/utilities.h
@@ -14,7 +14,7 @@ short ReadShortFromByteArray(int start_pos, QByteArray &content);
 QByteArray ReadSubByteArray(QByteArray &content, int &addr, int size);
 QByteArray ReadStringSubByteArray(QByteArray &content, int &addr);
 QString ConvertBytesToString(QByteArray Bytes);
-float ReadFloatFromByteArray(int start_pos, QByteArray &content);
+float QByteArrayToFloat(QByteArray &content);
 QByteArray GetBytesFromInt(int i);
 QByteArray GetBytesFromFloat(float f);
 QByteArray GetBytesFromShort(short i);

--- a/sources/Builder.cpp
+++ b/sources/Builder.cpp
@@ -389,7 +389,7 @@ int Builder::find_instruction(uint addr, function fun){
     }
 
     if (!success) {
-        qDebug() << hex << addr;
+        qDebug() << Qt::hex << addr;
         display_text("Couldn't find an instruction!");
     }
 

--- a/sources/Builder.cpp
+++ b/sources/Builder.cpp
@@ -357,10 +357,9 @@ bool Builder::UpdatePointersXLSX(){
 }
 int Builder::find_function(uint addr){
     int result = -1;
-    uint fun_addr = FunctionsParsed[0].actual_addr;
 
     for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++){
-        fun_addr = FunctionsParsed[idx_fun].actual_addr;
+        uint fun_addr = FunctionsParsed[idx_fun].actual_addr;
 
         if (addr<fun_addr) {
 

--- a/sources/Builder.cpp
+++ b/sources/Builder.cpp
@@ -183,7 +183,7 @@ int Builder::ReadIndividualFunction(function &fun,QByteArray &dat_content){
 
     }
     else if (fun.name.startsWith("_")) {
-        if ((fun.name != "_"+previous_fun_name)||fun.end_addr == dat_content.size()) //last one is for btl1006, cs3; not cool but I'm starting to feel like the "_" functions are just not supposed to exist, so this hack only helps me checking the integrity of the files
+        if ((fun.name != "_"+previous_fun_name)||fun.end_addr == static_cast<uint>(dat_content.size())) //last one is for btl1006, cs3; not cool but I'm starting to feel like the "_" functions are just not supposed to exist, so this hack only helps me checking the integrity of the files
         {
          function_type = 2;
         }
@@ -401,7 +401,7 @@ int Builder::find_operande(uint addr, Instruction instr){//NOT USEFUL! Since we 
     for (;idx_operande < instr.get_Nb_operandes(); idx_operande++){
 
         operande ope = instr.get_operande(idx_operande);
-        int ope_addr = ope.getAddr();
+        uint ope_addr = ope.getAddr();
         if (addr==ope_addr) {
             break;
         }

--- a/sources/Builder.cpp
+++ b/sources/Builder.cpp
@@ -173,7 +173,6 @@ int Builder::ReadIndividualFunction(function &fun,QByteArray &dat_content){
     else if (fun.name.startsWith("BookData")){ //Book: the first short read is crucial I think. 0 = text incoming; not zero =
         QRegExp rx("BookData(\\d+[A-Z]?)_(\\d+)");
         std::vector<int> result;
-        int Nb_Book = rx.cap(1).toInt();
 
         rx.indexIn(fun.name, 0);
         int Nb_Data = rx.cap(2).toInt();
@@ -358,7 +357,6 @@ bool Builder::UpdatePointersXLSX(){
 }
 int Builder::find_function(uint addr){
     int result = -1;
-    bool success = false;
     uint fun_addr = FunctionsParsed[0].actual_addr;
 
     for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++){
@@ -367,7 +365,6 @@ int Builder::find_function(uint addr){
         if (addr<fun_addr) {
 
             result = idx_fun-1;
-            success = true;
             break;
         }
 
@@ -400,15 +397,12 @@ int Builder::find_instruction(uint addr, function fun){
 }
 int Builder::find_operande(uint addr, Instruction instr){//NOT USEFUL! Since we should point towards OP codes exclusively
 
-    int idx_operande = 0, result = -1;
-    bool success = false;
+    int idx_operande = 0;
     for (;idx_operande < instr.get_Nb_operandes(); idx_operande++){
 
         operande ope = instr.get_operande(idx_operande);
         int ope_addr = ope.getAddr();
         if (addr==ope_addr) {
-            success = true;
-            result = idx_operande;
             break;
         }
     }

--- a/sources/decompiler.cpp
+++ b/sources/decompiler.cpp
@@ -280,8 +280,8 @@ bool Decompiler::CheckAllFiles(QStringList filesToRead, QString folder_for_refer
         int ref_size = content2.size();
         for (int i=0; i< ref_size; i++){
             if (content1[i]!=content2[i]) {
-                stream << "Mismatch at " << hex << i << " " << (int)content1[i] << " should be " << (int)content2[i] << "\n";
-                qDebug() << "Mismatch at " << hex << i << " " << (int)content1[i] << " should be " << (int)content2[i] << "\n";
+                stream << "Mismatch at " << Qt::hex << i << " " << (int)content1[i] << " should be " << (int)content2[i] << "\n";
+                qDebug() << "Mismatch at " << Qt::hex << i << " " << (int)content1[i] << " should be " << (int)content2[i] << "\n";
             }
         }
         if (content1.size()<ref_size) {
@@ -296,7 +296,7 @@ bool Decompiler::CheckAllFiles(QStringList filesToRead, QString folder_for_refer
             }
 
         }
-        stream << " Size 1: " << hex << content1.size() << " vs Size 2: " << hex << content2.size();
+        stream << " Size 1: " << Qt::hex << content1.size() << " vs Size 2: " << Qt::hex << content2.size();
 
 
     }

--- a/sources/decompiler.cpp
+++ b/sources/decompiler.cpp
@@ -79,7 +79,6 @@ bool Decompiler::ReadDAT(QFile &File){
     }
 
     QByteArray content = File.readAll();
-    QFileInfo info(File);
 
     IB->CreateHeaderFromDAT(content);
     IB->ReadFunctionsDAT(content);
@@ -104,7 +103,6 @@ bool Decompiler::WriteDAT(QString folder){
 
 
         for (uint idx_instr = 0; idx_instr < fun.InstructionsInFunction.size(); idx_instr++) {
-            QByteArray qb = fun.InstructionsInFunction[idx_instr]->getBytes();
             current_fun.push_back(fun.InstructionsInFunction[idx_instr]->getBytes());
 
         }

--- a/sources/decompiler.cpp
+++ b/sources/decompiler.cpp
@@ -122,7 +122,7 @@ bool Decompiler::WriteDAT(QString folder){
     if (CurrentTF.getNbFunctions()-1>=0){
         function fun = CurrentTF.FunctionsInFile[CurrentTF.FunctionsInFile.size()-1];
         current_fun.clear();
-        for (int idx_instr = 0; idx_instr < fun.InstructionsInFunction.size(); idx_instr++) {
+        for (uint idx_instr = 0; idx_instr < fun.InstructionsInFunction.size(); idx_instr++) {
             current_fun.push_back(fun.InstructionsInFunction[idx_instr]->getBytes());
         }
         functions.push_back(current_fun);

--- a/sources/instruction.cpp
+++ b/sources/instruction.cpp
@@ -166,7 +166,7 @@ int Instruction::WriteXLSX(QXlsx::Document &excelScenarioSheet, std::vector<func
     excelScenarioSheet.write(row, col + 2, "OP Code",FormatType);
     excelScenarioSheet.write(row+1, col + 2, OPCode,FormatOP);
     int col_cnt = 0;
-    for (int idx_op = 0; idx_op<operandes.size(); idx_op++){
+    for (uint idx_op = 0; idx_op < operandes.size(); idx_op++){
 
         QString type = operandes[idx_op].getType();
         QByteArray Value = operandes[idx_op].getValue();

--- a/sources/instruction.cpp
+++ b/sources/instruction.cpp
@@ -179,7 +179,7 @@ int Instruction::WriteXLSX(QXlsx::Document &excelScenarioSheet, std::vector<func
         }
         else if (type == "float"){
             excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
-            excelScenarioSheet.write(row+1, col + 3+col_cnt, ReadFloatFromByteArray(0,Value),FormatInstr);
+            excelScenarioSheet.write(row+1, col + 3+col_cnt, QByteArrayToFloat(Value), FormatInstr);
             col_cnt++;
         }
         else if (type == "short"){

--- a/sources/utilities.cpp
+++ b/sources/utilities.cpp
@@ -33,7 +33,6 @@ int ReadIntegerFromByteArray(int start_pos, QByteArray &content){
             + ((static_cast<unsigned int>(content[start_pos+1]) & 0xFF) << 8)
             + ((static_cast<unsigned int>(content[start_pos+2]) & 0xFF) << 16)
             + ((static_cast<unsigned int>(content[start_pos+3]) & 0xFF) << 24);
-    start_pos+=4;
     return size;
 
 }

--- a/sources/utilities.cpp
+++ b/sources/utilities.cpp
@@ -2,7 +2,7 @@
 
 void display_text(QString text){
     QTextStream out(stdout);
-    out << text << endl;
+    out << text << Qt::endl;
 }
 QString ConvertBytesToString(QByteArray Bytes){
     QString DataAsString = QString::fromStdString(Bytes.toStdString());

--- a/sources/utilities.cpp
+++ b/sources/utilities.cpp
@@ -74,7 +74,7 @@ float QByteArrayToFloat(QByteArray &arr) //thanks to jabk https://stackoverflow.
 short ReadShortFromByteArray(int start_pos, QByteArray &content){
     short size = ((static_cast<short>(content[start_pos+0]) & 0xFF) << 0)
              + ((static_cast<short>(content[start_pos+1]) & 0xFF) << 8);
-    start_pos+=2;
+
     return size;
 }
 QByteArray ReadSubByteArray(QByteArray &content, int &addr, int size){

--- a/sources/utilities.cpp
+++ b/sources/utilities.cpp
@@ -60,7 +60,7 @@ QByteArray GetBytesFromShort(short i){
 
     return q_b;
 }
-float QByteArrayToFloat(QByteArray arr) //thanks to jabk https://stackoverflow.com/questions/36859447/qbytearray-to-float
+float QByteArrayToFloat(QByteArray &arr) //thanks to jabk https://stackoverflow.com/questions/36859447/qbytearray-to-float
 {
     static_assert(std::numeric_limits<float>::is_iec559, "Only supports IEC 559 (IEEE 754) float");
 
@@ -69,9 +69,6 @@ float QByteArrayToFloat(QByteArray arr) //thanks to jabk https://stackoverflow.c
     float* out = reinterpret_cast<float*>(&temp);
 
     return *out;
-}
-float ReadFloatFromByteArray(int start_pos, QByteArray &content){
-    return QByteArrayToFloat(content);
 }
 
 short ReadShortFromByteArray(int start_pos, QByteArray &content){


### PR DESCRIPTION
I didn't mess with qxlxs, because they'd just get lost when importing a new version.

Please pay attention to the individual commit messages for details.

The `[[maybe_unused]]` attribute fix requires C++17. There's another commit incoming to change over to that from C++11