### PR TITLE
Add definitions for the meson build tool

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,44 @@
+project('SenScriptsDecompiler',
+    'cpp',
+    version: '1.5.2',
+    license: 'MIT',
+    meson_version: '>=0.59.0',
+    default_options: ['warning_level=3', 'cpp_std=c++17']
+)
+
+cpp_compiler = meson.get_compiler('cpp')
+
+if cpp_compiler.get_id() == 'msvc'
+    add_project_arguments(
+        '/bigobj',
+        language: 'cpp',
+    )
+endif
+
+add_project_arguments(
+    '-DQT_DISABLE_DEPRECATED_BEFORE=0x060000',
+    '-DQT_DEPRECATED_WARNINGS',
+    language : 'cpp',
+)
+
+qt_dep = dependency('qt5', modules: ['Core', 'Gui'])
+
+qxlsx_project = subproject('qxlsx', default_options: ['warning_level=0'])
+qxlsx_dep = qxlsx_project.get_variable('qxlsx_dep')
+
+executable('SenScriptsDecompiler',
+    'sources/Builder.cpp',
+    'sources/decompiler.cpp',
+    'sources/functions.cpp',
+    'sources/instruction.cpp',
+    'sources/main.cpp',
+    'sources/translationfile.cpp',
+    'sources/utilities.cpp',
+    include_directories :  [
+        include_directories('headers'),
+        qxlsx_project.get_variable('inc'),
+        'subprojects', # needed for current qxlsx import path
+    ],
+    dependencies: [qt_dep, qxlsx_dep],
+    install : true
+)

--- a/subprojects/qxlsx.wrap
+++ b/subprojects/qxlsx.wrap
@@ -1,0 +1,4 @@
+[wrap-file]
+[provide]
+qxlsx=qxlsx_dep
+

--- a/subprojects/qxlsx/meson.build
+++ b/subprojects/qxlsx/meson.build
@@ -1,0 +1,61 @@
+project('qxlsx',
+    'cpp',
+    license         : 'MIT',
+    meson_version   : '>=0.59.0',
+    default_options : ['warning_level=3', 'cpp_std=c++11']
+)
+
+qt5_mod = import('qt5')
+qt5_dep = dependency('qt5', modules: ['Core', 'Gui'], private_headers: true)
+
+inc = include_directories('headers')
+
+moc_files = qt5_mod.compile_moc(
+    headers : 'headers/xlsxdocument.h',
+    include_directories: inc,
+    dependencies: qt5_dep
+)
+
+qxlsx_lib = static_library('qxlsx',
+    'sources/xlsxabstractooxmlfile.cpp',
+    'sources/xlsxabstractsheet.cpp',
+    'sources/xlsxcell.cpp',
+    'sources/xlsxcellformula.cpp',
+    'sources/xlsxcellrange.cpp',
+    'sources/xlsxcellreference.cpp',
+    'sources/xlsxchart.cpp',
+    'sources/xlsxchartsheet.cpp',
+    'sources/xlsxcolor.cpp',
+    'sources/xlsxconditionalformatting.cpp',
+    'sources/xlsxcontenttypes.cpp',
+    'sources/xlsxdatavalidation.cpp',
+    'sources/xlsxdocpropsapp.cpp',
+    'sources/xlsxdocpropscore.cpp',
+    'sources/xlsxdocument.cpp',
+    'sources/xlsxdrawing.cpp',
+    'sources/xlsxdrawinganchor.cpp',
+    'sources/xlsxformat.cpp',
+    'sources/xlsxmediafile.cpp',
+    'sources/xlsxnumformatparser.cpp',
+    'sources/xlsxrelationships.cpp',
+    'sources/xlsxrichstring.cpp',
+    'sources/xlsxsharedstrings.cpp',
+    'sources/xlsxsimpleooxmlfile.cpp',
+    'sources/xlsxstyles.cpp',
+    'sources/xlsxtheme.cpp',
+    'sources/xlsxutility.cpp',
+    'sources/xlsxworkbook.cpp',
+    'sources/xlsxworksheet.cpp',
+    'sources/xlsxzipreader.cpp',
+    'sources/xlsxzipwriter.cpp',
+    'sources/xlsxcelllocation.cpp',
+    'sources/xlsxdatetype.cpp',
+    moc_files,
+    include_directories : inc,
+   dependencies: [qt5_dep],
+)
+
+qxlsx_dep = declare_dependency(
+    include_directories : inc,
+    link_with : qxlsx_lib
+)


### PR DESCRIPTION
https://mesonbuild.com/

Meson is used by a variety of open source projects. I much prefer it
over cmake.

The qxlsx project has a .wrap file and it's own build definition.
The .wrap file is used to expose it's definition to meson.

It's also possible to meson's wrapdb to fetch third party dependencies so we don't
have to bundle them in the future.

I don't expect we'll keep the qxlxs build definition, but rather just use
their cmake build defintions when we migrate to qt6 or perhaps drop the
dependency altogether.

If we do end up keeping it though, meson can call out to the cmake build
defintion, so we can still easily use it.

If you'd like to use it with qtcreator, then you can follow the instructions here: https://doc.qt.io/qtcreator/creator-project-meson.html

I did not drop the existing qmake based build stuff, so you don't actually have to do anything just yet (or perhaps never, we'll see)