### PR TITLE
Add clang-format configuration and run it

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+BasedOnStyle:  Mozilla
+ColumnLimit: 140
+BreakBeforeBraces: Attach
+ReflowComments: true
+AllowShortIfStatementsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakAfterReturnType: None
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+Standard: c++20

--- a/.clang-format-include
+++ b/.clang-format-include
@@ -1,0 +1,2 @@
+sources/**/*
+headers/**/*

--- a/headers/Builder.h
+++ b/headers/Builder.h
@@ -1,41 +1,45 @@
 #ifndef INSTRUCTIONBUILDER_H
 #define INSTRUCTIONBUILDER_H
-#include <QByteArray>
-#include <QVector>
 #include "headers/operande.h"
 #include "xlsxdocument.h"
+#include <QByteArray>
+#include <QVector>
 class function;
 class Instruction;
 
 /*A Builder is an "interface" (I doubt it's the correct word though when not all of the methods are abstract)
-But basically it is not supposed to be instanciated "by itself". There are a CS1Builder, a CS2Builder, a CS3Builder, a CS4Builder.
+But basically it is not supposed to be instanciated "by itself". There are a CS1Builder, a CS2Builder, a CS3Builder, a
+CS4Builder.
 
 Each game will have its own builder, but the global behaviour of each will stay the same:
 - A builder reads a dat file and creates a vector of instructions
 - A builder reads a xlsx file (generated previously from a dat file) and creates a vector of instructions
 
 CreateInstructionFromDAT: it creates an instruction from the dat file (addr pointing to the first byte, the OP Code)
-the addr argument is passed by reference to update the value of addr to the next instruction when the current one has been completely parsed
-It is abstract because it completely depends on the game that is used,
-since CS1, CS2, CS3 and CS4 all have different instructions set.
+the addr argument is passed by reference to update the value of addr to the next instruction when the current one has
+been completely parsed It is abstract because it completely depends on the game that is used, since CS1, CS2, CS3 and
+CS4 all have different instructions set.
 
 CreateInstructionFromXLSX: this creates an instruction from the input XLSX file.
 It is abstract but could have been virtual currently because the behaviour is always the same, currently.
-I put it abstract because I don't know when but I might make different ways to write or read the instruction inside the XLSX, depending on the OP Code
+I put it abstract because I don't know when but I might make different ways to write or read the instruction inside the
+XLSX, depending on the OP Code
 
 CreateHeaderFromDAT: this parses the header of the dat file and creates the functions inside the translation file
 Having the vector of functions alone is enough to reconstruct the header bytes from the dat
 
-CreateHeaderBytes: this reconstructs the header bytes from the functions vector, it will then be written inside the output dat file by the decompiler object
+CreateHeaderBytes: this reconstructs the header bytes from the functions vector, it will then be written inside the
+output dat file by the decompiler object
 
-find_function: this function is used to find the Sen function that contains the addr passed as input;  this way we know with the pointer value which function
-contains the location pointed
+find_function: this function is used to find the Sen function that contains the addr passed as input;  this way we know
+with the pointer value which function contains the location pointed
 
-find_instruction: returns the index of the instruction contained in the previously found function, located at the integer addr passed as parameter
+find_instruction: returns the index of the instruction contained in the previously found function, located at the
+integer addr passed as parameter
 
-find_operande: returns the index of the operand inside the previously found instruction contained in the previously found function,
-located at the integer addr passed as parameter; it is not used because a pointer (from what I've seen) always points to an instruction (their op code),
-not operands
+find_operande: returns the index of the operand inside the previously found instruction contained in the previously
+found function, located at the integer addr passed as parameter; it is not used because a pointer (from what I've seen)
+always points to an instruction (their op code), not operands
 
 FunctionsToParse: This vector contains all the functions, empty (without instructions)
 
@@ -43,13 +47,14 @@ FunctionsParsed: This vector contains all the functions that were finally parsed
 
 SceneName: contains the name of the scene (essentially the filename)
 
-ReadIndividualFunction: it adds to the function being read and located at addr all its instructions until it reaches the end of the function
+ReadIndividualFunction: it adds to the function being read and located at addr all its instructions until it reaches the
+end of the function
 
-UpdatePointersXLSX: after parsing the XLSX file, we get a translation file with its functions and instructions, but all of the address are not correct
-so this is updating both the addresses of each function/instructions and also pointers
+UpdatePointersXLSX: after parsing the XLSX file, we get a translation file with its functions and instructions, but all
+of the address are not correct so this is updating both the addresses of each function/instructions and also pointers
 
-UpdatePointersDAT: it adds a more generic object called "Destination" to the operands with type "pointers" so that we could technically put all the
-functions of the file in a different order and it would still work (but we dont do that)
+UpdatePointersDAT: it adds a more generic object called "Destination" to the operands with type "pointers" so that we
+could technically put all the functions of the file in a different order and it would still work (but we dont do that)
 
 Reset: clears the function vectors
 
@@ -60,19 +65,19 @@ flag_monsters: if set to true, the current function is a "monster" function
 error: the latest instruction/function was incorrect
 
 */
-class Builder{
-public:
+class Builder {
+  public:
     Builder();
     virtual ~Builder() = default;
-    virtual std::shared_ptr<Instruction> CreateInstructionFromDAT(int &addr, QByteArray &dat_content, int function_type)=0;
-    virtual std::shared_ptr<Instruction> CreateInstructionFromXLSX(int &addr, int row, QXlsx::Document &xls_content)=0;
+    virtual std::shared_ptr<Instruction> CreateInstructionFromDAT(int& addr, QByteArray& dat_content, int function_type) = 0;
+    virtual std::shared_ptr<Instruction> CreateInstructionFromXLSX(int& addr, int row, QXlsx::Document& xls_content) = 0;
 
-    virtual bool CreateHeaderFromDAT(QByteArray &dat_content)=0; //Header will probably be game specific
-    virtual QByteArray CreateHeaderBytes()=0;
+    virtual bool CreateHeaderFromDAT(QByteArray& dat_content) = 0; // Header will probably be game specific
+    virtual QByteArray CreateHeaderBytes() = 0;
 
-    virtual void ReadFunctionsDAT(QByteArray &dat_content); //Clearly this one is supposed to be generic (assuming the game format doesn't change)
-    virtual void ReadFunctionsXLSX(QXlsx::Document &xls_content);
-
+    virtual void ReadFunctionsDAT(
+      QByteArray& dat_content); // Clearly this one is supposed to be generic (assuming the game format doesn't change)
+    virtual void ReadFunctionsXLSX(QXlsx::Document& xls_content);
 
     int find_function(uint addr);
     int find_instruction(uint addr, function fun);
@@ -80,7 +85,7 @@ public:
     std::vector<function> FunctionsToParse;
     std::vector<function> FunctionsParsed;
     QString SceneName;
-    int ReadIndividualFunction(function &fun,QByteArray &dat_content);
+    int ReadIndividualFunction(function& fun, QByteArray& dat_content);
     bool UpdatePointersXLSX();
     bool UpdatePointersDAT();
     bool Reset();

--- a/headers/CS1InstructionsSet.h
+++ b/headers/CS1InstructionsSet.h
@@ -1,178 +1,165 @@
 #ifndef CS1INSTRUCTIONSSET_H
 #define CS1INSTRUCTIONSSET_H
-#include "headers/utilities.h"
 #include "headers/functions.h"
 #include "headers/translationfile.h"
+#include "headers/utilities.h"
 
 #include <QString>
 
-
-
-class CS1TranslationFile : public TranslationFile
-{
-    public:
-    CS1TranslationFile():TranslationFile(){}
-
+class CS1TranslationFile : public TranslationFile {
+  public:
+    CS1TranslationFile()
+      : TranslationFile() {}
 };
 
+class CS1Builder : public Builder {
+  public:
+    CS1Builder() {}
 
-
-class CS1Builder : public Builder
-{
-    public:
-    CS1Builder(){
-
-    }
-
-    QVector<QString> CS1UIFiles = {"battle_menu","camp_menu", "camp_menu_v","note_menu","note_menu_v","shop_menu","shop_menu_v","title_menu","title_menu_v"};
-    static void reading_dialog(int &addr, QByteArray &content, Instruction * instr){
+    QVector<QString> CS1UIFiles = { "battle_menu", "camp_menu",   "camp_menu_v", "note_menu",   "note_menu_v",
+                                    "shop_menu",   "shop_menu_v", "title_menu",  "title_menu_v" };
+    static void reading_dialog(int& addr, QByteArray& content, Instruction* instr) {
 
         QByteArray current_op_value;
         int addr_ = addr;
 
         bool start_text = false;
         int cnt = 0;
-        do{
+        do {
             unsigned char current_byte = content[addr];
 
-            switch(current_byte){
+            switch (current_byte) {
                 case 0x00:
                     current_op_value.clear();
                     current_op_value[0] = 0;
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     addr++;
                     return;
                 case 0x01:
 
                     if (start_text)
                         current_op_value.push_back(current_byte);
-                    else{
+                    else {
 
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         current_op_value.clear();
                     }
                     addr++;
                     break;
                 case 0x02:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
                     break;
                 case 0x10:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x17:
                 case 0x19:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x11:
                 case 0x12:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x23:
                     current_op_value.push_back(0x23);
                     addr_ = addr;
                     addr++;
                     current_byte = content[addr];
-                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) ||
-                           (current_byte == 0x42)||(current_byte == 0x48)||(current_byte == 0x56)||(current_byte == 0x4b) ||
-                            (current_byte == 0x6b) || (current_byte == 0x46)) {
+                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) || (current_byte == 0x42) ||
+                        (current_byte == 0x48) || (current_byte == 0x56) || (current_byte == 0x4b) || (current_byte == 0x6b) ||
+                        (current_byte == 0x46)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
+
+                        if (current_byte != 0x5f) {
+                            if (current_byte == 0x5b) {
+                                do {
+                                    current_op_value.push_back(current_byte);
+                                    addr++;
+                                    current_byte = content[addr];
+                                } while (current_byte != 0x5D);
+                                current_op_value.push_back(current_byte);
+                                addr++;
+                                current_byte = content[addr];
+                            }
+                            break;
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
-
-                              if (current_byte != 0x5f) {
-                                  if (current_byte == 0x5b) {
-                                      do{
-                                          current_op_value.push_back(current_byte);
-                                          addr++;
-                                          current_byte = content[addr];
-                                      }
-                                      while(current_byte!=0x5D);
-                                      current_op_value.push_back(current_byte);
-                                      addr++;
-                                      current_byte = content[addr];
-                                  }
-                                  break;
-                              }
-                              else{
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  break;
-                              }
-
-                           }
-                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
-                                 (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
-                                 (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
-                                 current_op_value.push_back(current_byte);
-                                 addr++;
-                                 current_byte = content[addr];
-                                 break;
+                            current_op_value.push_back(current_byte);
+                            addr++;
+                            current_byte = content[addr];
+                            break;
                         }
+
+                    } else if ((((current_byte + 0xb7) & 0xdf) == 0) || (current_byte == 0x50) || (current_byte == 0x54) ||
+                               (current_byte == 0x57) || (current_byte == 0x53) || (current_byte == 0x73) || (current_byte == 0x43) ||
+                               (current_byte == 99) || (current_byte == 0x78) || (current_byte == 0x79) || (current_byte == 0x47) ||
+                               (current_byte == 0x44) || (current_byte == 0x55) || (current_byte == 0x52)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
                         break;
+                    }
+                    break;
                 default:
-                    if (current_byte < 0x20){
-                        if (current_op_value.size()>0) {
-                            instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_byte < 0x20) {
+                        if (current_op_value.size() > 0) {
+                            instr->AddOperande(operande(addr_, "dialog", current_op_value));
                         }
                         start_text = false;
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         addr++;
                         current_op_value.clear();
-                    }
-                    else {
+                    } else {
                         if (!(start_text)) start_text = true;
 
-                        if ((current_byte < 0xE0)&&(current_byte >= 0xC0)){
+                        if ((current_byte < 0xE0) && (current_byte >= 0xC0)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte >= 0xE0)&&(current_byte <= 0xF7)){
+                        } else if ((current_byte >= 0xE0) && (current_byte <= 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
@@ -181,12 +168,10 @@ class CS1Builder : public Builder
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte > 0xF7)){
+                        } else if ((current_byte > 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else{
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                         }
@@ -194,3128 +179,3563 @@ class CS1Builder : public Builder
                     break;
             }
 
-
             cnt++;
-        }
-        while(cnt<9999);
-
+        } while (cnt < 9999);
     }
-    static void fun_1403c90e0(int &addr, QByteArray &content, Instruction * instr, int param){
+    static void fun_1403c90e0(int& addr, QByteArray& content, Instruction* instr, int param) {
         QByteArray control_byte3_arr = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte3_arr));
+        instr->AddOperande(operande(addr, "byte", control_byte3_arr));
         unsigned char control_byte3 = (unsigned char)control_byte3_arr[0];
 
-        if (control_byte3 == '\x11'){
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+        if (control_byte3 == '\x11') {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-        }
-        else if (control_byte3 != '3'){
+        } else if (control_byte3 != '3') {
 
-            if (control_byte3 == '\"'){
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            if (control_byte3 == '\"') {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-            }
-            else if (control_byte3 != 0x44){
+            } else if (control_byte3 != 0x44) {
 
-                if (control_byte3 == 0xDD){
+                if (control_byte3 == 0xDD) {
 
-                    //there is a XOR,XOR EDI which causes a jump that ignores the strcpy
-                    if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                }
-                else if (control_byte3 == 0xFF){
-                    instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                }
-                else{
-                    if (control_byte3 != 0xEE){
+                    // there is a XOR,XOR EDI which causes a jump that ignores the strcpy
+                    if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                } else if (control_byte3 == 0xFF) {
+                    instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                } else {
+                    if (control_byte3 != 0xEE) {
 
-                    }
-                    else{
-                        instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    } else {
+                        instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     }
                 }
 
-
-            }
-            else{
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            } else {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
 
-        }
-        else{
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+        } else {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     }
-    static void sub05(int &addr, QByteArray &content, Instruction * instr){
+    static void sub05(int& addr, QByteArray& content, Instruction* instr) {
         QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte));
+        instr->AddOperande(operande(addr, "byte", control_byte));
 
-        while ((int)control_byte[0]!=1){
+        while ((int)control_byte[0] != 1) {
 
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x0:
-                    case 0x24:
-                        instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x24:
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-                    case 0x1c:{
-                        //the next byte is the OP code for a new instruction
+                case 0x1c: {
+                    // the next byte is the OP code for a new instruction
 
-                        std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content,0);
+                    std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content, 0);
 
-                        operande op = operande(addr,"instruction", instr2->getBytes());
-                        instr->AddOperande(op);
+                    operande op = operande(addr, "instruction", instr2->getBytes());
+                    instr->AddOperande(op);
 
-
-                        break;
-                    }
-                    case 0x1e:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x1f:
-                    case 0x20:
-                    case 0x23:
-
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x21:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x25:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    default:
-                        ;
+                    break;
                 }
+                case 0x1e:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x1f:
+                case 0x20:
+                case 0x23:
 
-                control_byte = ReadSubByteArray(content, addr, 1);
-
-                instr->AddOperande(operande(addr,"byte", control_byte));
-
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x21:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x25:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                default:;
             }
+
+            control_byte = ReadSubByteArray(content, addr, 1);
+
+            instr->AddOperande(operande(addr, "byte", control_byte));
+        }
     }
-    class CreateMonsters : public Instruction
-    {
-        public:
-        CreateMonsters():Instruction(-1,256,nullptr){}
-        CreateMonsters(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"CreateMonsters", 256,Maker){}
-        CreateMonsters(int addr, Builder *Maker):Instruction(addr,"CreateMonsters", 256, Maker){}
-        CreateMonsters(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"CreateMonsters", 256,Maker){
+    class CreateMonsters : public Instruction {
+      public:
+        CreateMonsters()
+          : Instruction(-1, 256, nullptr) {}
+        CreateMonsters(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int addr, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {
             int initial_addr = addr;
-            if (Maker->goal<addr+0x20){
+            if (Maker->goal < addr + 0x20) {
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            int first = ReadIntegerFromByteArray(addr,content);
+            int first = ReadIntegerFromByteArray(addr, content);
 
-            if ((first == -1)&&(addr + 0x20 == Maker->goal)){
-                this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
+            if ((first == -1) && (addr + 0x20 == Maker->goal)) {
+                this->AddOperande(
+                  operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
                 Maker->flag_monsters = true;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            int check1 = ReadIntegerFromByteArray(addr,content);
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            int check1 = ReadIntegerFromByteArray(addr, content);
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            int check2 = ReadIntegerFromByteArray(addr,content);
-            if (check1 && check2 != 0){ //bad
+            int check2 = ReadIntegerFromByteArray(addr, content);
+            if (check1 && check2 != 0) { // bad
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2))); //0x10
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2))); //0x1A
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4))); //0x1C
-            //0x20
-
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x10
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x1A
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 0x1C
+            // 0x20
 
             int cnt = 0;
-            do{
-                if (Maker->goal<initial_addr+0x20 + cnt * (0x90)){
+            do {
+                if (Maker->goal < initial_addr + 0x20 + cnt * (0x90)) {
                     addr = initial_addr;
                     Maker->flag_monsters = false;
                     return;
                 }
                 QByteArray array = ReadSubByteArray(content, addr, 4);
-                this->AddOperande(operande(addr,"int", array));
+                this->AddOperande(operande(addr, "int", array));
 
                 int counter = 0;
 
-                do{
+                do {
                     counter++;
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10-monsters_name.size()-1);
-                    operande fill = operande(addr,"fill", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "fill", remaining);
                     fill.setBytesToFill(0x10);
                     this->AddOperande(fill);
 
-                }
-                while(counter < 0x8);
-                for (int idx_byte = 0; idx_byte < 8; idx_byte++) this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                if ((unsigned char) content[addr] == 0)this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 8))); //??
+                } while (counter < 0x8);
+                for (int idx_byte = 0; idx_byte < 8; idx_byte++)
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                if ((unsigned char)content[addr] == 0)
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 8))); //??
                 else {
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 12-monsters_name.size()-1);
-                    operande fill = operande(addr,"bytearray", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 12 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "bytearray", remaining);
                     fill.setBytesToFill(12);
                     this->AddOperande(fill);
-
-
                 }
 
-                first = ReadIntegerFromByteArray(addr,content);
+                first = ReadIntegerFromByteArray(addr, content);
 
                 cnt++;
 
-            }
-            while((first != -1)&&(addr != Maker->goal - 4));
+            } while ((first != -1) && (addr != Maker->goal - 4));
             if (addr == Maker->goal - 4) {
-                first = ReadIntegerFromByteArray(addr,content);
-                if (first != 1){
+                first = ReadIntegerFromByteArray(addr, content);
+                if (first != 1) {
                     addr = initial_addr;
                     Maker->flag_monsters = false;
                     return;
-                }
-                else{
+                } else {
                     Maker->flag_monsters = true;
                     return;
                 }
-
             }
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
+            this->AddOperande(
+              operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
             Maker->flag_monsters = true;
         }
-
-
     };
-    class EffectsInstr : public Instruction
-    {
-        public:
-        EffectsInstr():Instruction(-1,257,nullptr){}
-        EffectsInstr(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"EffectsInstr", 257,Maker){}
-        EffectsInstr(int addr, Builder *Maker):Instruction(addr,"EffectsInstr", 257, Maker){}
-        EffectsInstr(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"EffectsInstr", 257,Maker){
+    class EffectsInstr : public Instruction {
+      public:
+        EffectsInstr()
+          : Instruction(-1, 257, nullptr) {}
+        EffectsInstr(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int addr, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {
             unsigned char current_byte = content[addr];
-            while (current_byte!=0x01){
+            while (current_byte != 0x01) {
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
+                this->AddOperande(operande(addr, "string", str));
 
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
 
-
-                operande fill = operande(addr,"fill", remaining);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 current_byte = content[addr];
             }
         }
-
-
     };
-    class ActionTable : public Instruction
-    {
-        public:
-        ActionTable():Instruction(-1,258,nullptr){}
-        ActionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ActionTable", 258,Maker){}
-        ActionTable(int addr, Builder *Maker):Instruction(addr,"ActionTable", 258, Maker){}
-        ActionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ActionTable", 258,Maker){
+    class ActionTable : public Instruction {
+      public:
+        ActionTable()
+          : Instruction(-1, 258, nullptr) {}
+        ActionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ActionTable", 258, Maker) {}
+        ActionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {}
+        ActionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {
 
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
+            while (cnt < current_byte) {
 
-
-
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", short_bytes));//2
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//3
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//4
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//5
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//6
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//7
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//8
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//9
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//A
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//B
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//D
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//F
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//11
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//13
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//15
-                //here ok
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//17
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//19
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+                this->AddOperande(operande(addr, "short", short_bytes));                        // 2
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 3
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 4
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 5
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 6
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 7
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 8
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 9
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // A
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // B
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // C
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // D
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // F
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 11
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 13
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 15
+                // here ok
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 17
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 19
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
 
                 QByteArray str_ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str_));
-                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20-str_.size()-1);
-                operande fill_ = operande(addr,"fill", remaining_);
+                this->AddOperande(operande(addr, "string", str_));
+                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20 - str_.size() - 1);
+                operande fill_ = operande(addr, "fill", remaining_);
                 fill_.setBytesToFill(0x20);
                 this->AddOperande(fill_);
 
-
                 QByteArray str__ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str__));
-                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x30-str__.size()-1);
-                operande fill__ = operande(addr,"fill", remaining__);
+                this->AddOperande(operande(addr, "string", str__));
+                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x30 - str__.size() - 1);
+                operande fill__ = operande(addr, "fill", remaining__);
                 fill__.setBytesToFill(0x30);
                 this->AddOperande(fill__);
 
                 cnt++;
-          }
-
-
+            }
         }
-
-
     };
-    class AddCollision : public Instruction
-    {
-        public:
-        AddCollision():Instruction(-1,271,nullptr){}
-        AddCollision(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AddCollision", 271,Maker){}
-        AddCollision(int addr, Builder *Maker):Instruction(addr,"AddCollision", 271, Maker){}
-        AddCollision(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AddCollision", 271,Maker){
+    class AddCollision : public Instruction {
+      public:
+        AddCollision()
+          : Instruction(-1, 271, nullptr) {}
+        AddCollision(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AddCollision", 271, Maker) {}
+        AddCollision(int addr, Builder* Maker)
+          : Instruction(addr, "AddCollision", 271, Maker) {}
+        AddCollision(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AddCollision", 271, Maker) {
 
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            while (cnt < current_byte) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                cnt++;
-          }
-
-
-        }
-
-
-    };
-    class AlgoTable : public Instruction
-    {
-        public:
-        AlgoTable():Instruction(-1,259,nullptr){}
-        AlgoTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AlgoTable", 259,Maker){}
-        AlgoTable(int addr, Builder *Maker):Instruction(addr,"AlgoTable", 259, Maker){}
-        AlgoTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AlgoTable", 259,Maker){
-            int cnt = 0;
-            unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//3
-            while(cnt < current_byte){
-
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-
-                this->AddOperande(operande(addr,"short", short_bytes));
-
-
-
-                this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-                short shrt = ReadShortFromByteArray(0, short_bytes);
-                if (shrt == -1) this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x8)));
                 cnt++;
             }
-
         }
     };
-    class WeaponAttTable : public Instruction
-    {
-        public:
-        WeaponAttTable():Instruction(-1,260,nullptr){}
-        WeaponAttTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"WeaponAttTable", 260,Maker){}
-        WeaponAttTable(int addr, Builder *Maker):Instruction(addr,"WeaponAttTable", 260, Maker){}
-        WeaponAttTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"WeaponAttTable", 260,Maker){
-
-
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class BreakTable : public Instruction
-    {
-        public:
-        BreakTable():Instruction(-1,261,nullptr){}
-        BreakTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BreakTable", 261,Maker){}
-        BreakTable(int addr, Builder *Maker):Instruction(addr,"BreakTable", 261, Maker){}
-        BreakTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BreakTable", 261,Maker){
+    class AlgoTable : public Instruction {
+      public:
+        AlgoTable()
+          : Instruction(-1, 259, nullptr) {}
+        AlgoTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AlgoTable", 259, Maker) {}
+        AlgoTable(int addr, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {}
+        AlgoTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {
             int cnt = 0;
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            unsigned char current_byte = content[addr];
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // 3
+            while (cnt < current_byte) {
+
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+
+                this->AddOperande(operande(addr, "short", short_bytes));
+
+                this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1E)));
                 short shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                if (shrt == -1) this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x8)));
+                cnt++;
+            }
+        }
+    };
+    class WeaponAttTable : public Instruction {
+      public:
+        WeaponAttTable()
+          : Instruction(-1, 260, nullptr) {}
+        WeaponAttTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int addr, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {
+
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class BreakTable : public Instruction {
+      public:
+        BreakTable()
+          : Instruction(-1, 261, nullptr) {}
+        BreakTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BreakTable", 261, Maker) {}
+        BreakTable(int addr, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {}
+        BreakTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {
+            int cnt = 0;
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+                short shrt = ReadShortFromByteArray(0, short_bytes);
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0) break;
-                QByteArray short_bytes2 = ReadSubByteArray(content, addr,2);
+                QByteArray short_bytes2 = ReadSubByteArray(content, addr, 2);
 
-                this->AddOperande(operande(addr,"short", short_bytes2)); //not sure if two single bytes
-                //or one short, guessing its one short
+                this->AddOperande(operande(addr, "short", short_bytes2)); // not sure if two single bytes
+                // or one short, guessing its one short
 
                 cnt++;
-            }
-            while(cnt < 0x40);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x2)));
+            } while (cnt < 0x40);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x2)));
         }
     };
-    class SummonTable : public Instruction //140142002
+    class SummonTable
+      : public Instruction // 140142002
     {
-        public:
-        SummonTable():Instruction(-1,262,nullptr){}
-        SummonTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"SummonTable", 262,Maker){}
-        SummonTable(int addr, Builder *Maker):Instruction(addr,"SummonTable", 262, Maker){}
-        SummonTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"SummonTable", 262,Maker){
+      public:
+        SummonTable()
+          : Instruction(-1, 262, nullptr) {}
+        SummonTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "SummonTable", 262, Maker) {}
+        SummonTable(int addr, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {}
+        SummonTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {
 
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            while (cnt < current_byte) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 ushort shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0xFFFF) break;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
                 cnt++;
             }
-
         }
     };
-    class ReactionTable : public Instruction //140142002
+    class ReactionTable
+      : public Instruction // 140142002
     {
-        public:
-        ReactionTable():Instruction(-1,263,nullptr){}
-        ReactionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ReactionTable", 263,Maker){}
-        ReactionTable(int addr, Builder *Maker):Instruction(addr,"ReactionTable", 263, Maker){}
-        ReactionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ReactionTable", 263,Maker){
+      public:
+        ReactionTable()
+          : Instruction(-1, 263, nullptr) {}
+        ReactionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ReactionTable", 263, Maker) {}
+        ReactionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {}
+        ReactionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {
             int cnt = 0;
-            ushort current_shrt = ReadShortFromByteArray(addr,content);
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            ushort current_shrt = ReadShortFromByteArray(addr, content);
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            while(cnt < current_shrt){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            while (cnt < current_shrt) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
 
-                this->AddOperande(operande(addr,"short", short_bytes));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                this->AddOperande(operande(addr, "short", short_bytes));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 cnt++;
             }
         }
     };
-    class PartTable : public Instruction //14019797c
+    class PartTable
+      : public Instruction // 14019797c
     {
-        public:
-        PartTable():Instruction(-1,264,nullptr){}
-        PartTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"PartTable", 264,Maker){}
-        PartTable(int addr, Builder *Maker):Instruction(addr,"PartTable", 264, Maker){}
-        PartTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"PartTable", 264,Maker){
+      public:
+        PartTable()
+          : Instruction(-1, 264, nullptr) {}
+        PartTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "PartTable", 264, Maker) {}
+        PartTable(int addr, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {}
+        PartTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
+            while (cnt < current_byte) {
 
-                QByteArray int_bytes = ReadSubByteArray(content, addr,4);
+                QByteArray int_bytes = ReadSubByteArray(content, addr, 4);
 
-                this->AddOperande(operande(addr,"int", int_bytes));
+                this->AddOperande(operande(addr, "int", int_bytes));
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 cnt++;
             }
-
         }
     };
-    class AnimeClipTable : public Instruction //140253d20
+    class AnimeClipTable
+      : public Instruction // 140253d20
     {
-        public:
-        AnimeClipTable():Instruction(-1,265,nullptr){}
-        AnimeClipTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipTable", 265,Maker){}
-        AnimeClipTable(int addr, Builder *Maker):Instruction(addr,"AnimeClipTable", 265, Maker){}
-        AnimeClipTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipTable", 265,Maker){
+      public:
+        AnimeClipTable()
+          : Instruction(-1, 265, nullptr) {}
+        AnimeClipTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {
 
             int first_integer;
             first_integer = ReadIntegerFromByteArray(addr, content);
 
-            while(first_integer != 0){
-                QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-                this->AddOperande(operande(addr,"int", first_integer_bytes));//14025b3c2
+            while (first_integer != 0) {
+                QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+                this->AddOperande(operande(addr, "int", first_integer_bytes)); // 14025b3c2
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
 
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill((0x20));
                 this->AddOperande(fill);
 
                 str = ReadStringSubByteArray(content, addr);
 
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+                fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill((0x20));
                 this->AddOperande(fill);
                 first_integer = ReadIntegerFromByteArray(addr, content);
-
             }
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            //I think this is some sort of a table with ID at the beginning and then two names
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            // I think this is some sort of a table with ID at the beginning and then two names
         }
     };
-    class FieldMonsterData : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
+    class FieldMonsterData
+      : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
     {
-        public:
-        FieldMonsterData():Instruction(-1,266,nullptr){}
-        FieldMonsterData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 266,Maker){}
-        FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
-        FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
+      public:
+        FieldMonsterData()
+          : Instruction(-1, 266, nullptr) {}
+        FieldMonsterData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {
 
-
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FieldFollowData : public Instruction //
+    class FieldFollowData
+      : public Instruction //
     {
-        public:
-        FieldFollowData():Instruction(-1,267,nullptr){}
-        FieldFollowData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 267,Maker){}
-        FieldFollowData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 267, Maker){}
-        FieldFollowData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 267,Maker){
+      public:
+        FieldFollowData()
+          : Instruction(-1, 267, nullptr) {}
+        FieldFollowData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FC_autoX : public Instruction //
+    class FC_autoX
+      : public Instruction //
     {
-        public:
-        FC_autoX():Instruction(-1,268,nullptr){}
-        FC_autoX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FC_autoX", 268,Maker){}
-        FC_autoX(int addr, Builder *Maker):Instruction(addr,"FC_autoX", 268, Maker){}
-        FC_autoX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FC_autoX", 268,Maker){
+      public:
+        FC_autoX()
+          : Instruction(-1, 268, nullptr) {}
+        FC_autoX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FC_autoX", 268, Maker) {}
+        FC_autoX(int addr, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {}
+        FC_autoX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {
 
             QByteArray things = ReadStringSubByteArray(content, addr);
-            this->AddOperande(operande(addr,"string", things));
+            this->AddOperande(operande(addr, "string", things));
         }
     };
-    class BookData99 : public Instruction //
+    class BookData99
+      : public Instruction //
     {
-        public:
-        BookData99():Instruction(-1,269,nullptr){}
-        BookData99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookData99", 269,Maker){}
-        BookData99(int addr, Builder *Maker):Instruction(addr,"BookData99", 269, Maker){}
-        BookData99(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookData99", 269,Maker){
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+      public:
+        BookData99()
+          : Instruction(-1, 269, nullptr) {}
+        BookData99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookData99", 269, Maker) {}
+        BookData99(int addr, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {}
+        BookData99(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class BookDataX: public Instruction //0000000140464549
+    class BookDataX
+      : public Instruction // 0000000140464549
     {
-        public:
-        BookDataX():Instruction(-1,270,nullptr){}
-        BookDataX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookDataX", 270,Maker){}
-        BookDataX(int addr, Builder *Maker):Instruction(addr,"BookDataX", 270, Maker){}
-        BookDataX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookDataX", 270,Maker){
+      public:
+        BookDataX()
+          : Instruction(-1, 270, nullptr) {}
+        BookDataX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookDataX", 270, Maker) {}
+        BookDataX(int addr, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {}
+        BookDataX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             short control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));//3
-            if (control>0){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", control_short)); // 3
+            if (control > 0) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 QByteArray title = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", title));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-title.size()-1);
-                operande fill = operande(addr,"bytearray", remaining);
+                this->AddOperande(operande(addr, "string", title));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - title.size() - 1);
+                operande fill = operande(addr, "bytearray", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x12
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x14
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x16
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x18
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1E
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x20
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x22
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x24
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            }
-            else
-            {
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x12
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x14
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x16
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x18
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1A
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1C
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1E
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x20
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x22
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x24
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            } else {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
         }
     };
 
-
-    class OPCode0 : public Instruction
-    {
-        public:
-        OPCode0():Instruction(-1,0,nullptr){}
-        OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
-        OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
-            addr++;
-
-        }
-
-
-    };
-    class OPCode1 : public Instruction
-    {
-        public:
-        OPCode1():Instruction(-1,1,nullptr){}
-        OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
-        OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+    class OPCode0 : public Instruction {
+      public:
+        OPCode0()
+          : Instruction(-1, 0, nullptr) {}
+        OPCode0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Instruction 0", 0, Maker) {}
+        OPCode0(int addr, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {}
+        OPCode0(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {
             addr++;
         }
-
-
     };
-
-    class UI_OP13: public Instruction{
-    public:
-        UI_OP13():Instruction(-1,0x13,nullptr){}
-        UI_OP13(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x13,Maker){}
-        UI_OP13(int addr, Builder *Maker):Instruction(addr,"???",0x13,Maker){}
-        UI_OP13(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x13,Maker){
-        addr++;
-
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch ((unsigned char) control_byte[0])  {
-
-            case 0x00:{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x01:{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case 10:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0xb:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0xc:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x32:
-            case 0x26:
-            case 0xd:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0xe:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0xf:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x10:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x11:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x12:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x13:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x14:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x15:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x16:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x17:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x18:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x19:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1B:
-            case 0x1A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x20:
-            case 0x1F:
-            case 0x1E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x21:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x22:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-
-            case 0x23:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x24:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x25:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x27:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x28:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x29:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2B:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x30:
-            case 0x2F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x33:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x34:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x35:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x36:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x37:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x3B:
-            case 0x38:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x3A:
-            case 0x39:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x3C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x41:
-            case 0x3D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x3E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x3F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x40:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x44:
-            case 0x43:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            }
-        }
-
-    };
-    //SCENARIO FILES INSTRUCTIONS
-    //0x05
-    class OPCode05: public Instruction{
-    public:
-        OPCode05():Instruction(-1,0x05,nullptr){}
-        OPCode05(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x05,Maker){}
-        OPCode05(int addr, Builder *Maker):Instruction(addr,"???",0x05,Maker){}
-        OPCode05(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x05,Maker){
+    class OPCode1 : public Instruction {
+      public:
+        OPCode1()
+          : Instruction(-1, 1, nullptr) {}
+        OPCode1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Return", 1, Maker) {}
+        OPCode1(int addr, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {}
+        OPCode1(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {
             addr++;
-            sub05(addr, content, this);
-
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr, 4)));
         }
     };
 
-    //0x02
-    class OPCode02: public Instruction{
-    public:
-        OPCode02():Instruction(-1,0x02,nullptr){}
-        OPCode02(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x02,Maker){}
-        OPCode02(int addr, Builder *Maker):Instruction(addr,"???",0x02,Maker){}
-        OPCode02(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x02,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-    //0x03
-    class OPCode03: public Instruction{
-    public:
-        OPCode03():Instruction(-1,0x03,nullptr){}
-        OPCode03(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x03,Maker){}
-        OPCode03(int addr, Builder *Maker):Instruction(addr,"???",0x03,Maker){}
-        OPCode03(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x03,Maker){
+    class UI_OP13 : public Instruction {
+      public:
+        UI_OP13()
+          : Instruction(-1, 0x13, nullptr) {}
+        UI_OP13(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x13, Maker) {}
+        UI_OP13(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {}
+        UI_OP13(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
 
-        }
-    };
-    //0x04
-    class OPCode04: public Instruction{
-        public:
-        OPCode04():Instruction(-1,0x04,nullptr){}
-        OPCode04(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x04,Maker){}
-        OPCode04(int addr, Builder *Maker):Instruction(addr,"???",0x04,Maker){}
-        OPCode04(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x04,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-    //0x06
-    class OPCode06: public Instruction{
-        public:
-            OPCode06():Instruction(-1,0x06,nullptr){}
-            OPCode06(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x06,Maker){}
-            OPCode06(int addr, Builder *Maker):Instruction(addr,"???",0x06,Maker){}
-            OPCode06(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x06,Maker){
-            addr++;
-            sub05(addr, content, this);
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
 
-            if ((unsigned char) control_byte[0] != 0){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
+                case 0x00: {
 
-                for (unsigned char i = 0; i<control_byte[0]; i++){
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    break;
+                }
+                case 0x01: {
 
-                    this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
+                    break;
+                }
+                case 10: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0xb: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xc: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x32:
+                case 0x26:
+                case 0xd: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xe: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0xf: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x10: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x11: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x13: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x16: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x18: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x19: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1B:
+                case 0x1A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x20:
+                case 0x1F:
+                case 0x1E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x21: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x22: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+
+                case 0x23: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x24: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x25: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x27: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x28: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x29: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x30:
+                case 0x2F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x33: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x34: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x35: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x36: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x37: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x3B:
+                case 0x38: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x3A:
+                case 0x39: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x3C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x41:
+                case 0x3D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x3E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x3F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x40: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x44:
+                case 0x43: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
                 }
             }
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
-           }
-
-    };
-    //0x07
-    class OPCode07: public Instruction{
-    public:
-        OPCode07():Instruction(-1,0x07,nullptr){}
-        OPCode07(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x07,Maker){}
-        OPCode07(int addr, Builder *Maker):Instruction(addr,"???",0x07,Maker){}
-        OPCode07(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x07,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
         }
-
     };
-    //0x08
-    class OPCode08: public Instruction{
-    public:
-        OPCode08():Instruction(-1,0x08,nullptr){}
-        OPCode08(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x08,Maker){}
-        OPCode08(int addr, Builder *Maker):Instruction(addr,"???",0x08,Maker){}
-        OPCode08(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x08,Maker){
+    // SCENARIO FILES INSTRUCTIONS
+    // 0x05
+    class OPCode05 : public Instruction {
+      public:
+        OPCode05()
+          : Instruction(-1, 0x05, nullptr) {}
+        OPCode05(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x05, Maker) {}
+        OPCode05(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x05, Maker) {}
+        OPCode05(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x05, Maker) {
+            addr++;
+            sub05(addr, content, this);
+
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+
+    // 0x02
+    class OPCode02 : public Instruction {
+      public:
+        OPCode02()
+          : Instruction(-1, 0x02, nullptr) {}
+        OPCode02(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x02, Maker) {}
+        OPCode02(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x02, Maker) {}
+        OPCode02(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x02, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x03
+    class OPCode03 : public Instruction {
+      public:
+        OPCode03()
+          : Instruction(-1, 0x03, nullptr) {}
+        OPCode03(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x03, Maker) {}
+        OPCode03(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x03, Maker) {}
+        OPCode03(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x03, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x04
+    class OPCode04 : public Instruction {
+      public:
+        OPCode04()
+          : Instruction(-1, 0x04, nullptr) {}
+        OPCode04(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x04, Maker) {}
+        OPCode04(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x04, Maker) {}
+        OPCode04(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x04, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x06
+    class OPCode06 : public Instruction {
+      public:
+        OPCode06()
+          : Instruction(-1, 0x06, nullptr) {}
+        OPCode06(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x06, Maker) {}
+        OPCode06(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x06, Maker) {}
+        OPCode06(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x06, Maker) {
+            addr++;
+            sub05(addr, content, this);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            if ((unsigned char)control_byte[0] != 0) {
+
+                for (unsigned char i = 0; i < control_byte[0]; i++) {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+                }
+            }
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x07
+    class OPCode07 : public Instruction {
+      public:
+        OPCode07()
+          : Instruction(-1, 0x07, nullptr) {}
+        OPCode07(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x07, Maker) {}
+        OPCode07(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x07, Maker) {}
+        OPCode07(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x07, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x08
+    class OPCode08 : public Instruction {
+      public:
+        OPCode08()
+          : Instruction(-1, 0x08, nullptr) {}
+        OPCode08(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x08, Maker) {}
+        OPCode08(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x08, Maker) {}
+        OPCode08(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x08, Maker) {
             addr++;
             sub05(addr, content, this);
         }
-
     };
-    //0x0A
-    class OPCode0A: public Instruction{
-    public:
-        OPCode0A():Instruction(-1,0x0A,nullptr){}
-        OPCode0A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0A,Maker){}
-        OPCode0A(int addr, Builder *Maker):Instruction(addr,"???",0x0A,Maker){}
-        OPCode0A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0A,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        sub05(addr, content, this);
-
-        }
-    };
-    //0x0C
-    class OPCode0C: public Instruction{
-    public:
-        OPCode0C():Instruction(-1,0x0C,nullptr){}
-        OPCode0C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0C,Maker){}
-        OPCode0C(int addr, Builder *Maker):Instruction(addr,"???",0x0C,Maker){}
-        OPCode0C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0C,Maker){
+    // 0x0A
+    class OPCode0A : public Instruction {
+      public:
+        OPCode0A()
+          : Instruction(-1, 0x0A, nullptr) {}
+        OPCode0A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0A, Maker) {}
+        OPCode0A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0A, Maker) {}
+        OPCode0A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x0D
-    class OPCode0D: public Instruction{
-    public:
-        OPCode0D():Instruction(-1,0x0D,nullptr){}
-        OPCode0D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0D,Maker){}
-        OPCode0D(int addr, Builder *Maker):Instruction(addr,"???",0x0D,Maker){}
-        OPCode0D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0D,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x0E
-    class OPCode0E: public Instruction{
-    public:
-        OPCode0E():Instruction(-1,0x0E,nullptr){}
-        OPCode0E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0E,Maker){}
-        OPCode0E(int addr, Builder *Maker):Instruction(addr,"???",0x0E,Maker){}
-        OPCode0E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0E,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-       }
-    };
-    //0x0F
-    class OPCode0F: public Instruction{
-    public:
-        OPCode0F():Instruction(-1,0x0F,nullptr){}
-        OPCode0F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0F,Maker){}
-        OPCode0F(int addr, Builder *Maker):Instruction(addr,"???",0x0F,Maker){}
-        OPCode0F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x10
-    class OPCode10: public Instruction{
-    public:
-        OPCode10():Instruction(-1,0x10,nullptr){}
-        OPCode10(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x10,Maker){}
-        OPCode10(int addr, Builder *Maker):Instruction(addr,"???",0x10,Maker){}
-        OPCode10(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x10,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x11
-    class OPCode11: public Instruction{
-    public:
-        OPCode11():Instruction(-1,0x11,nullptr){}
-        OPCode11(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x11,Maker){}
-        OPCode11(int addr, Builder *Maker):Instruction(addr,"???",0x11,Maker){}
-        OPCode11(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x11,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x12
-    class OPCode12: public Instruction{
-    public:
-        OPCode12():Instruction(-1,0x12,nullptr){}
-        OPCode12(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x12,Maker){}
-        OPCode12(int addr, Builder *Maker):Instruction(addr,"???",0x12,Maker){}
-        OPCode12(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x12,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             sub05(addr, content, this);
         }
     };
-    //0x13
-    class OPCode13: public Instruction{
-    public:
-        OPCode13():Instruction(-1,0x13,nullptr){}
-        OPCode13(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x13,Maker){}
-        OPCode13(int addr, Builder *Maker):Instruction(addr,"???",0x13,Maker){}
-        OPCode13(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x13,Maker){
+    // 0x0C
+    class OPCode0C : public Instruction {
+      public:
+        OPCode0C()
+          : Instruction(-1, 0x0C, nullptr) {}
+        OPCode0C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0C, Maker) {}
+        OPCode0C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0C, Maker) {}
+        OPCode0C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0C, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//i think this one is the id of the battle function it triggers
-
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-
-    //0x14
-    class OPCode14: public Instruction{
-    public:
-        OPCode14():Instruction(-1,0x14,nullptr){}
-        OPCode14(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x14,Maker){}
-        OPCode14(int addr, Builder *Maker):Instruction(addr,"???",0x14,Maker){}
-        OPCode14(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x14,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-
-    };
-    //0x15
-    class OPCode15: public Instruction{
-    public:
-        OPCode15():Instruction(-1,0x15,nullptr){}
-        OPCode15(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x15,Maker){}
-        OPCode15(int addr, Builder *Maker):Instruction(addr,"???",0x15,Maker){}
-        OPCode15(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x15,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x16
-    class OPCode16: public Instruction{
-    public:
-        OPCode16():Instruction(-1,0x16,nullptr){}
-        OPCode16(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x16,Maker){}
-        OPCode16(int addr, Builder *Maker):Instruction(addr,"???",0x16,Maker){}
-        OPCode16(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x16,Maker){
+    // 0x0D
+    class OPCode0D : public Instruction {
+      public:
+        OPCode0D()
+          : Instruction(-1, 0x0D, nullptr) {}
+        OPCode0D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0D, Maker) {}
+        OPCode0D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {}
+        OPCode0D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-          }
-
-    };
-    //0x17
-    class OPCode17: public Instruction{
-    public:
-        OPCode17():Instruction(-1,0x17,nullptr){}
-        OPCode17(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x17,Maker){}
-        OPCode17(int addr, Builder *Maker):Instruction(addr,"???",0x17,Maker){}
-        OPCode17(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x17,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x18
-    class OPCode18: public Instruction{
-    public:
-        OPCode18():Instruction(-1,0x18,nullptr){}
-        OPCode18(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x18,Maker){}
-        OPCode18(int addr, Builder *Maker):Instruction(addr,"???",0x18,Maker){}
-        OPCode18(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x18,Maker){
+    // 0x0E
+    class OPCode0E : public Instruction {
+      public:
+        OPCode0E()
+          : Instruction(-1, 0x0E, nullptr) {}
+        OPCode0E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0E, Maker) {}
+        OPCode0E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0E, Maker) {}
+        OPCode0E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            //this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0x0F
+    class OPCode0F : public Instruction {
+      public:
+        OPCode0F()
+          : Instruction(-1, 0x0F, nullptr) {}
+        OPCode0F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0F, Maker) {}
+        OPCode0F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0F, Maker) {}
+        OPCode0F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x10
+    class OPCode10 : public Instruction {
+      public:
+        OPCode10()
+          : Instruction(-1, 0x10, nullptr) {}
+        OPCode10(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x10, Maker) {}
+        OPCode10(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {}
+        OPCode10(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x11
+    class OPCode11 : public Instruction {
+      public:
+        OPCode11()
+          : Instruction(-1, 0x11, nullptr) {}
+        OPCode11(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x11, Maker) {}
+        OPCode11(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {}
+        OPCode11(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x12
+    class OPCode12 : public Instruction {
+      public:
+        OPCode12()
+          : Instruction(-1, 0x12, nullptr) {}
+        OPCode12(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x12, Maker) {}
+        OPCode12(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {}
+        OPCode12(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            sub05(addr, content, this);
+        }
+    };
+    // 0x13
+    class OPCode13 : public Instruction {
+      public:
+        OPCode13()
+          : Instruction(-1, 0x13, nullptr) {}
+        OPCode13(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x13, Maker) {}
+        OPCode13(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {}
+        OPCode13(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(
+              operande(addr, "int", ReadSubByteArray(content, addr, 4))); // i think this one is the id of the battle function it triggers
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+
+    // 0x14
+    class OPCode14 : public Instruction {
+      public:
+        OPCode14()
+          : Instruction(-1, 0x14, nullptr) {}
+        OPCode14(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x14, Maker) {}
+        OPCode14(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {}
+        OPCode14(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x15
+    class OPCode15 : public Instruction {
+      public:
+        OPCode15()
+          : Instruction(-1, 0x15, nullptr) {}
+        OPCode15(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x15, Maker) {}
+        OPCode15(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {}
+        OPCode15(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x16
+    class OPCode16 : public Instruction {
+      public:
+        OPCode16()
+          : Instruction(-1, 0x16, nullptr) {}
+        OPCode16(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x16, Maker) {}
+        OPCode16(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {}
+        OPCode16(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x17
+    class OPCode17 : public Instruction {
+      public:
+        OPCode17()
+          : Instruction(-1, 0x17, nullptr) {}
+        OPCode17(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x17, Maker) {}
+        OPCode17(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {}
+        OPCode17(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x18
+    class OPCode18 : public Instruction {
+      public:
+        OPCode18()
+          : Instruction(-1, 0x18, nullptr) {}
+        OPCode18(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x18, Maker) {}
+        OPCode18(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {}
+        OPCode18(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            // this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
             reading_dialog(addr, content, this);
         }
-
     };
-    //0x19
-    class OPCode19: public Instruction{
-    public:
-        OPCode19():Instruction(-1,0x19,nullptr){}
-        OPCode19(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x19,Maker){}
-        OPCode19(int addr, Builder *Maker):Instruction(addr,"???",0x19,Maker){}
-        OPCode19(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x19,Maker){
+    // 0x19
+    class OPCode19 : public Instruction {
+      public:
+        OPCode19()
+          : Instruction(-1, 0x19, nullptr) {}
+        OPCode19(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x19, Maker) {}
+        OPCode19(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x19, Maker) {}
+        OPCode19(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x19, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x05:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
             }
         }
-
     };
-    //0x1A
-    class OPCode1A: public Instruction{
-    public:
-        OPCode1A():Instruction(-1,0x1A,nullptr){}
-        OPCode1A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1A,Maker){}
-        OPCode1A(int addr, Builder *Maker):Instruction(addr,"???",0x1A,Maker){}
-        OPCode1A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1A,Maker){
+    // 0x1A
+    class OPCode1A : public Instruction {
+      public:
+        OPCode1A()
+          : Instruction(-1, 0x1A, nullptr) {}
+        OPCode1A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1A, Maker) {}
+        OPCode1A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {}
+        OPCode1A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             reading_dialog(addr, content, this);
         }
-
     };
-    //0x1B
-    class OPCode1B: public Instruction{
-    public:
-        OPCode1B():Instruction(-1,0x1B,nullptr){}
-        OPCode1B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1B,Maker){}
-        OPCode1B(int addr, Builder *Maker):Instruction(addr,"???",0x1B,Maker){}
-        OPCode1B(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1B,Maker){
+    // 0x1B
+    class OPCode1B : public Instruction {
+      public:
+        OPCode1B()
+          : Instruction(-1, 0x1B, nullptr) {}
+        OPCode1B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1B, Maker) {}
+        OPCode1B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1B, Maker) {}
+        OPCode1B(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1B, Maker) {
             addr++;
         }
-
     };
-    //0x1C
-    class OPCode1C: public Instruction{
-    public:
-        OPCode1C():Instruction(-1,0x1C,nullptr){}
-        OPCode1C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1C,Maker){}
-        OPCode1C(int addr, Builder *Maker):Instruction(addr,"???",0x1C,Maker){}
-        OPCode1C(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
+    // 0x1C
+    class OPCode1C : public Instruction {
+      public:
+        OPCode1C()
+          : Instruction(-1, 0x1C, nullptr) {}
+        OPCode1C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1C, Maker) {}
+        OPCode1C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1C, Maker) {}
+        OPCode1C(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1C, Maker) {
             addr++;
         }
-
     };
-    //0x1D
-    class OPCode1D: public Instruction{
-    public:
-        OPCode1D():Instruction(-1,0x1D,nullptr){}
-        OPCode1D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1D,Maker){}
-        OPCode1D(int addr, Builder *Maker):Instruction(addr,"???",0x1D,Maker){}
-        OPCode1D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1D,Maker){
+    // 0x1D
+    class OPCode1D : public Instruction {
+      public:
+        OPCode1D()
+          : Instruction(-1, 0x1D, nullptr) {}
+        OPCode1D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1D, Maker) {}
+        OPCode1D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {}
+        OPCode1D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x1E
-    class OPCode1E: public Instruction{
-    public:
-        OPCode1E():Instruction(-1,0x1E,nullptr){}
-        OPCode1E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1E,Maker){}
-        OPCode1E(int addr, Builder *Maker):Instruction(addr,"???",0x1E,Maker){}
-        OPCode1E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1E,Maker){
+    // 0x1E
+    class OPCode1E : public Instruction {
+      public:
+        OPCode1E()
+          : Instruction(-1, 0x1E, nullptr) {}
+        OPCode1E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1E, Maker) {}
+        OPCode1E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {}
+        OPCode1E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x1F
-    class OPCode1F: public Instruction{
-    public:
-        OPCode1F():Instruction(-1,0x1F,nullptr){}
-        OPCode1F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1F,Maker){}
-        OPCode1F(int addr, Builder *Maker):Instruction(addr,"???",0x1F,Maker){}
-        OPCode1F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1F,Maker){
+    // 0x1F
+    class OPCode1F : public Instruction {
+      public:
+        OPCode1F()
+          : Instruction(-1, 0x1F, nullptr) {}
+        OPCode1F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1F, Maker) {}
+        OPCode1F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {}
+        OPCode1F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
-        if ((unsigned char)control_byte2[0]<0x4){
-            switch((unsigned char)control_byte[0]) {
+            this->AddOperande(operande(addr, "byte", control_byte2));
+            if ((unsigned char)control_byte2[0] < 0x4) {
+                switch ((unsigned char)control_byte[0]) {
 
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x04:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    break;
-                }
-                case 0x05:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x07:
-                case 0x06:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    case 0x00: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    }
+                    case 0x01: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x02: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x04: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+                        break;
+                    }
+                    case 0x05: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x07:
+                    case 0x06: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    break;
+                        break;
+                    }
                 }
-
             }
         }
-
-        }
-
     };
-    //0x20
-    class OPCode20: public Instruction{
-        public:
-        OPCode20():Instruction(-1,0x20,nullptr){}
-        OPCode20(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x20,Maker){}
-        OPCode20(int addr, Builder *Maker):Instruction(addr,"???",0x20,Maker){}
-        OPCode20(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x20,Maker){
+    // 0x20
+    class OPCode20 : public Instruction {
+      public:
+        OPCode20()
+          : Instruction(-1, 0x20, nullptr) {}
+        OPCode20(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x20, Maker) {}
+        OPCode20(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {}
+        OPCode20(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch ((unsigned char)control_byte[0])  {
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x02:
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-
             }
         }
-
-
     };
-    //0x21
-    class OPCode21: public Instruction{
-        public:
-        OPCode21():Instruction(-1,0x21,nullptr){}
-        OPCode21(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x21,Maker){}
-        OPCode21(int addr, Builder *Maker):Instruction(addr,"???",0x21,Maker){}
-        OPCode21(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x21,Maker){
+    // 0x21
+    class OPCode21 : public Instruction {
+      public:
+        OPCode21()
+          : Instruction(-1, 0x21, nullptr) {}
+        OPCode21(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x21, Maker) {}
+        OPCode21(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {}
+        OPCode21(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            switch ((unsigned char)control_byte[0])  {
-                case 0x01:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-
             }
         }
-
     };
-    //0x22
-    class OPCode22: public Instruction{
-        public:
-        OPCode22():Instruction(-1,0x22,nullptr){}
-        OPCode22(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x22,Maker){}
-        OPCode22(int addr, Builder *Maker):Instruction(addr,"???",0x22,Maker){}
-        OPCode22(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x22,Maker){
+    // 0x22
+    class OPCode22 : public Instruction {
+      public:
+        OPCode22()
+          : Instruction(-1, 0x22, nullptr) {}
+        OPCode22(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x22, Maker) {}
+        OPCode22(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {}
+        OPCode22(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x23
-    class OPCode23: public Instruction{
-        public:
-        OPCode23():Instruction(-1,0x23,nullptr){}
-        OPCode23(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x23,Maker){}
-        OPCode23(int addr, Builder *Maker):Instruction(addr,"???",0x23,Maker){}
-        OPCode23(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x23,Maker){
+    // 0x23
+    class OPCode23 : public Instruction {
+      public:
+        OPCode23()
+          : Instruction(-1, 0x23, nullptr) {}
+        OPCode23(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x23, Maker) {}
+        OPCode23(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {}
+        OPCode23(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x24
-    class OPCode24: public Instruction{
-        public:
-        OPCode24():Instruction(-1,0x24,nullptr){}
-        OPCode24(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x24,Maker){}
-        OPCode24(int addr, Builder *Maker):Instruction(addr,"???",0x24,Maker){}
-        OPCode24(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x24,Maker){
+    // 0x24
+    class OPCode24 : public Instruction {
+      public:
+        OPCode24()
+          : Instruction(-1, 0x24, nullptr) {}
+        OPCode24(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x24, Maker) {}
+        OPCode24(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {}
+        OPCode24(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x25
-    class OPCode25: public Instruction{
-        public:
-        OPCode25():Instruction(-1,0x25,nullptr){}
-        OPCode25(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x25,Maker){}
-        OPCode25(int addr, Builder *Maker):Instruction(addr,"???",0x25,Maker){}
-        OPCode25(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x25,Maker){
+    // 0x25
+    class OPCode25 : public Instruction {
+      public:
+        OPCode25()
+          : Instruction(-1, 0x25, nullptr) {}
+        OPCode25(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x25, Maker) {}
+        OPCode25(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {}
+        OPCode25(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x26
-    class OPCode26: public Instruction{
-        public:
-        OPCode26():Instruction(-1,0x26,nullptr){}
-        OPCode26(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x26,Maker){}
-        OPCode26(int addr, Builder *Maker):Instruction(addr,"???",0x26,Maker){}
-        OPCode26(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
+    // 0x26
+    class OPCode26 : public Instruction {
+      public:
+        OPCode26()
+          : Instruction(-1, 0x26, nullptr) {}
+        OPCode26(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x26, Maker) {}
+        OPCode26(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {}
+        OPCode26(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x27
-    class OPCode27: public Instruction{
-        public:
-        OPCode27():Instruction(-1,0x27,nullptr){}
-        OPCode27(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x27,Maker){}
-        OPCode27(int addr, Builder *Maker):Instruction(addr,"???",0x27,Maker){}
-        OPCode27(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x27,Maker){
+    // 0x27
+    class OPCode27 : public Instruction {
+      public:
+        OPCode27()
+          : Instruction(-1, 0x27, nullptr) {}
+        OPCode27(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x27, Maker) {}
+        OPCode27(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {}
+        OPCode27(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 }
-                case 0x0B:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
                 case 0x11:
                 case 0x10:
-                case 0x0F:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x12:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x13:
-                case 0x14:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x14: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x15:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x15: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 }
                 case 0xD:
-                case 0xE:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0xE: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
                     break;
                 }
-
             }
         }
-
     };
-    //0x28
-    class OPCode28: public Instruction{
-    public:
-        OPCode28():Instruction(-1,0x28,nullptr){}
-        OPCode28(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x28,Maker){}
-        OPCode28(int addr, Builder *Maker):Instruction(addr,"???",0x28,Maker){}
-        OPCode28(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x28,Maker){
+    // 0x28
+    class OPCode28 : public Instruction {
+      public:
+        OPCode28()
+          : Instruction(-1, 0x28, nullptr) {}
+        OPCode28(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x28, Maker) {}
+        OPCode28(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {}
+        OPCode28(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
-                break;
+                    break;
+                }
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case '\b':
+                case 0x06:
+                case 0x04:
+                case 0x02: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case '\a':
+                case 0x05: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 'm':
+                case 'l':
+                case 'k':
+                case 'f':
+                case 'e':
+                case 'c':
+                case '\x1C':
+                case '\x1A':
+                case '\x17':
+                case '\x19':
+                case '\x14':
+                case '\r':
+                case '\x10':
+                case 'H':
+                case ']':
+                case '\t':
+                case '^':
+                case '_':
+                case '`':
+                case 's':
+                case 't':
+                case 'u':
+                case 'y': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '\x0f':
+                case '\n': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '\f':
+                case '4':
+                case 'Z':
+                case '\v': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '\x0e': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 'b':
+                case '\x11':
+                case 'z': {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case '\x12': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    for (int i = 0; i < 8; i++)
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case '\x13': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '\x15': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '2': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case '5': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case '6': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case '7': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case '<': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 'F': {
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 'P': {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case '[': {
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '\\': {
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case 'a': {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 'd': {
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 'n': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '~':
+                case 'q': {
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case 'r': {
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case '{': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 'i': {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 'j': {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
             }
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case '\b':
-            case 0x06:
-            case 0x04:
-            case 0x02:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case '\a':
-            case 0x05:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 'm':
-            case 'l':
-            case 'k':
-            case 'f':
-            case 'e':
-            case 'c':
-            case '\x1C':
-            case '\x1A':
-            case '\x17':
-            case '\x19':
-            case '\x14':
-            case '\r':
-            case '\x10':
-            case 'H':
-            case ']':
-            case '\t':
-            case '^':
-            case '_':
-            case '`':
-            case 's':
-            case 't':
-            case 'u':
-            case 'y':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '\x0f':
-            case '\n':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '\f':
-            case '4':
-            case 'Z':
-            case '\v':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '\x0e':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 'b':
-            case '\x11':
-            case 'z':{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case '\x12':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                for (int i = 0; i<8; i++) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case '\x13':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '\x15':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '2':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case '5':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case '6':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case '7':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case '<':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 'F':{
-
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 'P':{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case '[':{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '\\':{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case 'a':{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 'd':{
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 'n':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '~':
-            case 'q':{
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case 'r':{
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case '{':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 'i':{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 'j':{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-
         }
-
-
-        }
-
     };
-    //0x29
-    class OPCode29: public Instruction{
-    public:
-        OPCode29():Instruction(-1,0x29,nullptr){}
-        OPCode29(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x29,Maker){}
-        OPCode29(int addr, Builder *Maker):Instruction(addr,"???",0x29,Maker){}
-        OPCode29(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x29,Maker){
+    // 0x29
+    class OPCode29 : public Instruction {
+      public:
+        OPCode29()
+          : Instruction(-1, 0x29, nullptr) {}
+        OPCode29(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x29, Maker) {}
+        OPCode29(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {}
+        OPCode29(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x2A
-    class OPCode2A: public Instruction{
-    public:
-        OPCode2A():Instruction(-1,0x2A,nullptr){}
-        OPCode2A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2A,Maker){}
-        OPCode2A(int addr, Builder *Maker):Instruction(addr,"???",0x2A,Maker){}
-        OPCode2A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2A,Maker){
+    // 0x2A
+    class OPCode2A : public Instruction {
+      public:
+        OPCode2A()
+          : Instruction(-1, 0x2A, nullptr) {}
+        OPCode2A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2A, Maker) {}
+        OPCode2A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {}
+        OPCode2A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x2B
-    class OPCode2B: public Instruction{
-    public:
-        OPCode2B():Instruction(-1,0x2B,nullptr){}
-        OPCode2B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2B,Maker){}
-        OPCode2B(int addr, Builder *Maker):Instruction(addr,"???",0x2B,Maker){}
-        OPCode2B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2B,Maker){
+    // 0x2B
+    class OPCode2B : public Instruction {
+      public:
+        OPCode2B()
+          : Instruction(-1, 0x2B, nullptr) {}
+        OPCode2B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2B, Maker) {}
+        OPCode2B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {}
+        OPCode2B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
 
-    //0x2C
-    class OPCode2C: public Instruction{
-    public:
-        OPCode2C():Instruction(-1,0x2C,nullptr){}
-        OPCode2C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2C,Maker){}
-        OPCode2C(int addr, Builder *Maker):Instruction(addr,"???",0x2C,Maker){}
-        OPCode2C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2C,Maker){
+    // 0x2C
+    class OPCode2C : public Instruction {
+      public:
+        OPCode2C()
+          : Instruction(-1, 0x2C, nullptr) {}
+        OPCode2C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2C, Maker) {}
+        OPCode2C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {}
+        OPCode2C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x2D
-    class OPCode2D: public Instruction{
-    public:
-        OPCode2D():Instruction(-1,0x2D,nullptr){}
-        OPCode2D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2D,Maker){}
-        OPCode2D(int addr, Builder *Maker):Instruction(addr,"???",0x2D,Maker){}
-        OPCode2D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2D,Maker){
+    // 0x2D
+    class OPCode2D : public Instruction {
+      public:
+        OPCode2D()
+          : Instruction(-1, 0x2D, nullptr) {}
+        OPCode2D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2D, Maker) {}
+        OPCode2D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {}
+        OPCode2D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            case 0x02:{
+                case 0x02: {
 
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x14:
-            case 0x03:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x14:
+                case 0x03: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x04:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x05:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x07:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x08:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x09:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x0B:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0D:
-            case 0x0C:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0E:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x07: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x08: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x09: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0D:
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case 0x11:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x12:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    break;
+                }
+                case 0x11: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
-            }
-            case 0x13:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    break;
+                }
+                case 0x13: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
-
-                break;
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x16: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
             }
-            case 0x15:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x16:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x17:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-
         }
-        }
-
     };
-    //0x2E
-    class OPCode2E: public Instruction{
-    public:
-        OPCode2E():Instruction(-1,0x2E,nullptr){}
-        OPCode2E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2E,Maker){}
-        OPCode2E(int addr, Builder *Maker):Instruction(addr,"???",0x2E,Maker){}
-        OPCode2E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2E,Maker){
+    // 0x2E
+    class OPCode2E : public Instruction {
+      public:
+        OPCode2E()
+          : Instruction(-1, 0x2E, nullptr) {}
+        OPCode2E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2E, Maker) {}
+        OPCode2E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {}
+        OPCode2E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x2F
-    class OPCode2F: public Instruction{
-    public:
-        OPCode2F():Instruction(-1,0x2F,nullptr){}
-        OPCode2F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2F,Maker){}
-        OPCode2F(int addr, Builder *Maker):Instruction(addr,"???",0x2F,Maker){}
-        OPCode2F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2F,Maker){
+    // 0x2F
+    class OPCode2F : public Instruction {
+      public:
+        OPCode2F()
+          : Instruction(-1, 0x2F, nullptr) {}
+        OPCode2F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2F, Maker) {}
+        OPCode2F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {}
+        OPCode2F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x30
-    class OPCode30: public Instruction{
-    public:
-        OPCode30():Instruction(-1,0x30,nullptr){}
-        OPCode30(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x30,Maker){}
-        OPCode30(int addr, Builder *Maker):Instruction(addr,"???",0x30,Maker){}
-        OPCode30(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x30,Maker){
+    // 0x30
+    class OPCode30 : public Instruction {
+      public:
+        OPCode30()
+          : Instruction(-1, 0x30, nullptr) {}
+        OPCode30(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x30, Maker) {}
+        OPCode30(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {}
+        OPCode30(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0:{
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 1:{
+                case 1: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 2:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 2: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                default:{
+                default: {
                     break;
                 }
-                case 3:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 3: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 4:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 4: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 5:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 5: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 6:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 6: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
             }
         }
     };
-    //0x31
-    class OPCode31: public Instruction{
-    public:
-        OPCode31():Instruction(-1,0x31,nullptr){}
-        OPCode31(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x31,Maker){}
-        OPCode31(int addr, Builder *Maker):Instruction(addr,"???",0x31,Maker){}
-        OPCode31(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x31,Maker){
+    // 0x31
+    class OPCode31 : public Instruction {
+      public:
+        OPCode31()
+          : Instruction(-1, 0x31, nullptr) {}
+        OPCode31(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x31, Maker) {}
+        OPCode31(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {}
+        OPCode31(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
+            if ((unsigned char)control_byte[0] > 0xFD) {
+                if ((unsigned char)control_byte[0] == 0xFE) {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                } else if ((unsigned char)control_byte[0] == 0xFF) {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                }
 
-        if ((unsigned char)control_byte[0] > 0xFD){
-            if ((unsigned char)control_byte[0] == 0xFE){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                return;
             }
-            else if ((unsigned char)control_byte[0] == 0xFF){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            }
 
-            return;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                case 0x32: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x33:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 4:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 0xb:
+                case 0xc:
+                case 0xd:
+                case 0xe:
+                case 0xf:
+                case 0x10:
+                case 0x11:
+                case 0x12:
+                case 0x13:
+                case 0x14:
+                case 0x15:
+                case 0x16:
+                case 0x17:
+                case 0x18:
+                case 0x19:
+                case 0x1a:
+                case 0x1b:
+                case 0x1c:
+                case 0x1d:
+                case 0x1e:
+                case 0x1f:
+                case 0x20:
+                case 0x21:
+                case 0x22:
+                case 0x23:
+                case 0x24:
+                case 0x25:
+                case 0x26:
+                case 0x27:
+                case 0x28:
+                case 0x29:
+                case 0x2a:
+                case 0x2b:
+                case 0x2c:
+                case 0x2d:
+                case 0x2e:
+                case 0x2f:
+                case 0x30:
+                case 0x31:
+                case 0x36:
+                case 0x3b:
+                case 0x3c:
+                case 0x3d:
+                case 0x3e:
+                case 0x3f:
+                case 0x40:
+                case 0x41:
+                case 0x42:
+                case 0x43:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x47:
+                case 0x48:
+                case 0x49:
+                case 0x4a:
+                case 0x4b:
+                case 0x4c:
+                case 0x4d:
+                case 0x4e:
+                case 0x4f:
+                case 0x50:
+                case 0x51:
+                case 0x52:
+                case 0x53:
+                case 0x54:
+                case 0x55:
+                case 0x56:
+                case 0x57:
+                case 0x58:
+                case 0x59:
+                case 0x5a:
+                case 0x5b:
+                case 0x5c:
+                case 0x5d:
+                case 0x5e:
+                case 0x5f:
+                case 0x60:
+                case 0x61:
+                case 0x62:
+                case 99:
+                case 0x66:
+                case 0x67:
+                case 0x68:
+                case 0x69:
+                case 0x6a:
+                case 0x6b:
+                case 0x6c:
+                case 0x6d:
+                case 0x6e:
+                case 0x6f:
+                case 0x70:
+                case 0x71:
+                case 0x72:
+                case 0x73:
+                case 0x74:
+                case 0x75:
+                case 0x76:
+                case 0x77:
+                case 0x78:
+                case 0x79:
+                case 0x7a:
+                case 0x7b:
+                case 0x7c:
+                case 0x7d:
+                case 0x7e:
+                case 0x7f:
+                case 0x80:
+                case 0x81:
+                case 0x82:
+                case 0x83:
+                case 0x84:
+                case 0x85:
+                case 0x86:
+                case 0x87:
+                case 0x88:
+                case 0x89:
+                case 0x8a:
+                case 0x8b:
+                case 0x8c:
+                case 0x8d:
+                case 0x8e:
+                case 0x8f:
+                case 0x90:
+                case 0x91:
+                case 0x92:
+                case 0x93:
+                case 0x94:
+                case 0x95:
+                    break;
+                case 0x96:
+                case 0x39:
+                case 0x06:
+                case 0x38:
+                case 0x05:
+                case 0x37:
+                case 0x34:
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x35:
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x3A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 100: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x65: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0xFD: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                }
+                default: {
+                }
+            }
         }
-
-
-
-        switch ((unsigned char)control_byte[0])  {
-            case 0x00:
-            case 0x32:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-                break;
-            }
-            case 0x33:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 4:
-            case 7:
-            case 8:
-            case 9:
-            case 10:
-            case 0xb:
-            case 0xc:
-            case 0xd:
-            case 0xe:
-            case 0xf:
-            case 0x10:
-            case 0x11:
-            case 0x12:
-            case 0x13:
-            case 0x14:
-            case 0x15:
-            case 0x16:
-            case 0x17:
-            case 0x18:
-            case 0x19:
-            case 0x1a:
-            case 0x1b:
-            case 0x1c:
-            case 0x1d:
-            case 0x1e:
-            case 0x1f:
-            case 0x20:
-            case 0x21:
-            case 0x22:
-            case 0x23:
-            case 0x24:
-            case 0x25:
-            case 0x26:
-            case 0x27:
-            case 0x28:
-            case 0x29:
-            case 0x2a:
-            case 0x2b:
-            case 0x2c:
-            case 0x2d:
-            case 0x2e:
-            case 0x2f:
-            case 0x30:
-            case 0x31:
-            case 0x36:
-            case 0x3b:
-            case 0x3c:
-            case 0x3d:
-            case 0x3e:
-            case 0x3f:
-            case 0x40:
-            case 0x41:
-            case 0x42:
-            case 0x43:
-            case 0x44:
-            case 0x45:
-            case 0x46:
-            case 0x47:
-            case 0x48:
-            case 0x49:
-            case 0x4a:
-            case 0x4b:
-            case 0x4c:
-            case 0x4d:
-            case 0x4e:
-            case 0x4f:
-            case 0x50:
-            case 0x51:
-            case 0x52:
-            case 0x53:
-            case 0x54:
-            case 0x55:
-            case 0x56:
-            case 0x57:
-            case 0x58:
-            case 0x59:
-            case 0x5a:
-            case 0x5b:
-            case 0x5c:
-            case 0x5d:
-            case 0x5e:
-            case 0x5f:
-            case 0x60:
-            case 0x61:
-            case 0x62:
-            case 99:
-            case 0x66:
-            case 0x67:
-            case 0x68:
-            case 0x69:
-            case 0x6a:
-            case 0x6b:
-            case 0x6c:
-            case 0x6d:
-            case 0x6e:
-            case 0x6f:
-            case 0x70:
-            case 0x71:
-            case 0x72:
-            case 0x73:
-            case 0x74:
-            case 0x75:
-            case 0x76:
-            case 0x77:
-            case 0x78:
-            case 0x79:
-            case 0x7a:
-            case 0x7b:
-            case 0x7c:
-            case 0x7d:
-            case 0x7e:
-            case 0x7f:
-            case 0x80:
-            case 0x81:
-            case 0x82:
-            case 0x83:
-            case 0x84:
-            case 0x85:
-            case 0x86:
-            case 0x87:
-            case 0x88:
-            case 0x89:
-            case 0x8a:
-            case 0x8b:
-            case 0x8c:
-            case 0x8d:
-            case 0x8e:
-            case 0x8f:
-            case 0x90:
-            case 0x91:
-            case 0x92:
-            case 0x93:
-            case 0x94:
-            case 0x95:
-                break;
-            case 0x96:
-            case 0x39:
-            case 0x06:
-            case 0x38:
-            case 0x05:
-            case 0x37:
-            case 0x34:
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x35:
-            case 0x03:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x3A:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 100:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x65:
-            {
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0xFD:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            }
-            default:{}
-
-
-        }
-        }
-
     };
-    //0x32
-    class OPCode32: public Instruction{
-    public:
-        OPCode32():Instruction(-1,0x32,nullptr){}
-        OPCode32(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x32,Maker){}
-        OPCode32(int addr, Builder *Maker):Instruction(addr,"???",0x32,Maker){}
-        OPCode32(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x32,Maker){
+    // 0x32
+    class OPCode32 : public Instruction {
+      public:
+        OPCode32()
+          : Instruction(-1, 0x32, nullptr) {}
+        OPCode32(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x32, Maker) {}
+        OPCode32(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {}
+        OPCode32(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x01:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                break;
-            }
-            case 0x04:
-            {
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                break;
+                    break;
+                }
             }
         }
+    };
+    // 0x33
+    class OPCode33 : public Instruction {
+      public:
+        OPCode33()
+          : Instruction(-1, 0x33, nullptr) {}
+        OPCode33(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x33, Maker) {}
+        OPCode33(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {}
+        OPCode33(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x33
-    class OPCode33: public Instruction{
-    public:
-        OPCode33():Instruction(-1,0x33,nullptr){}
-        OPCode33(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x33,Maker){}
-        OPCode33(int addr, Builder *Maker):Instruction(addr,"???",0x33,Maker){}
-        OPCode33(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x33,Maker){
+    // 0x34
+    class OPCode34 : public Instruction {
+      public:
+        OPCode34()
+          : Instruction(-1, 0x34, nullptr) {}
+        OPCode34(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x34, Maker) {}
+        OPCode34(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {}
+        OPCode34(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
-    //0x34
-    class OPCode34: public Instruction{
-    public:
-        OPCode34():Instruction(-1,0x34,nullptr){}
-        OPCode34(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x34,Maker){}
-        OPCode34(int addr, Builder *Maker):Instruction(addr,"???",0x34,Maker){}
-        OPCode34(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x34,Maker){
+    // 0x35
+    class OPCode35 : public Instruction {
+      public:
+        OPCode35()
+          : Instruction(-1, 0x35, nullptr) {}
+        OPCode35(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x35, Maker) {}
+        OPCode35(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {}
+        OPCode35(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-       }
-
-    };
-    //0x35
-    class OPCode35: public Instruction{
-    public:
-        OPCode35():Instruction(-1,0x35,nullptr){}
-        OPCode35(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x35,Maker){}
-        OPCode35(int addr, Builder *Maker):Instruction(addr,"???",0x35,Maker){}
-        OPCode35(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x35,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x36
-    class OPCode36: public Instruction{
-    public:
-        OPCode36():Instruction(-1,0x36,nullptr){}
-        OPCode36(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x36,Maker){}
-        OPCode36(int addr, Builder *Maker):Instruction(addr,"???",0x36,Maker){}
-        OPCode36(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x36,Maker){
+    // 0x36
+    class OPCode36 : public Instruction {
+      public:
+        OPCode36()
+          : Instruction(-1, 0x36, nullptr) {}
+        OPCode36(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x36, Maker) {}
+        OPCode36(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {}
+        OPCode36(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
             short second_arg = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            if ((second_arg == -0x1fe)||(second_arg == -0x1fd)){
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            if ((second_arg == -0x1fe) || (second_arg == -0x1fd)) {
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
             }
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x37
-    class OPCode37: public Instruction{
-    public:
-        OPCode37():Instruction(-1,0x37,nullptr){}
-        OPCode37(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x37,Maker){}
-        OPCode37(int addr, Builder *Maker):Instruction(addr,"???",0x37,Maker){}
-        OPCode37(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x37,Maker){
+    // 0x37
+    class OPCode37 : public Instruction {
+      public:
+        OPCode37()
+          : Instruction(-1, 0x37, nullptr) {}
+        OPCode37(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x37, Maker) {}
+        OPCode37(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {}
+        OPCode37(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x38
-    class OPCode38: public Instruction{
-    public:
-        OPCode38():Instruction(-1,0x38,nullptr){}
-        OPCode38(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x38,Maker){}
-        OPCode38(int addr, Builder *Maker):Instruction(addr,"???",0x38,Maker){}
-        OPCode38(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x38,Maker){
+    // 0x38
+    class OPCode38 : public Instruction {
+      public:
+        OPCode38()
+          : Instruction(-1, 0x38, nullptr) {}
+        OPCode38(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x38, Maker) {}
+        OPCode38(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {}
+        OPCode38(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-       }
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
     };
-    //0x39
-    class OPCode39: public Instruction{
-    public:
-        OPCode39():Instruction(-1,0x39,nullptr){}
-        OPCode39(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x39,Maker){}
-        OPCode39(int addr, Builder *Maker):Instruction(addr,"???",0x39,Maker){}
-        OPCode39(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x39,Maker){
+    // 0x39
+    class OPCode39 : public Instruction {
+      public:
+        OPCode39()
+          : Instruction(-1, 0x39, nullptr) {}
+        OPCode39(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x39, Maker) {}
+        OPCode39(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {}
+        OPCode39(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            if ((code != 0xC)&&(code != 0x5)&&(code != 0x69)&&(code != 0xA)&&(code != 0xB)&&(code != 0xFF)&&(code != 0xFE)){
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            if ((code != 0xC) && (code != 0x5) && (code != 0x69) && (code != 0xA) && (code != 0xB) && (code != 0xFF) && (code != 0xFE)) {
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
             }
-       }
-
-    };
-    //0x3A
-    class OPCode3A: public Instruction{
-    public:
-        OPCode3A():Instruction(-1,0x3A,nullptr){}
-        OPCode3A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3A,Maker){}
-        OPCode3A(int addr, Builder *Maker):Instruction(addr,"???",0x3A,Maker){}
-        OPCode3A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3A,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
-
     };
-    //0x3B
-    class OPCode3B: public Instruction{
-    public:
-        OPCode3B():Instruction(-1,0x3B,nullptr){}
-        OPCode3B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3B,Maker){}
-        OPCode3B(int addr, Builder *Maker):Instruction(addr,"???",0x3B,Maker){}
-        OPCode3B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3B,Maker){
+    // 0x3A
+    class OPCode3A : public Instruction {
+      public:
+        OPCode3A()
+          : Instruction(-1, 0x3A, nullptr) {}
+        OPCode3A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3A, Maker) {}
+        OPCode3A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {}
+        OPCode3A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x3C
-    static int FUN_00644350(ushort first_two_bytes){
+    // 0x3B
+    class OPCode3B : public Instruction {
+      public:
+        OPCode3B()
+          : Instruction(-1, 0x3B, nullptr) {}
+        OPCode3B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3B, Maker) {}
+        OPCode3B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {}
+        OPCode3B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x3C
+    static int FUN_00644350(ushort first_two_bytes) {
         if (first_two_bytes < 0x10) {
-          return 0;
+            return 0;
         }
         if (first_two_bytes == 0xFFFD) return 0;
         return 1;
     }
 
-    class OPCode3C: public Instruction{
-        public:
-        OPCode3C():Instruction(-1,0x3C,nullptr){}
-        OPCode3C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3C,Maker){}
-        OPCode3C(int addr, Builder *Maker):Instruction(addr,"???",0x3C,Maker){}
-        OPCode3C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3C,Maker){
+    class OPCode3C : public Instruction {
+      public:
+        OPCode3C()
+          : Instruction(-1, 0x3C, nullptr) {}
+        OPCode3C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3C, Maker) {}
+        OPCode3C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {}
+        OPCode3C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
             QByteArray control_short2 = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short2));
+            this->AddOperande(operande(addr, "short", control_short2));
             QByteArray control_short3 = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short3));
+            this->AddOperande(operande(addr, "short", control_short3));
             ushort short1 = ReadShortFromByteArray(0, control_short);
             ushort short2 = ReadShortFromByteArray(0, control_short2);
 
             int var2 = FUN_00644350(short1);
             int var3 = FUN_00644350(short2);
             if (((var2 == 0) || (var3 == 0)) || (var2 == var3)) {
-                if (short2 == 0xFFFF){
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                if (short2 == 0xFFFF) {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                 }
             }
-
         }
-
     };
-    //0x3D
-    class OPCode3D: public Instruction{
-    public:
-        OPCode3D():Instruction(-1,0x3D,nullptr){}
-        OPCode3D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3D,Maker){}
-        OPCode3D(int addr, Builder *Maker):Instruction(addr,"???",0x3D,Maker){}
-        OPCode3D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3D,Maker){
+    // 0x3D
+    class OPCode3D : public Instruction {
+      public:
+        OPCode3D()
+          : Instruction(-1, 0x3D, nullptr) {}
+        OPCode3D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3D, Maker) {}
+        OPCode3D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {}
+        OPCode3D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x3E
-    class OPCode3E: public Instruction{
-    public:
-        OPCode3E():Instruction(-1,0x3E,nullptr){}
-        OPCode3E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3E,Maker){}
-        OPCode3E(int addr, Builder *Maker):Instruction(addr,"???",0x3E,Maker){}
-        OPCode3E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3E,Maker){
+    // 0x3E
+    class OPCode3E : public Instruction {
+      public:
+        OPCode3E()
+          : Instruction(-1, 0x3E, nullptr) {}
+        OPCode3E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3E, Maker) {}
+        OPCode3E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {}
+        OPCode3E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x3F
-    class OPCode3F: public Instruction{
-    public:
-        OPCode3F():Instruction(-1,0x3F,nullptr){}
-        OPCode3F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3F,Maker){}
-        OPCode3F(int addr, Builder *Maker):Instruction(addr,"???",0x3F,Maker){}
-        OPCode3F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3F,Maker){
+    // 0x3F
+    class OPCode3F : public Instruction {
+      public:
+        OPCode3F()
+          : Instruction(-1, 0x3F, nullptr) {}
+        OPCode3F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3F, Maker) {}
+        OPCode3F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {}
+        OPCode3F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x09:
                 case 0x0A:
                 case 0x0B:
@@ -3323,658 +3743,765 @@ class CS1Builder : public Builder
                 case 0x06:
                 case 0x05:
                 case 0x04:
-                case 0x00:{
+                case 0x00: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x08:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x08: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
+            }
         }
-        }
-
     };
 
-    //0x40
-    class OPCode40: public Instruction{
-    public:
-        OPCode40():Instruction(-1,0x40,nullptr){}
-        OPCode40(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x40,Maker){}
-        OPCode40(int addr, Builder *Maker):Instruction(addr,"???",0x40,Maker){}
-        OPCode40(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x40,Maker){
+    // 0x40
+    class OPCode40 : public Instruction {
+      public:
+        OPCode40()
+          : Instruction(-1, 0x40, nullptr) {}
+        OPCode40(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x40, Maker) {}
+        OPCode40(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {}
+        OPCode40(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x41
-    class OPCode41: public Instruction{
-    public:
-        OPCode41():Instruction(-1,0x41,nullptr){}
-        OPCode41(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x41,Maker){}
-        OPCode41(int addr, Builder *Maker):Instruction(addr,"???",0x41,Maker){}
-        OPCode41(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x41,Maker){
+    // 0x41
+    class OPCode41 : public Instruction {
+      public:
+        OPCode41()
+          : Instruction(-1, 0x41, nullptr) {}
+        OPCode41(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x41, Maker) {}
+        OPCode41(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x41, Maker) {}
+        OPCode41(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x41, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
 
-    //0x42
-    class OPCode42: public Instruction{
-    public:
-        OPCode42():Instruction(-1,0x42,nullptr){}
-        OPCode42(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x42,Maker){}
-        OPCode42(int addr, Builder *Maker):Instruction(addr,"???",0x42,Maker){}
-        OPCode42(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x42,Maker){
+    // 0x42
+    class OPCode42 : public Instruction {
+      public:
+        OPCode42()
+          : Instruction(-1, 0x42, nullptr) {}
+        OPCode42(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x42, Maker) {}
+        OPCode42(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {}
+        OPCode42(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
 
-    //0x43
-    class OPCode43: public Instruction{
-    public:
-        OPCode43():Instruction(-1,0x43,nullptr){}
-        OPCode43(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x43,Maker){}
-        OPCode43(int addr, Builder *Maker):Instruction(addr,"???",0x43,Maker){}
-        OPCode43(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x43,Maker){
+    // 0x43
+    class OPCode43 : public Instruction {
+      public:
+        OPCode43()
+          : Instruction(-1, 0x43, nullptr) {}
+        OPCode43(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x43, Maker) {}
+        OPCode43(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {}
+        OPCode43(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x44
-    class OPCode44: public Instruction{
-    public:
-        OPCode44():Instruction(-1,0x44,nullptr){}
-        OPCode44(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x44,Maker){}
-        OPCode44(int addr, Builder *Maker):Instruction(addr,"???",0x44,Maker){}
-        OPCode44(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x44,Maker){
+    // 0x44
+    class OPCode44 : public Instruction {
+      public:
+        OPCode44()
+          : Instruction(-1, 0x44, nullptr) {}
+        OPCode44(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x44, Maker) {}
+        OPCode44(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x44, Maker) {}
+        OPCode44(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x44, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
 
-                case 0x00:{
+                case 0x00: {
 
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x03:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x03: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
                 case 0x04:
-                case 0x05:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;}
-
-
-            }
-        }
-
-    };
-    //0x45
-    class OPCode45: public Instruction{
-    public:
-        OPCode45():Instruction(-1,0x45,nullptr){}
-        OPCode45(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x45,Maker){}
-        OPCode45(int addr, Builder *Maker):Instruction(addr,"???",0x45,Maker){}
-        OPCode45(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x45,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-    //0x46
-    class OPCode46: public Instruction{
-    public:
-        OPCode46():Instruction(-1,0x46,nullptr){}
-        OPCode46(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x46,Maker){}
-        OPCode46(int addr, Builder *Maker):Instruction(addr,"???",0x46,Maker){}
-        OPCode46(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x46,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-    //0x47
-    class OPCode47: public Instruction{
-    public:
-        OPCode47():Instruction(-1,0x47,nullptr){}
-        OPCode47(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x47,Maker){}
-        OPCode47(int addr, Builder *Maker):Instruction(addr,"???",0x47,Maker){}
-        OPCode47(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x47,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x48
-    class OPCode48: public Instruction{
-    public:
-        OPCode48():Instruction(-1,0x48,nullptr){}
-        OPCode48(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x48,Maker){}
-        OPCode48(int addr, Builder *Maker):Instruction(addr,"???",0x48,Maker){}
-        OPCode48(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x48,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-           }
-
-    };
-    //0x49
-    class OPCode49: public Instruction{
-    public:
-        OPCode49():Instruction(-1,0x49,nullptr){}
-        OPCode49(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x49,Maker){}
-        OPCode49(int addr, Builder *Maker):Instruction(addr,"???",0x49,Maker){}
-        OPCode49(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x49,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-
-            case 0x0A:
-            case 0x04:
-            case 0x03:
-            case 0x02:
-            case 0x01:
-            case 0x00:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '\r':{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x14:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x15:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-                break;
-            }
-            case 0x17:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x18:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x19:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x1C:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '!':{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '(':
-            case '$':
-            case '#':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '&':{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case ')':{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-
-        }
-        }
-
-    };
-    //0x4A
-    class OPCode4A: public Instruction{
-    public:
-        OPCode4A():Instruction(-1,0x4A,nullptr){}
-        OPCode4A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4A,Maker){}
-        OPCode4A(int addr, Builder *Maker):Instruction(addr,"???",0x4A,Maker){}
-        OPCode4A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4A,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-        }
-
-    };
-    //0x4B
-    class OPCode4B: public Instruction{
-    public:
-        OPCode4B():Instruction(-1,0x4B,nullptr){}
-        OPCode4B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4B,Maker){}
-        OPCode4B(int addr, Builder *Maker):Instruction(addr,"???",0x4B,Maker){}
-        OPCode4B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4B,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x4C
-    class OPCode4C: public Instruction{
-    public:
-        OPCode4C():Instruction(-1,0x4C,nullptr){}
-        OPCode4C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4C,Maker){}
-        OPCode4C(int addr, Builder *Maker):Instruction(addr,"???",0x4C,Maker){}
-        OPCode4C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4C,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-        }
-
-    };
-    //0x4D
-    class OPCode4D: public Instruction{
-    public:
-        OPCode4D():Instruction(-1,0x4D,nullptr){}
-        OPCode4D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4D,Maker){}
-        OPCode4D(int addr, Builder *Maker):Instruction(addr,"???",0x4D,Maker){}
-        OPCode4D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4D,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-    };
-    //0x4E
-    class OPCode4E: public Instruction{
-    public:
-        OPCode4E():Instruction(-1,0x4E,nullptr){}
-        OPCode4E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4E,Maker){}
-        OPCode4E(int addr, Builder *Maker):Instruction(addr,"???",0x4E,Maker){}
-        OPCode4E(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4E,Maker){
-            addr++;
-        }
-
-    };
-    //0x4F
-    class OPCode4F: public Instruction{
-    public:
-        OPCode4F():Instruction(-1,0x4F,nullptr){}
-        OPCode4F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4F,Maker){}
-        OPCode4F(int addr, Builder *Maker):Instruction(addr,"???",0x4F,Maker){}
-        OPCode4F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x50
-    class OPCode50: public Instruction{
-    public:
-        OPCode50():Instruction(-1,0x50,nullptr){}
-        OPCode50(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x50,Maker){}
-        OPCode50(int addr, Builder *Maker):Instruction(addr,"???",0x50,Maker){}
-        OPCode50(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x50,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-       }
-
-    };
-    //0x51
-    class OPCode51: public Instruction{
-        public:
-            OPCode51():Instruction(-1,0x51,nullptr){}
-            OPCode51(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x51,Maker){}
-            OPCode51(int addr, Builder *Maker):Instruction(addr,"???",0x51,Maker){}
-            OPCode51(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x51,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            }
-
-    };
-    //0x52
-    class OPCode52: public Instruction{
-    public:
-        OPCode52():Instruction(-1,0x52,nullptr){}
-        OPCode52(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x52,Maker){}
-        OPCode52(int addr, Builder *Maker):Instruction(addr,"???",0x52,Maker){}
-        OPCode52(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x52,Maker){
-            addr++;
-
-
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x53
-    class OPCode53: public Instruction{
-    public:
-        OPCode53():Instruction(-1,0x53,nullptr){}
-        OPCode53(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x53,Maker){}
-        OPCode53(int addr, Builder *Maker):Instruction(addr,"???",0x53,Maker){}
-        OPCode53(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x53,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x55
-    class OPCode55: public Instruction{
-    public:
-        OPCode55():Instruction(-1,0x55,nullptr){}
-        OPCode55(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x55,Maker){}
-        OPCode55(int addr, Builder *Maker):Instruction(addr,"???",0x55,Maker){}
-        OPCode55(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x55,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-       }
-
-    };
-    //0x56
-    class OPCode56: public Instruction{
-    public:
-        OPCode56():Instruction(-1,0x56,nullptr){}
-        OPCode56(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x56,Maker){}
-        OPCode56(int addr, Builder *Maker):Instruction(addr,"???",0x56,Maker){}
-        OPCode56(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x56,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x57
-    class OPCode57: public Instruction{
-    public:
-        OPCode57():Instruction(-1,0x57,nullptr){}
-        OPCode57(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x57,Maker){}
-        OPCode57(int addr, Builder *Maker):Instruction(addr,"???",0x57,Maker){}
-        OPCode57(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x57,Maker){
-            addr++;
-        }
-
-    };
-    //0x58
-    class OPCode58: public Instruction{
-    public:
-        OPCode58():Instruction(-1,0x58,nullptr){}
-        OPCode58(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x58,Maker){}
-        OPCode58(int addr, Builder *Maker):Instruction(addr,"???",0x58,Maker){}
-        OPCode58(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x58,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        }
-
-    };
-    //0x59
-    class OPCode59: public Instruction{
-    public:
-        OPCode59():Instruction(-1,0x59,nullptr){}
-        OPCode59(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x59,Maker){}
-        OPCode59(int addr, Builder *Maker):Instruction(addr,"???",0x59,Maker){}
-        OPCode59(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x59,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-    //0x5A
-    class OPCode5A: public Instruction{
-    public:
-        OPCode5A():Instruction(-1,0x5A,nullptr){}
-        OPCode5A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5A,Maker){}
-        OPCode5A(int addr, Builder *Maker):Instruction(addr,"???",0x5A,Maker){}
-        OPCode5A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5A,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x5B
-    class OPCode5B: public Instruction{
-    public:
-        OPCode5B():Instruction(-1,0x5B,nullptr){}
-        OPCode5B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5B,Maker){}
-        OPCode5B(int addr, Builder *Maker):Instruction(addr,"???",0x5B,Maker){}
-        OPCode5B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5B,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch((unsigned char)control_byte[0]){
-                case 0x04:
-                case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
             }
         }
-
     };
-    //0x5C
-    class OPCode5C: public Instruction{
-    public:
-        OPCode5C():Instruction(-1,0x5C,nullptr){}
-        OPCode5C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5C,Maker){}
-        OPCode5C(int addr, Builder *Maker):Instruction(addr,"???",0x5C,Maker){}
-        OPCode5C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5C,Maker){
+    // 0x45
+    class OPCode45 : public Instruction {
+      public:
+        OPCode45()
+          : Instruction(-1, 0x45, nullptr) {}
+        OPCode45(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x45, Maker) {}
+        OPCode45(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x45, Maker) {}
+        OPCode45(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x45, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x46
+    class OPCode46 : public Instruction {
+      public:
+        OPCode46()
+          : Instruction(-1, 0x46, nullptr) {}
+        OPCode46(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x46, Maker) {}
+        OPCode46(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x46, Maker) {}
+        OPCode46(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x46, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x47
+    class OPCode47 : public Instruction {
+      public:
+        OPCode47()
+          : Instruction(-1, 0x47, nullptr) {}
+        OPCode47(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x47, Maker) {}
+        OPCode47(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {}
+        OPCode47(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x48
+    class OPCode48 : public Instruction {
+      public:
+        OPCode48()
+          : Instruction(-1, 0x48, nullptr) {}
+        OPCode48(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x48, Maker) {}
+        OPCode48(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {}
+        OPCode48(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x49
+    class OPCode49 : public Instruction {
+      public:
+        OPCode49()
+          : Instruction(-1, 0x49, nullptr) {}
+        OPCode49(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x49, Maker) {}
+        OPCode49(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x49, Maker) {}
+        OPCode49(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x49, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x01:
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+
+                case 0x0A:
+                case 0x04:
+                case 0x03:
+                case 0x02:
+                case 0x01:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '\r': {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x18: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x19: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x1C: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '!': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '(':
+                case '$':
+                case '#': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '&': {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case ')': {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
             }
         }
-        }
-
     };
-    //0x5D
-    class OPCode5D: public Instruction{
-    public:
-        OPCode5D():Instruction(-1,0x5D,nullptr){}
-        OPCode5D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5D,Maker){}
-        OPCode5D(int addr, Builder *Maker):Instruction(addr,"???",0x5D,Maker){}
-        OPCode5D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5D,Maker){
+    // 0x4A
+    class OPCode4A : public Instruction {
+      public:
+        OPCode4A()
+          : Instruction(-1, 0x4A, nullptr) {}
+        OPCode4A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4A, Maker) {}
+        OPCode4A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4A, Maker) {}
+        OPCode4A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x4B
+    class OPCode4B : public Instruction {
+      public:
+        OPCode4B()
+          : Instruction(-1, 0x4B, nullptr) {}
+        OPCode4B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4B, Maker) {}
+        OPCode4B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4B, Maker) {}
+        OPCode4B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x4C
+    class OPCode4C : public Instruction {
+      public:
+        OPCode4C()
+          : Instruction(-1, 0x4C, nullptr) {}
+        OPCode4C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4C, Maker) {}
+        OPCode4C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4C, Maker) {}
+        OPCode4C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x4D
+    class OPCode4D : public Instruction {
+      public:
+        OPCode4D()
+          : Instruction(-1, 0x4D, nullptr) {}
+        OPCode4D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4D, Maker) {}
+        OPCode4D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4D, Maker) {}
+        OPCode4D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0x4E
+    class OPCode4E : public Instruction {
+      public:
+        OPCode4E()
+          : Instruction(-1, 0x4E, nullptr) {}
+        OPCode4E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4E, Maker) {}
+        OPCode4E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4E, Maker) {}
+        OPCode4E(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4E, Maker) {
+            addr++;
+        }
+    };
+    // 0x4F
+    class OPCode4F : public Instruction {
+      public:
+        OPCode4F()
+          : Instruction(-1, 0x4F, nullptr) {}
+        OPCode4F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4F, Maker) {}
+        OPCode4F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4F, Maker) {}
+        OPCode4F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x50
+    class OPCode50 : public Instruction {
+      public:
+        OPCode50()
+          : Instruction(-1, 0x50, nullptr) {}
+        OPCode50(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x50, Maker) {}
+        OPCode50(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x50, Maker) {}
+        OPCode50(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x50, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x51
+    class OPCode51 : public Instruction {
+      public:
+        OPCode51()
+          : Instruction(-1, 0x51, nullptr) {}
+        OPCode51(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x51, Maker) {}
+        OPCode51(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x51, Maker) {}
+        OPCode51(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x51, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x52
+    class OPCode52 : public Instruction {
+      public:
+        OPCode52()
+          : Instruction(-1, 0x52, nullptr) {}
+        OPCode52(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x52, Maker) {}
+        OPCode52(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x52, Maker) {}
+        OPCode52(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x52, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x53
+    class OPCode53 : public Instruction {
+      public:
+        OPCode53()
+          : Instruction(-1, 0x53, nullptr) {}
+        OPCode53(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x53, Maker) {}
+        OPCode53(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x53, Maker) {}
+        OPCode53(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x53, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x55
+    class OPCode55 : public Instruction {
+      public:
+        OPCode55()
+          : Instruction(-1, 0x55, nullptr) {}
+        OPCode55(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x55, Maker) {}
+        OPCode55(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x55, Maker) {}
+        OPCode55(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x55, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x56
+    class OPCode56 : public Instruction {
+      public:
+        OPCode56()
+          : Instruction(-1, 0x56, nullptr) {}
+        OPCode56(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x56, Maker) {}
+        OPCode56(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x56, Maker) {}
+        OPCode56(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x56, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x57
+    class OPCode57 : public Instruction {
+      public:
+        OPCode57()
+          : Instruction(-1, 0x57, nullptr) {}
+        OPCode57(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x57, Maker) {}
+        OPCode57(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x57, Maker) {}
+        OPCode57(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x57, Maker) {
+            addr++;
+        }
+    };
+    // 0x58
+    class OPCode58 : public Instruction {
+      public:
+        OPCode58()
+          : Instruction(-1, 0x58, nullptr) {}
+        OPCode58(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x58, Maker) {}
+        OPCode58(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x58, Maker) {}
+        OPCode58(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x58, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x59
+    class OPCode59 : public Instruction {
+      public:
+        OPCode59()
+          : Instruction(-1, 0x59, nullptr) {}
+        OPCode59(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x59, Maker) {}
+        OPCode59(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x59, Maker) {}
+        OPCode59(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x59, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x5A
+    class OPCode5A : public Instruction {
+      public:
+        OPCode5A()
+          : Instruction(-1, 0x5A, nullptr) {}
+        OPCode5A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5A, Maker) {}
+        OPCode5A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5A, Maker) {}
+        OPCode5A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x5B
+    class OPCode5B : public Instruction {
+      public:
+        OPCode5B()
+          : Instruction(-1, 0x5B, nullptr) {}
+        OPCode5B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5B, Maker) {}
+        OPCode5B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5B, Maker) {}
+        OPCode5B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5B, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x04:
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+            }
+        }
+    };
+    // 0x5C
+    class OPCode5C : public Instruction {
+      public:
+        OPCode5C()
+          : Instruction(-1, 0x5C, nullptr) {}
+        OPCode5C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5C, Maker) {}
+        OPCode5C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5C, Maker) {}
+        OPCode5C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+            }
+        }
+    };
+    // 0x5D
+    class OPCode5D : public Instruction {
+      public:
+        OPCode5D()
+          : Instruction(-1, 0x5D, nullptr) {}
+        OPCode5D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5D, Maker) {}
+        OPCode5D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {}
+        OPCode5D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x04:
                 case 0x03:
-                case 0x02:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
 
-
-
-                case '\a':{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case '\a': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case '\b':{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case '\b': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-
             }
         }
-
     };
-    //0x5E
-    class OPCode5E: public Instruction{
-    public:
-        OPCode5E():Instruction(-1,0x5E,nullptr){}
-        OPCode5E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5E,Maker){}
-        OPCode5E(int addr, Builder *Maker):Instruction(addr,"???",0x5E,Maker){}
-        OPCode5E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5E,Maker){
+    // 0x5E
+    class OPCode5E : public Instruction {
+      public:
+        OPCode5E()
+          : Instruction(-1, 0x5E, nullptr) {}
+        OPCode5E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5E, Maker) {}
+        OPCode5E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {}
+        OPCode5E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {
             addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x0B:
@@ -3982,1497 +4509,1831 @@ class CS1Builder : public Builder
                 case 0x07:
                 case 0x08:
                 case 0x04:
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
                 case 0x05:
                 case 0x03:
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x06:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x06: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
                 case 0x0D:
-                case 0x0C:{
+                case 0x0C: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-
-
             }
         }
-
     };
-    //0x5F
-    class OPCode5F: public Instruction{
-    public:
-        OPCode5F():Instruction(-1,0x5F,nullptr){}
-        OPCode5F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5F,Maker){}
-        OPCode5F(int addr, Builder *Maker):Instruction(addr,"???",0x5F,Maker){}
-        OPCode5F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5F,Maker){
+    // 0x5F
+    class OPCode5F : public Instruction {
+      public:
+        OPCode5F()
+          : Instruction(-1, 0x5F, nullptr) {}
+        OPCode5F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5F, Maker) {}
+        OPCode5F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5F, Maker) {}
+        OPCode5F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5F, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x00:
-                case 0x03:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x03: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-
             }
         }
-
     };
-    //0x60
-    class OPCode60: public Instruction{
-    public:
-        OPCode60():Instruction(-1,0x60,nullptr){}
-        OPCode60(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x60,Maker){}
-        OPCode60(int addr, Builder *Maker):Instruction(addr,"???",0x60,Maker){}
-        OPCode60(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x60,Maker){
+    // 0x60
+    class OPCode60 : public Instruction {
+      public:
+        OPCode60()
+          : Instruction(-1, 0x60, nullptr) {}
+        OPCode60(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x60, Maker) {}
+        OPCode60(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {}
+        OPCode60(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {
             addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x61
-    class OPCode61: public Instruction{
-    public:
-        OPCode61():Instruction(-1,0x61,nullptr){}
-        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x61,Maker){}
-        OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){}
-        OPCode61(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x62
-    class OPCode62: public Instruction{
-    public:
-        OPCode62():Instruction(-1,0x62,nullptr){}
-        OPCode62(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x62,Maker){}
-        OPCode62(int addr, Builder *Maker):Instruction(addr,"???",0x62,Maker){}
-        OPCode62(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x62,Maker){
+    // 0x61
+    class OPCode61 : public Instruction {
+      public:
+        OPCode61()
+          : Instruction(-1, 0x61, nullptr) {}
+        OPCode61(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x61, Maker) {}
+        OPCode61(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {}
+        OPCode61(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x63
-    class OPCode63: public Instruction{
-    public:
-        OPCode63():Instruction(-1,0x63,nullptr){}
-        OPCode63(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x63,Maker){}
-        OPCode63(int addr, Builder *Maker):Instruction(addr,"???",0x63,Maker){}
-        OPCode63(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x63,Maker){
+    // 0x62
+    class OPCode62 : public Instruction {
+      public:
+        OPCode62()
+          : Instruction(-1, 0x62, nullptr) {}
+        OPCode62(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x62, Maker) {}
+        OPCode62(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x62, Maker) {}
+        OPCode62(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x62, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x64
-    class OPCode64: public Instruction{
-    public:
-        OPCode64():Instruction(-1,0x64,nullptr){}
-        OPCode64(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x64,Maker){}
-        OPCode64(int addr, Builder *Maker):Instruction(addr,"???",0x64,Maker){}
-        OPCode64(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x64,Maker){
+    // 0x63
+    class OPCode63 : public Instruction {
+      public:
+        OPCode63()
+          : Instruction(-1, 0x63, nullptr) {}
+        OPCode63(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x63, Maker) {}
+        OPCode63(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x63, Maker) {}
+        OPCode63(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x63, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x65
-    class OPCode65: public Instruction{
-    public:
-        OPCode65():Instruction(-1,0x65,nullptr){}
-        OPCode65(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x65,Maker){}
-        OPCode65(int addr, Builder *Maker):Instruction(addr,"???",0x65,Maker){}
-        OPCode65(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x65,Maker){
+    // 0x64
+    class OPCode64 : public Instruction {
+      public:
+        OPCode64()
+          : Instruction(-1, 0x64, nullptr) {}
+        OPCode64(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x64, Maker) {}
+        OPCode64(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {}
+        OPCode64(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x65
+    class OPCode65 : public Instruction {
+      public:
+        OPCode65()
+          : Instruction(-1, 0x65, nullptr) {}
+        OPCode65(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x65, Maker) {}
+        OPCode65(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {}
+        OPCode65(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x05:
-            case 0x03:
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x05:
+                case 0x03:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
-                break;
-            }
-            case 0x06:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    break;
+                }
+                case 0x06: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
-                break;
+                    break;
+                }
+                case 0x09:
+                case 0x07:
+                case 0x04:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x08: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
             }
-            case 0x09:
-            case 0x07:
-            case 0x04:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x08:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-
         }
-
-        }
-
     };
 
-    //0x66
-    class OPCode66: public Instruction{
-    public:
-        OPCode66():Instruction(-1,0x66,nullptr){}
-        OPCode66(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x66,Maker){}
-        OPCode66(int addr, Builder *Maker):Instruction(addr,"???",0x66,Maker){}
-        OPCode66(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x66,Maker){
+    // 0x66
+    class OPCode66 : public Instruction {
+      public:
+        OPCode66()
+          : Instruction(-1, 0x66, nullptr) {}
+        OPCode66(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x66, Maker) {}
+        OPCode66(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {}
+        OPCode66(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x67
-    class OPCode67: public Instruction{
-    public:
-        OPCode67():Instruction(-1,0x67,nullptr){}
-        OPCode67(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x67,Maker){}
-        OPCode67(int addr, Builder *Maker):Instruction(addr,"???",0x67,Maker){}
-        OPCode67(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x67,Maker){
+    // 0x67
+    class OPCode67 : public Instruction {
+      public:
+        OPCode67()
+          : Instruction(-1, 0x67, nullptr) {}
+        OPCode67(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x67, Maker) {}
+        OPCode67(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {}
+        OPCode67(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             ushort control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-        switch(code){
-            case 0x02:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            switch (code) {
+                case 0x02:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
+                    break;
+                }
+                case 0x03:
+                case 0x04: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
             }
-            case 0x03:
-            case 0x04:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
+            if ((control != 0xFFFF) && (control <= 0x96) && (code == 0x6)) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             }
         }
-        if ((control != 0xFFFF) &&(control <= 0x96)&& (code == 0x6)){
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-        }
-
     };
-    //0x68
-    class OPCode68: public Instruction{
-    public:
-        OPCode68():Instruction(-1,0x68,nullptr){}
-        OPCode68(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x68,Maker){}
-        OPCode68(int addr, Builder *Maker):Instruction(addr,"???",0x68,Maker){}
-        OPCode68(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x68,Maker){
+    // 0x68
+    class OPCode68 : public Instruction {
+      public:
+        OPCode68()
+          : Instruction(-1, 0x68, nullptr) {}
+        OPCode68(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x68, Maker) {}
+        OPCode68(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {}
+        OPCode68(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
-            }
-            case 0x00:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    break;
+                }
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
-                break;
+                    break;
+                }
             }
         }
-        }
-
     };
-    //0x69
-    class OPCode69: public Instruction{
-    public:
-        OPCode69():Instruction(-1,0x69,nullptr){}
-        OPCode69(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x69,Maker){}
-        OPCode69(int addr, Builder *Maker):Instruction(addr,"???",0x69,Maker){}
-        OPCode69(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x69,Maker){
+    // 0x69
+    class OPCode69 : public Instruction {
+      public:
+        OPCode69()
+          : Instruction(-1, 0x69, nullptr) {}
+        OPCode69(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x69, Maker) {}
+        OPCode69(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {}
+        OPCode69(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x00:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
+                    break;
+                }
+
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
             }
-
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-                break;
-            }
-            case 0x05:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-
-
-
         }
-        }
-
     };
-    //0x6A
-    class OPCode6A: public Instruction{
-        public:
-            OPCode6A():Instruction(-1,0x6A,nullptr){}
-            OPCode6A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6A,Maker){}
-            OPCode6A(int addr, Builder *Maker):Instruction(addr,"???",0x6A,Maker){}
-            OPCode6A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6A,Maker){
+    // 0x6A
+    class OPCode6A : public Instruction {
+      public:
+        OPCode6A()
+          : Instruction(-1, 0x6A, nullptr) {}
+        OPCode6A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6A, Maker) {}
+        OPCode6A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {}
+        OPCode6A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
+            this->AddOperande(operande(addr, "byte", control_byte2));
 
-            if ((unsigned char)control_byte2[0] < 4){
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x00:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    }
-
-                    case 0x01:{
-                        //reading_dialog(addr, content, this);
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x02:{
-
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x04:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            if ((unsigned char)control_byte2[0] < 4) {
+                switch ((unsigned char)control_byte[0]) {
+                    case 0x00: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                         break;
                     }
-                    case 0x05:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+
+                    case 0x01: {
+                        // reading_dialog(addr, content, this);
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x02: {
+
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x04: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+
+                        break;
+                    }
+                    case 0x05: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                         break;
                     }
                     case 0x07:
-                    case 0x06:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    case 0x06: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                         break;
                     }
-
-
-
                 }
             }
-
         }
-
     };
-    //0x6B
-    class OPCode6B: public Instruction{
-    public:
-        OPCode6B():Instruction(-1,0x6B,nullptr){}
-        OPCode6B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6B,Maker){}
-        OPCode6B(int addr, Builder *Maker):Instruction(addr,"???",0x6B,Maker){}
-        OPCode6B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6B,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+    // 0x6B
+    class OPCode6B : public Instruction {
+      public:
+        OPCode6B()
+          : Instruction(-1, 0x6B, nullptr) {}
+        OPCode6B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6B, Maker) {}
+        OPCode6B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6B, Maker) {}
+        OPCode6B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x6C
-    class OPCode6C: public Instruction{
-    public:
-        OPCode6C():Instruction(-1,0x6C,nullptr){}
-        OPCode6C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6C,Maker){}
-        OPCode6C(int addr, Builder *Maker):Instruction(addr,"???",0x6C,Maker){}
-        OPCode6C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6C,Maker){
-        addr++;
-
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-    //0x6D
-    class OPCode6D: public Instruction{
-    public:
-        OPCode6D():Instruction(-1,0x6D,nullptr){}
-        OPCode6D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6D,Maker){}
-        OPCode6D(int addr, Builder *Maker):Instruction(addr,"???",0x6D,Maker){}
-        OPCode6D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6D,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-
-    };
-    //0x6E
-    class OPCode6E: public Instruction{
-    public:
-        OPCode6E():Instruction(-1,0x6E,nullptr){}
-        OPCode6E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6E,Maker){}
-        OPCode6E(int addr, Builder *Maker):Instruction(addr,"???",0x6E,Maker){}
-        OPCode6E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6E,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x05:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-        }
-        }
-
-    };
-    //0x6F
-    class OPCode6F: public Instruction{
-        public:
-        OPCode6F():Instruction(-1,0x6F,nullptr){}
-        OPCode6F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6F,Maker){}
-        OPCode6F(int addr, Builder *Maker):Instruction(addr,"???",0x6F,Maker){}
-        OPCode6F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6F,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x00:{
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x02:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-        }
-        }
-
-    };
-    //0x70
-    class OPCode70: public Instruction{
-        public:
-        OPCode70():Instruction(-1,0x70,nullptr){}
-        OPCode70(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x70,Maker){}
-        OPCode70(int addr, Builder *Maker):Instruction(addr,"???",0x70,Maker){}
-        OPCode70(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x70,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        unsigned char code = control_byte[0];
-        if (code == 0x01){
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        }
-        }
-
-    };
-    //0x71
-    class OPCode71: public Instruction{
-    public:
-        OPCode71():Instruction(-1,0x71,nullptr){}
-        OPCode71(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x71,Maker){}
-        OPCode71(int addr, Builder *Maker):Instruction(addr,"???",0x71,Maker){}
-        OPCode71(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x71,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        unsigned char code = control_byte[0];
-        if (code == 0x00){
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-        }
-
-    };
-    //0x72
-    class OPCode72: public Instruction{
-    public:
-        OPCode72():Instruction(-1,0x72,nullptr){}
-        OPCode72(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x72,Maker){}
-        OPCode72(int addr, Builder *Maker):Instruction(addr,"???",0x72,Maker){}
-        OPCode72(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x72,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-    //0x73
-    class OPCode73: public Instruction{
-    public:
-        OPCode73():Instruction(-1,0x73,nullptr){}
-        OPCode73(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x73,Maker){}
-        OPCode73(int addr, Builder *Maker):Instruction(addr,"???",0x73,Maker){}
-        OPCode73(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x73,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x03:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x06:
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x04:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x05:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-
-
-
-        }
-        }
-
-    };
-    //0x74
-    class OPCode74: public Instruction{
-    public:
-        OPCode74():Instruction(-1,0x74,nullptr){}
-        OPCode74(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x74,Maker){}
-        OPCode74(int addr, Builder *Maker):Instruction(addr,"???",0x74,Maker){}
-        OPCode74(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x74,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-
-        }
-
-    };
-    //0x77
-    class OPCode77: public Instruction{
-        public:
-            OPCode77():Instruction(-1,0x77,nullptr){}
-            OPCode77(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x77,Maker){}
-            OPCode77(int addr, Builder *Maker):Instruction(addr,"???",0x77,Maker){}
-            OPCode77(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x77,Maker){
+    // 0x6C
+    class OPCode6C : public Instruction {
+      public:
+        OPCode6C()
+          : Instruction(-1, 0x6C, nullptr) {}
+        OPCode6C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6C, Maker) {}
+        OPCode6C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {}
+        OPCode6C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-            }
-
-    };
-    //0x78
-    class OPCode78: public Instruction{
-    public:
-        OPCode78():Instruction(-1,0x78,nullptr){}
-        OPCode78(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x78,Maker){}
-        OPCode78(int addr, Builder *Maker):Instruction(addr,"???",0x78,Maker){}
-        OPCode78(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x78,Maker){
-        addr++;
-
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x79
-    class OPCode79: public Instruction{
-    public:
-        OPCode79():Instruction(-1,0x79,nullptr){}
-        OPCode79(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x79,Maker){}
-        OPCode79(int addr, Builder *Maker):Instruction(addr,"???",0x79,Maker){}
-        OPCode79(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x79,Maker){
+    // 0x6D
+    class OPCode6D : public Instruction {
+      public:
+        OPCode6D()
+          : Instruction(-1, 0x6D, nullptr) {}
+        OPCode6D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6D, Maker) {}
+        OPCode6D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6D, Maker) {}
+        OPCode6D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x7A
-    class OPCode7A: public Instruction{
-    public:
-        OPCode7A():Instruction(-1,0x7A,nullptr){}
-        OPCode7A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7A,Maker){}
-        OPCode7A(int addr, Builder *Maker):Instruction(addr,"???",0x7A,Maker){}
-        OPCode7A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7A,Maker){
-            addr++;
-
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        }
-
-    };
-    //0x7B
-    class OPCode7B: public Instruction{
-    public:
-        OPCode7B():Instruction(-1,0x7B,nullptr){}
-        OPCode7B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7B,Maker){}
-        OPCode7B(int addr, Builder *Maker):Instruction(addr,"???",0x7B,Maker){}
-        OPCode7B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7B,Maker){
-            addr++;
-
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-        }
-
-    };
-    //0x7D
-    class OPCode7D: public Instruction{
-    public:
-        OPCode7D():Instruction(-1,0x7D,nullptr){}
-        OPCode7D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7D,Maker){}
-        OPCode7D(int addr, Builder *Maker):Instruction(addr,"???",0x7D,Maker){}
-        OPCode7D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7D,Maker){
-            addr++;
-
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-
-        }
-
-    };
-    //0x7E
-    class OPCode7E: public Instruction{
-    public:
-        OPCode7E():Instruction(-1,0x7E,nullptr){}
-        OPCode7E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7E,Maker){}
-        OPCode7E(int addr, Builder *Maker):Instruction(addr,"???",0x7E,Maker){}
-        OPCode7E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7E,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x7F
-    class OPCode7F: public Instruction{
-    public:
-        OPCode7F():Instruction(-1,0x7F,nullptr){}
-        OPCode7F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7F,Maker){}
-        OPCode7F(int addr, Builder *Maker):Instruction(addr,"???",0x7F,Maker){}
-        OPCode7F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7F,Maker){
+    // 0x6E
+    class OPCode6E : public Instruction {
+      public:
+        OPCode6E()
+          : Instruction(-1, 0x6E, nullptr) {}
+        OPCode6E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6E, Maker) {}
+        OPCode6E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {}
+        OPCode6E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch(control_byte[0]){
-            case 0x01   :
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
             }
-            case -2:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case -1:{
-
-                break;
-            }
-            default:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            }
-
-
-        }
         }
     };
-    //0x80
-    class OPCode80: public Instruction{
-    public:
-        OPCode80():Instruction(-1,0x80,nullptr){}
-        OPCode80(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x80,Maker){}
-        OPCode80(int addr, Builder *Maker):Instruction(addr,"???",0x80,Maker){}
-        OPCode80(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x80,Maker){
+    // 0x6F
+    class OPCode6F : public Instruction {
+      public:
+        OPCode6F()
+          : Instruction(-1, 0x6F, nullptr) {}
+        OPCode6F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6F, Maker) {}
+        OPCode6F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6F, Maker) {}
+        OPCode6F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6F, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x02:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+            }
         }
     };
-    //0x81
-    class OPCode81: public Instruction{
-    public:
-        OPCode81():Instruction(-1,0x81,nullptr){}
-        OPCode81(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x81,Maker){}
-        OPCode81(int addr, Builder *Maker):Instruction(addr,"???",0x81,Maker){}
-        OPCode81(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x81,Maker){
+    // 0x70
+    class OPCode70 : public Instruction {
+      public:
+        OPCode70()
+          : Instruction(-1, 0x70, nullptr) {}
+        OPCode70(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x70, Maker) {}
+        OPCode70(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {}
+        OPCode70(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            if (code == 0x00) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            if (code == 0x01) {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+            }
         }
     };
-    //0x82
-    class OPCode82: public Instruction{
-    public:
-        OPCode82():Instruction(-1,0x82,nullptr){}
-        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x82,Maker){}
-        OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){}
-        OPCode82(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x83
-    class OPCode83: public Instruction{
-    public:
-        OPCode83():Instruction(-1,0x83,nullptr){}
-        OPCode83(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x83,Maker){}
-        OPCode83(int addr, Builder *Maker):Instruction(addr,"???",0x83,Maker){}
-        OPCode83(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x83,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x84
-    class OPCode84: public Instruction{
-    public:
-        OPCode84():Instruction(-1,0x84,nullptr){}
-        OPCode84(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x84,Maker){}
-        OPCode84(int addr, Builder *Maker):Instruction(addr,"???",0x84,Maker){}
-        OPCode84(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
-            addr++;
-
-       }
-    };
-    //0x85
-    class OPCode85: public Instruction{
-    public:
-        OPCode85():Instruction(-1,0x85,nullptr){}
-        OPCode85(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x85,Maker){}
-        OPCode85(int addr, Builder *Maker):Instruction(addr,"???",0x85,Maker){}
-        OPCode85(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x85,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    //0x86
-    class OPCode86: public Instruction{
-    public:
-        OPCode86():Instruction(-1,0x86,nullptr){}
-        OPCode86(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x86,Maker){}
-        OPCode86(int addr, Builder *Maker):Instruction(addr,"???",0x86,Maker){}
-        OPCode86(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x86,Maker){
+    // 0x71
+    class OPCode71 : public Instruction {
+      public:
+        OPCode71()
+          : Instruction(-1, 0x71, nullptr) {}
+        OPCode71(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x71, Maker) {}
+        OPCode71(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x71, Maker) {}
+        OPCode71(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x71, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch ((unsigned char)control_byte[0])  {
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            }
+        }
+    };
+    // 0x72
+    class OPCode72 : public Instruction {
+      public:
+        OPCode72()
+          : Instruction(-1, 0x72, nullptr) {}
+        OPCode72(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x72, Maker) {}
+        OPCode72(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {}
+        OPCode72(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x73
+    class OPCode73 : public Instruction {
+      public:
+        OPCode73()
+          : Instruction(-1, 0x73, nullptr) {}
+        OPCode73(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x73, Maker) {}
+        OPCode73(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {}
+        OPCode73(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x03: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x06:
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+            }
+        }
+    };
+    // 0x74
+    class OPCode74 : public Instruction {
+      public:
+        OPCode74()
+          : Instruction(-1, 0x74, nullptr) {}
+        OPCode74(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x74, Maker) {}
+        OPCode74(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {}
+        OPCode74(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    // 0x77
+    class OPCode77 : public Instruction {
+      public:
+        OPCode77()
+          : Instruction(-1, 0x77, nullptr) {}
+        OPCode77(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x77, Maker) {}
+        OPCode77(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x77, Maker) {}
+        OPCode77(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x77, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x78
+    class OPCode78 : public Instruction {
+      public:
+        OPCode78()
+          : Instruction(-1, 0x78, nullptr) {}
+        OPCode78(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x78, Maker) {}
+        OPCode78(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {}
+        OPCode78(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x79
+    class OPCode79 : public Instruction {
+      public:
+        OPCode79()
+          : Instruction(-1, 0x79, nullptr) {}
+        OPCode79(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x79, Maker) {}
+        OPCode79(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {}
+        OPCode79(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x7A
+    class OPCode7A : public Instruction {
+      public:
+        OPCode7A()
+          : Instruction(-1, 0x7A, nullptr) {}
+        OPCode7A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7A, Maker) {}
+        OPCode7A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {}
+        OPCode7A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x7B
+    class OPCode7B : public Instruction {
+      public:
+        OPCode7B()
+          : Instruction(-1, 0x7B, nullptr) {}
+        OPCode7B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7B, Maker) {}
+        OPCode7B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {}
+        OPCode7B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x7D
+    class OPCode7D : public Instruction {
+      public:
+        OPCode7D()
+          : Instruction(-1, 0x7D, nullptr) {}
+        OPCode7D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7D, Maker) {}
+        OPCode7D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7D, Maker) {}
+        OPCode7D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7D, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x7E
+    class OPCode7E : public Instruction {
+      public:
+        OPCode7E()
+          : Instruction(-1, 0x7E, nullptr) {}
+        OPCode7E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7E, Maker) {}
+        OPCode7E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {}
+        OPCode7E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x7F
+    class OPCode7F : public Instruction {
+      public:
+        OPCode7F()
+          : Instruction(-1, 0x7F, nullptr) {}
+        OPCode7F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7F, Maker) {}
+        OPCode7F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7F, Maker) {}
+        OPCode7F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7F, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch (control_byte[0]) {
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            }
-        }
-    };
-    //0x87
-    class OPCode87: public Instruction{
-    public:
-        OPCode87():Instruction(-1,0x87,nullptr){}
-        OPCode87(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x87,Maker){}
-        OPCode87(int addr, Builder *Maker):Instruction(addr,"???",0x87,Maker){}
-        OPCode87(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x87,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x88
-    class OPCode88: public Instruction{
-    public:
-        OPCode88():Instruction(-1,0x88,nullptr){}
-        OPCode88(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x88,Maker){}
-        OPCode88(int addr, Builder *Maker):Instruction(addr,"???",0x88,Maker){}
-        OPCode88(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x88,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            unsigned char code = control_byte[0];
-            if (code == 0x00){
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            }
-        }
-    };
-
-    //0x89
-    class OPCode89: public Instruction{
-    public:
-        OPCode89():Instruction(-1,0x89,nullptr){}
-        OPCode89(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x89,Maker){}
-        OPCode89(int addr, Builder *Maker):Instruction(addr,"???",0x89,Maker){}
-        OPCode89(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x89,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            unsigned char code = control_byte[0];
-            if (code == 0x00){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            }
-        }
-    };
-    //0x8A
-    class OPCode8A: public Instruction{
-    public:
-        OPCode8A():Instruction(-1,0x8A,nullptr){}
-        OPCode8A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8A,Maker){}
-        OPCode8A(int addr, Builder *Maker):Instruction(addr,"???",0x8A,Maker){}
-        OPCode8A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8A,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            unsigned char code = control_byte[0];
-            if (code == 0x00){
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            }
-        }
-    };
-    //0x8B
-    class OPCode8B: public Instruction{
-    public:
-        OPCode8B():Instruction(-1,0x8B,nullptr){}
-        OPCode8B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8B,Maker){}
-        OPCode8B(int addr, Builder *Maker):Instruction(addr,"???",0x8B,Maker){}
-        OPCode8B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8B,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        }
-    };
-    //0x8C
-    class OPCode8C: public Instruction{
-    public:
-        OPCode8C():Instruction(-1,0x8C,nullptr){}
-        OPCode8C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8C,Maker){}
-        OPCode8C(int addr, Builder *Maker):Instruction(addr,"???",0x8C,Maker){}
-        OPCode8C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8C,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    //0x8D
-    class OPCode8D: public Instruction{
-    public:
-        OPCode8D():Instruction(-1,0x8D,nullptr){}
-        OPCode8D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8D,Maker){}
-        OPCode8D(int addr, Builder *Maker):Instruction(addr,"???",0x8D,Maker){}
-        OPCode8D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8D,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    //0x8E
-    class OPCode8E: public Instruction{
-    public:
-        OPCode8E():Instruction(-1,0x8E,nullptr){}
-        OPCode8E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8E,Maker){}
-        OPCode8E(int addr, Builder *Maker):Instruction(addr,"???",0x8E,Maker){}
-        OPCode8E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8E,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x90
-    class OPCode90: public Instruction{
-    public:
-        OPCode90():Instruction(-1,0x90,nullptr){}
-        OPCode90(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x90,Maker){}
-        OPCode90(int addr, Builder *Maker):Instruction(addr,"???",0x90,Maker){}
-        OPCode90(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x90,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 }
+                case -2: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            }
-        }
-    };
-    //0x91
-    class OPCode91: public Instruction{
-    public:
-        OPCode91():Instruction(-1,0x91,nullptr){}
-        OPCode91(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x91,Maker){}
-        OPCode91(int addr, Builder *Maker):Instruction(addr,"???",0x91,Maker){}
-        OPCode91(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x91,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
+                case -1: {
 
+                    break;
+                }
+                default: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                }
             }
         }
     };
-    //0x92
-    class OPCode92: public Instruction{
-    public:
-        OPCode92():Instruction(-1,0x92,nullptr){}
-        OPCode92(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x92,Maker){}
-        OPCode92(int addr, Builder *Maker):Instruction(addr,"???",0x92,Maker){}
-        OPCode92(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x92,Maker){
+    // 0x80
+    class OPCode80 : public Instruction {
+      public:
+        OPCode80()
+          : Instruction(-1, 0x80, nullptr) {}
+        OPCode80(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x80, Maker) {}
+        OPCode80(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {}
+        OPCode80(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
     };
-
-    //0x93
-    class OPCode93: public Instruction{
-    public:
-        OPCode93():Instruction(-1,0x93,nullptr){}
-        OPCode93(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x93,Maker){}
-        OPCode93(int addr, Builder *Maker):Instruction(addr,"???",0x93,Maker){}
-        OPCode93(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x93,Maker){
+    // 0x81
+    class OPCode81 : public Instruction {
+      public:
+        OPCode81()
+          : Instruction(-1, 0x81, nullptr) {}
+        OPCode81(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x81, Maker) {}
+        OPCode81(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x81, Maker) {}
+        OPCode81(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x81, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x00) this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x94
-    class OPCode94: public Instruction{
-    public:
-        OPCode94():Instruction(-1,0x94,nullptr){}
-        OPCode94(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x94,Maker){}
-        OPCode94(int addr, Builder *Maker):Instruction(addr,"???",0x94,Maker){}
-        OPCode94(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x94,Maker){
+    // 0x82
+    class OPCode82 : public Instruction {
+      public:
+        OPCode82()
+          : Instruction(-1, 0x82, nullptr) {}
+        OPCode82(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x82, Maker) {}
+        OPCode82(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {}
+        OPCode82(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x95
-    class OPCode95: public Instruction{
-    public:
-        OPCode95():Instruction(-1,0x95,nullptr){}
-        OPCode95(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x95,Maker){}
-        OPCode95(int addr, Builder *Maker):Instruction(addr,"???",0x95,Maker){}
-        OPCode95(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x95,Maker){
+    // 0x83
+    class OPCode83 : public Instruction {
+      public:
+        OPCode83()
+          : Instruction(-1, 0x83, nullptr) {}
+        OPCode83(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x83, Maker) {}
+        OPCode83(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {}
+        OPCode83(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {
             addr++;
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x96
-    class OPCode96: public Instruction{
-    public:
-        OPCode96():Instruction(-1,0x96,nullptr){}
-        OPCode96(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x96,Maker){}
-        OPCode96(int addr, Builder *Maker):Instruction(addr,"???",0x96,Maker){}
-        OPCode96(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x96,Maker){
+    // 0x84
+    class OPCode84 : public Instruction {
+      public:
+        OPCode84()
+          : Instruction(-1, 0x84, nullptr) {}
+        OPCode84(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x84, Maker) {}
+        OPCode84(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {}
+        OPCode84(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
         }
     };
-    //0x97
-    class OPCode97: public Instruction{
-    public:
-        OPCode97():Instruction(-1,0x97,nullptr){}
-        OPCode97(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x97,Maker){}
-        OPCode97(int addr, Builder *Maker):Instruction(addr,"???",0x97,Maker){}
-        OPCode97(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x97,Maker){
+    // 0x85
+    class OPCode85 : public Instruction {
+      public:
+        OPCode85()
+          : Instruction(-1, 0x85, nullptr) {}
+        OPCode85(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x85, Maker) {}
+        OPCode85(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x85, Maker) {}
+        OPCode85(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x85, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x98
-    class OPCode98: public Instruction{
-    public:
-        OPCode98():Instruction(-1,0x98,nullptr){}
-        OPCode98(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x98,Maker){}
-        OPCode98(int addr, Builder *Maker):Instruction(addr,"???",0x98,Maker){}
-        OPCode98(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x98,Maker){
+    // 0x86
+    class OPCode86 : public Instruction {
+      public:
+        OPCode86()
+          : Instruction(-1, 0x86, nullptr) {}
+        OPCode86(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x86, Maker) {}
+        OPCode86(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x86, Maker) {}
+        OPCode86(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x86, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x99
-    class OPCode99: public Instruction{
-    public:
-        OPCode99():Instruction(-1,0x99,nullptr){}
-        OPCode99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x99,Maker){}
-        OPCode99(int addr, Builder *Maker):Instruction(addr,"???",0x99,Maker){}
-        OPCode99(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
-            addr++;
-
-        }
-    };
-    //0x9A
-    class OPCode9A: public Instruction{
-        public:
-            OPCode9A():Instruction(-1,0x9A,nullptr){}
-            OPCode9A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9A,Maker){}
-            OPCode9A(int addr, Builder *Maker):Instruction(addr,"???",0x9A,Maker){}
-            OPCode9A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9A,Maker){
-                addr++;
-
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 0x01:
-                    case 0x02:{
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    }
-                    case 0x03:
-                    case 0x04:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    }
-
-
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
             }
-
         }
     };
-    //0x9B
-    class OPCode9B: public Instruction{
-        public:
-            OPCode9B():Instruction(-1,0x9B,nullptr){}
-            OPCode9B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9B,Maker){}
-            OPCode9B(int addr, Builder *Maker):Instruction(addr,"???",0x9B,Maker){}
-            OPCode9B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9B,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    //0x9D
-    class OPCode9D: public Instruction{
-        public:
-            OPCode9D():Instruction(-1,0x9D,nullptr){}
-            OPCode9D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9D,Maker){}
-            OPCode9D(int addr, Builder *Maker):Instruction(addr,"???",0x9D,Maker){}
-            OPCode9D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    //0x9E
-    class OPCode9E: public Instruction{
-        public:
-            OPCode9E():Instruction(-1,0x9E,nullptr){}
-            OPCode9E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9E,Maker){}
-            OPCode9E(int addr, Builder *Maker):Instruction(addr,"???",0x9E,Maker){}
-            OPCode9E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-        }
-    };
-    //0x9F
-    class OPCode9F: public Instruction{
-    public:
-        OPCode9F():Instruction(-1,0x9F,nullptr){}
-        OPCode9F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9F,Maker){}
-        OPCode9F(int addr, Builder *Maker):Instruction(addr,"???",0x9F,Maker){}
-        OPCode9F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9F,Maker){
+    // 0x87
+    class OPCode87 : public Instruction {
+      public:
+        OPCode87()
+          : Instruction(-1, 0x87, nullptr) {}
+        OPCode87(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x87, Maker) {}
+        OPCode87(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x87, Maker) {}
+        OPCode87(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x87, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0xFF
-    class OPCodeFF: public Instruction{
-    public:
-        OPCodeFF():Instruction(-1,0xFF,nullptr){}
-        OPCodeFF(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xFF,Maker){}
-        OPCodeFF(int addr, Builder *Maker):Instruction(addr,"???",0xFF,Maker){}
-        OPCodeFF(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xFF,Maker){
+    // 0x88
+    class OPCode88 : public Instruction {
+      public:
+        OPCode88()
+          : Instruction(-1, 0x88, nullptr) {}
+        OPCode88(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x88, Maker) {}
+        OPCode88(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x88, Maker) {}
+        OPCode88(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x88, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            }
         }
     };
 
-    std::shared_ptr<Instruction> CreateInstructionFromDAT(int &addr, QByteArray &dat_content, int function_type){
-        int OP = (dat_content[addr]&0xFF);
+    // 0x89
+    class OPCode89 : public Instruction {
+      public:
+        OPCode89()
+          : Instruction(-1, 0x89, nullptr) {}
+        OPCode89(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x89, Maker) {}
+        OPCode89(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x89, Maker) {}
+        OPCode89(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x89, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            }
+        }
+    };
+    // 0x8A
+    class OPCode8A : public Instruction {
+      public:
+        OPCode8A()
+          : Instruction(-1, 0x8A, nullptr) {}
+        OPCode8A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8A, Maker) {}
+        OPCode8A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8A, Maker) {}
+        OPCode8A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            }
+        }
+    };
+    // 0x8B
+    class OPCode8B : public Instruction {
+      public:
+        OPCode8B()
+          : Instruction(-1, 0x8B, nullptr) {}
+        OPCode8B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8B, Maker) {}
+        OPCode8B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8B, Maker) {}
+        OPCode8B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x8C
+    class OPCode8C : public Instruction {
+      public:
+        OPCode8C()
+          : Instruction(-1, 0x8C, nullptr) {}
+        OPCode8C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8C, Maker) {}
+        OPCode8C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8C, Maker) {}
+        OPCode8C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x8D
+    class OPCode8D : public Instruction {
+      public:
+        OPCode8D()
+          : Instruction(-1, 0x8D, nullptr) {}
+        OPCode8D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8D, Maker) {}
+        OPCode8D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8D, Maker) {}
+        OPCode8D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x8E
+    class OPCode8E : public Instruction {
+      public:
+        OPCode8E()
+          : Instruction(-1, 0x8E, nullptr) {}
+        OPCode8E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8E, Maker) {}
+        OPCode8E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8E, Maker) {}
+        OPCode8E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x90
+    class OPCode90 : public Instruction {
+      public:
+        OPCode90()
+          : Instruction(-1, 0x90, nullptr) {}
+        OPCode90(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x90, Maker) {}
+        OPCode90(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x90, Maker) {}
+        OPCode90(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x90, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+            }
+        }
+    };
+    // 0x91
+    class OPCode91 : public Instruction {
+      public:
+        OPCode91()
+          : Instruction(-1, 0x91, nullptr) {}
+        OPCode91(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x91, Maker) {}
+        OPCode91(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x91, Maker) {}
+        OPCode91(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x91, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+            }
+        }
+    };
+    // 0x92
+    class OPCode92 : public Instruction {
+      public:
+        OPCode92()
+          : Instruction(-1, 0x92, nullptr) {}
+        OPCode92(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x92, Maker) {}
+        OPCode92(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x92, Maker) {}
+        OPCode92(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x92, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+
+    // 0x93
+    class OPCode93 : public Instruction {
+      public:
+        OPCode93()
+          : Instruction(-1, 0x93, nullptr) {}
+        OPCode93(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x93, Maker) {}
+        OPCode93(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x93, Maker) {}
+        OPCode93(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x93, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    // 0x94
+    class OPCode94 : public Instruction {
+      public:
+        OPCode94()
+          : Instruction(-1, 0x94, nullptr) {}
+        OPCode94(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x94, Maker) {}
+        OPCode94(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x94, Maker) {}
+        OPCode94(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x94, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x95
+    class OPCode95 : public Instruction {
+      public:
+        OPCode95()
+          : Instruction(-1, 0x95, nullptr) {}
+        OPCode95(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x95, Maker) {}
+        OPCode95(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x95, Maker) {}
+        OPCode95(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x95, Maker) {
+            addr++;
+        }
+    };
+    // 0x96
+    class OPCode96 : public Instruction {
+      public:
+        OPCode96()
+          : Instruction(-1, 0x96, nullptr) {}
+        OPCode96(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x96, Maker) {}
+        OPCode96(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x96, Maker) {}
+        OPCode96(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x96, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x97
+    class OPCode97 : public Instruction {
+      public:
+        OPCode97()
+          : Instruction(-1, 0x97, nullptr) {}
+        OPCode97(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x97, Maker) {}
+        OPCode97(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x97, Maker) {}
+        OPCode97(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x97, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x98
+    class OPCode98 : public Instruction {
+      public:
+        OPCode98()
+          : Instruction(-1, 0x98, nullptr) {}
+        OPCode98(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x98, Maker) {}
+        OPCode98(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x98, Maker) {}
+        OPCode98(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x98, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x99
+    class OPCode99 : public Instruction {
+      public:
+        OPCode99()
+          : Instruction(-1, 0x99, nullptr) {}
+        OPCode99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x99, Maker) {}
+        OPCode99(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x99, Maker) {}
+        OPCode99(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x99, Maker) {
+            addr++;
+        }
+    };
+    // 0x9A
+    class OPCode9A : public Instruction {
+      public:
+        OPCode9A()
+          : Instruction(-1, 0x9A, nullptr) {}
+        OPCode9A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9A, Maker) {}
+        OPCode9A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9A, Maker) {}
+        OPCode9A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9A, Maker) {
+            addr++;
+
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01:
+                case 0x02: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x03:
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+            }
+        }
+    };
+    // 0x9B
+    class OPCode9B : public Instruction {
+      public:
+        OPCode9B()
+          : Instruction(-1, 0x9B, nullptr) {}
+        OPCode9B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9B, Maker) {}
+        OPCode9B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9B, Maker) {}
+        OPCode9B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x9D
+    class OPCode9D : public Instruction {
+      public:
+        OPCode9D()
+          : Instruction(-1, 0x9D, nullptr) {}
+        OPCode9D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9D, Maker) {}
+        OPCode9D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9D, Maker) {}
+        OPCode9D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x9E
+    class OPCode9E : public Instruction {
+      public:
+        OPCode9E()
+          : Instruction(-1, 0x9E, nullptr) {}
+        OPCode9E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9E, Maker) {}
+        OPCode9E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9E, Maker) {}
+        OPCode9E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0x9F
+    class OPCode9F : public Instruction {
+      public:
+        OPCode9F()
+          : Instruction(-1, 0x9F, nullptr) {}
+        OPCode9F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9F, Maker) {}
+        OPCode9F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9F, Maker) {}
+        OPCode9F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0xFF
+    class OPCodeFF : public Instruction {
+      public:
+        OPCodeFF()
+          : Instruction(-1, 0xFF, nullptr) {}
+        OPCodeFF(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xFF, Maker) {}
+        OPCodeFF(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xFF, Maker) {}
+        OPCodeFF(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xFF, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+
+    std::shared_ptr<Instruction> CreateInstructionFromDAT(int& addr, QByteArray& dat_content, int function_type) {
+        int OP = (dat_content[addr] & 0xFF);
 
         int i = CS1UIFiles.indexOf(SceneName);
-        if ((i != -1)&&(OP == 0x13)) return std::make_shared<UI_OP13>(addr,dat_content,this); //UI files have a special 0x13 instruction
+        if ((i != -1) && (OP == 0x13))
+            return std::make_shared<UI_OP13>(addr, dat_content, this); // UI files have a special 0x13 instruction
 
-        if (function_type == 0){ //the function is read with OPCodes
+        if (function_type == 0) { // the function is read with OPCodes
 
-            switch(OP){
-                case 0x00: return std::make_shared<OPCode0>(addr,dat_content,this);
-                case 0x01: return std::make_shared<OPCode1>(addr,dat_content,this);
-                case 0x02: return std::make_shared<OPCode02>(addr,dat_content,this);
-                case 0x03: return std::make_shared<OPCode03>(addr,dat_content,this);
-                case 0x04: return std::make_shared<OPCode04>(addr,dat_content,this);
-                case 0x05: return std::make_shared<OPCode05>(addr,dat_content,this);
-                case 0x06: return std::make_shared<OPCode06>(addr,dat_content,this);
-                case 0x07: return std::make_shared<OPCode07>(addr,dat_content,this);
-                case 0x08: return std::make_shared<OPCode08>(addr,dat_content,this);
-                case 0x0A: return std::make_shared<OPCode0A>(addr,dat_content,this);
-                case 0x0C: return std::make_shared<OPCode0C>(addr,dat_content,this);
-                case 0x0D: return std::make_shared<OPCode0D>(addr,dat_content,this);
-                case 0x0E: return std::make_shared<OPCode0E>(addr,dat_content,this);
-                case 0x0F: return std::make_shared<OPCode0F>(addr,dat_content,this);
-                case 0x10: return std::make_shared<OPCode10>(addr,dat_content,this);
-                case 0x11: return std::make_shared<OPCode11>(addr,dat_content,this);
-                case 0x12: return std::make_shared<OPCode12>(addr,dat_content,this);
-                case 0x13: return std::make_shared<OPCode13>(addr,dat_content,this);
-                case 0x14: return std::make_shared<OPCode14>(addr,dat_content,this);
-                case 0x15: return std::make_shared<OPCode15>(addr,dat_content,this);
-                case 0x16: return std::make_shared<OPCode16>(addr,dat_content,this);
-                case 0x17: return std::make_shared<OPCode17>(addr,dat_content,this);
-                case 0x18: return std::make_shared<OPCode18>(addr,dat_content,this);
-                case 0x19: return std::make_shared<OPCode19>(addr,dat_content,this);
-                case 0x1A: return std::make_shared<OPCode1A>(addr,dat_content,this);
-                case 0x1B: return std::make_shared<OPCode1B>(addr,dat_content,this);
-                case 0x1C: return std::make_shared<OPCode1C>(addr,dat_content,this);
-                case 0x1D: return std::make_shared<OPCode1D>(addr,dat_content,this);
-                case 0x1E: return std::make_shared<OPCode1E>(addr,dat_content,this);
-                case 0x1F: return std::make_shared<OPCode1F>(addr,dat_content,this);
-                case 0x20: return std::make_shared<OPCode20>(addr,dat_content,this);
-                case 0x21: return std::make_shared<OPCode21>(addr,dat_content,this);
-                case 0x22: return std::make_shared<OPCode22>(addr,dat_content,this);
-                case 0x23: return std::make_shared<OPCode23>(addr,dat_content,this);
-                case 0x24: return std::make_shared<OPCode24>(addr,dat_content,this);
-                case 0x25: return std::make_shared<OPCode25>(addr,dat_content,this);
-                case 0x26: return std::make_shared<OPCode26>(addr,dat_content,this);
-                case 0x27: return std::make_shared<OPCode27>(addr,dat_content,this);
-                case 0x28: return std::make_shared<OPCode28>(addr,dat_content,this);
-                case 0x29: return std::make_shared<OPCode29>(addr,dat_content,this);
-                case 0x2A: return std::make_shared<OPCode2A>(addr,dat_content,this);
-                case 0x2B: return std::make_shared<OPCode2B>(addr,dat_content,this);
-                case 0x2C: return std::make_shared<OPCode2C>(addr,dat_content,this);
-                case 0x2D: return std::make_shared<OPCode2D>(addr,dat_content,this);
-                case 0x2E: return std::make_shared<OPCode2E>(addr,dat_content,this);
-                case 0x2F: return std::make_shared<OPCode2F>(addr,dat_content,this);
-                case 0x30: return std::make_shared<OPCode30>(addr,dat_content,this);
-                case 0x31: return std::make_shared<OPCode31>(addr,dat_content,this);
-                case 0x32: return std::make_shared<OPCode32>(addr,dat_content,this);
-                case 0x33: return std::make_shared<OPCode33>(addr,dat_content,this);
-                case 0x34: return std::make_shared<OPCode34>(addr,dat_content,this);
-                case 0x35: return std::make_shared<OPCode35>(addr,dat_content,this);
-                case 0x36: return std::make_shared<OPCode36>(addr,dat_content,this);
-                case 0x37: return std::make_shared<OPCode37>(addr,dat_content,this);
-                case 0x38: return std::make_shared<OPCode38>(addr,dat_content,this);
-                case 0x39: return std::make_shared<OPCode39>(addr,dat_content,this);
-                case 0x3A: return std::make_shared<OPCode3A>(addr,dat_content,this);
-                case 0x3B: return std::make_shared<OPCode3B>(addr,dat_content,this);
-                case 0x3C: return std::make_shared<OPCode3C>(addr,dat_content,this);
-                case 0x3D: return std::make_shared<OPCode3D>(addr,dat_content,this);
-                case 0x3E: return std::make_shared<OPCode3E>(addr,dat_content,this);
-                case 0x3F: return std::make_shared<OPCode3F>(addr,dat_content,this);
-                case 0x40: return std::make_shared<OPCode40>(addr,dat_content,this);
-                case 0x41: return std::make_shared<OPCode41>(addr,dat_content,this);
-                case 0x42: return std::make_shared<OPCode42>(addr,dat_content,this);
-                case 0x43: return std::make_shared<OPCode43>(addr,dat_content,this);
-                case 0x44: return std::make_shared<OPCode44>(addr,dat_content,this);
-                case 0x45: return std::make_shared<OPCode45>(addr,dat_content,this);
-                case 0x46: return std::make_shared<OPCode46>(addr,dat_content,this);
-                case 0x47: return std::make_shared<OPCode47>(addr,dat_content,this);
-                case 0x48: return std::make_shared<OPCode48>(addr,dat_content,this);
-                case 0x49: return std::make_shared<OPCode49>(addr,dat_content,this);
-                case 0x4A: return std::make_shared<OPCode4A>(addr,dat_content,this);
-                case 0x4B: return std::make_shared<OPCode4B>(addr,dat_content,this);
-                case 0x4C: return std::make_shared<OPCode4C>(addr,dat_content,this);
-                case 0x4D: return std::make_shared<OPCode4D>(addr,dat_content,this);
-                //case 0x4E: return std::make_shared<OPCode4E>(addr,dat_content,this);
-                case 0x4F: return std::make_shared<OPCode4F>(addr,dat_content,this);
-                //case 0x50: return std::make_shared<OPCode50>(addr,dat_content,this);
-                case 0x51: return std::make_shared<OPCode51>(addr,dat_content,this);
-                case 0x52: return std::make_shared<OPCode52>(addr,dat_content,this);
-                case 0x53: return std::make_shared<OPCode53>(addr,dat_content,this);
+            switch (OP) {
+                case 0x00:
+                    return std::make_shared<OPCode0>(addr, dat_content, this);
+                case 0x01:
+                    return std::make_shared<OPCode1>(addr, dat_content, this);
+                case 0x02:
+                    return std::make_shared<OPCode02>(addr, dat_content, this);
+                case 0x03:
+                    return std::make_shared<OPCode03>(addr, dat_content, this);
+                case 0x04:
+                    return std::make_shared<OPCode04>(addr, dat_content, this);
+                case 0x05:
+                    return std::make_shared<OPCode05>(addr, dat_content, this);
+                case 0x06:
+                    return std::make_shared<OPCode06>(addr, dat_content, this);
+                case 0x07:
+                    return std::make_shared<OPCode07>(addr, dat_content, this);
+                case 0x08:
+                    return std::make_shared<OPCode08>(addr, dat_content, this);
+                case 0x0A:
+                    return std::make_shared<OPCode0A>(addr, dat_content, this);
+                case 0x0C:
+                    return std::make_shared<OPCode0C>(addr, dat_content, this);
+                case 0x0D:
+                    return std::make_shared<OPCode0D>(addr, dat_content, this);
+                case 0x0E:
+                    return std::make_shared<OPCode0E>(addr, dat_content, this);
+                case 0x0F:
+                    return std::make_shared<OPCode0F>(addr, dat_content, this);
+                case 0x10:
+                    return std::make_shared<OPCode10>(addr, dat_content, this);
+                case 0x11:
+                    return std::make_shared<OPCode11>(addr, dat_content, this);
+                case 0x12:
+                    return std::make_shared<OPCode12>(addr, dat_content, this);
+                case 0x13:
+                    return std::make_shared<OPCode13>(addr, dat_content, this);
+                case 0x14:
+                    return std::make_shared<OPCode14>(addr, dat_content, this);
+                case 0x15:
+                    return std::make_shared<OPCode15>(addr, dat_content, this);
+                case 0x16:
+                    return std::make_shared<OPCode16>(addr, dat_content, this);
+                case 0x17:
+                    return std::make_shared<OPCode17>(addr, dat_content, this);
+                case 0x18:
+                    return std::make_shared<OPCode18>(addr, dat_content, this);
+                case 0x19:
+                    return std::make_shared<OPCode19>(addr, dat_content, this);
+                case 0x1A:
+                    return std::make_shared<OPCode1A>(addr, dat_content, this);
+                case 0x1B:
+                    return std::make_shared<OPCode1B>(addr, dat_content, this);
+                case 0x1C:
+                    return std::make_shared<OPCode1C>(addr, dat_content, this);
+                case 0x1D:
+                    return std::make_shared<OPCode1D>(addr, dat_content, this);
+                case 0x1E:
+                    return std::make_shared<OPCode1E>(addr, dat_content, this);
+                case 0x1F:
+                    return std::make_shared<OPCode1F>(addr, dat_content, this);
+                case 0x20:
+                    return std::make_shared<OPCode20>(addr, dat_content, this);
+                case 0x21:
+                    return std::make_shared<OPCode21>(addr, dat_content, this);
+                case 0x22:
+                    return std::make_shared<OPCode22>(addr, dat_content, this);
+                case 0x23:
+                    return std::make_shared<OPCode23>(addr, dat_content, this);
+                case 0x24:
+                    return std::make_shared<OPCode24>(addr, dat_content, this);
+                case 0x25:
+                    return std::make_shared<OPCode25>(addr, dat_content, this);
+                case 0x26:
+                    return std::make_shared<OPCode26>(addr, dat_content, this);
+                case 0x27:
+                    return std::make_shared<OPCode27>(addr, dat_content, this);
+                case 0x28:
+                    return std::make_shared<OPCode28>(addr, dat_content, this);
+                case 0x29:
+                    return std::make_shared<OPCode29>(addr, dat_content, this);
+                case 0x2A:
+                    return std::make_shared<OPCode2A>(addr, dat_content, this);
+                case 0x2B:
+                    return std::make_shared<OPCode2B>(addr, dat_content, this);
+                case 0x2C:
+                    return std::make_shared<OPCode2C>(addr, dat_content, this);
+                case 0x2D:
+                    return std::make_shared<OPCode2D>(addr, dat_content, this);
+                case 0x2E:
+                    return std::make_shared<OPCode2E>(addr, dat_content, this);
+                case 0x2F:
+                    return std::make_shared<OPCode2F>(addr, dat_content, this);
+                case 0x30:
+                    return std::make_shared<OPCode30>(addr, dat_content, this);
+                case 0x31:
+                    return std::make_shared<OPCode31>(addr, dat_content, this);
+                case 0x32:
+                    return std::make_shared<OPCode32>(addr, dat_content, this);
+                case 0x33:
+                    return std::make_shared<OPCode33>(addr, dat_content, this);
+                case 0x34:
+                    return std::make_shared<OPCode34>(addr, dat_content, this);
+                case 0x35:
+                    return std::make_shared<OPCode35>(addr, dat_content, this);
+                case 0x36:
+                    return std::make_shared<OPCode36>(addr, dat_content, this);
+                case 0x37:
+                    return std::make_shared<OPCode37>(addr, dat_content, this);
+                case 0x38:
+                    return std::make_shared<OPCode38>(addr, dat_content, this);
+                case 0x39:
+                    return std::make_shared<OPCode39>(addr, dat_content, this);
+                case 0x3A:
+                    return std::make_shared<OPCode3A>(addr, dat_content, this);
+                case 0x3B:
+                    return std::make_shared<OPCode3B>(addr, dat_content, this);
+                case 0x3C:
+                    return std::make_shared<OPCode3C>(addr, dat_content, this);
+                case 0x3D:
+                    return std::make_shared<OPCode3D>(addr, dat_content, this);
+                case 0x3E:
+                    return std::make_shared<OPCode3E>(addr, dat_content, this);
+                case 0x3F:
+                    return std::make_shared<OPCode3F>(addr, dat_content, this);
+                case 0x40:
+                    return std::make_shared<OPCode40>(addr, dat_content, this);
+                case 0x41:
+                    return std::make_shared<OPCode41>(addr, dat_content, this);
+                case 0x42:
+                    return std::make_shared<OPCode42>(addr, dat_content, this);
+                case 0x43:
+                    return std::make_shared<OPCode43>(addr, dat_content, this);
+                case 0x44:
+                    return std::make_shared<OPCode44>(addr, dat_content, this);
+                case 0x45:
+                    return std::make_shared<OPCode45>(addr, dat_content, this);
+                case 0x46:
+                    return std::make_shared<OPCode46>(addr, dat_content, this);
+                case 0x47:
+                    return std::make_shared<OPCode47>(addr, dat_content, this);
+                case 0x48:
+                    return std::make_shared<OPCode48>(addr, dat_content, this);
+                case 0x49:
+                    return std::make_shared<OPCode49>(addr, dat_content, this);
+                case 0x4A:
+                    return std::make_shared<OPCode4A>(addr, dat_content, this);
+                case 0x4B:
+                    return std::make_shared<OPCode4B>(addr, dat_content, this);
+                case 0x4C:
+                    return std::make_shared<OPCode4C>(addr, dat_content, this);
+                case 0x4D:
+                    return std::make_shared<OPCode4D>(addr, dat_content, this);
+                // case 0x4E: return std::make_shared<OPCode4E>(addr,dat_content,this);
+                case 0x4F:
+                    return std::make_shared<OPCode4F>(addr, dat_content, this);
+                // case 0x50: return std::make_shared<OPCode50>(addr,dat_content,this);
+                case 0x51:
+                    return std::make_shared<OPCode51>(addr, dat_content, this);
+                case 0x52:
+                    return std::make_shared<OPCode52>(addr, dat_content, this);
+                case 0x53:
+                    return std::make_shared<OPCode53>(addr, dat_content, this);
 
-                case 0x55: return std::make_shared<OPCode55>(addr,dat_content,this);
-                case 0x56: return std::make_shared<OPCode56>(addr,dat_content,this);
-                case 0x57: return std::make_shared<OPCode57>(addr,dat_content,this);
-                case 0x58: return std::make_shared<OPCode58>(addr,dat_content,this);
-                case 0x59: return std::make_shared<OPCode59>(addr,dat_content,this);
-                case 0x5A: return std::make_shared<OPCode5A>(addr,dat_content,this);
-                case 0x5B: return std::make_shared<OPCode5B>(addr,dat_content,this);
-                case 0x5C: return std::make_shared<OPCode5C>(addr,dat_content,this);
-                case 0x5D: return std::make_shared<OPCode5D>(addr,dat_content,this);
-                case 0x5E: return std::make_shared<OPCode5E>(addr,dat_content,this);
-                case 0x5F: return std::make_shared<OPCode5F>(addr,dat_content,this);
-                case 0x60: return std::make_shared<OPCode60>(addr,dat_content,this);
-                case 0x61: return std::make_shared<OPCode61>(addr,dat_content,this);
-                case 0x62: return std::make_shared<OPCode62>(addr,dat_content,this);
-                case 0x63: return std::make_shared<OPCode63>(addr,dat_content,this);
-                case 0x64: return std::make_shared<OPCode64>(addr,dat_content,this);
-                case 0x65: return std::make_shared<OPCode65>(addr,dat_content,this);
-                case 0x66: return std::make_shared<OPCode66>(addr,dat_content,this);
-                case 0x67: return std::make_shared<OPCode67>(addr,dat_content,this);
-                case 0x68: return std::make_shared<OPCode68>(addr,dat_content,this);
-                case 0x69: return std::make_shared<OPCode69>(addr,dat_content,this);
-                case 0x6A: return std::make_shared<OPCode6A>(addr,dat_content,this);
-                case 0x6B: return std::make_shared<OPCode6B>(addr,dat_content,this);
-                case 0x6C: return std::make_shared<OPCode6C>(addr,dat_content,this);
-                case 0x6D: return std::make_shared<OPCode6D>(addr,dat_content,this);
-                case 0x6E: return std::make_shared<OPCode6E>(addr,dat_content,this);
-                case 0x6F: return std::make_shared<OPCode6F>(addr,dat_content,this);
-                case 0x70: return std::make_shared<OPCode70>(addr,dat_content,this);
-                case 0x71: return std::make_shared<OPCode71>(addr,dat_content,this);
-                case 0x72: return std::make_shared<OPCode72>(addr,dat_content,this);
-                case 0x73: return std::make_shared<OPCode73>(addr,dat_content,this);
-                case 0x74: return std::make_shared<OPCode74>(addr,dat_content,this);
+                case 0x55:
+                    return std::make_shared<OPCode55>(addr, dat_content, this);
+                case 0x56:
+                    return std::make_shared<OPCode56>(addr, dat_content, this);
+                case 0x57:
+                    return std::make_shared<OPCode57>(addr, dat_content, this);
+                case 0x58:
+                    return std::make_shared<OPCode58>(addr, dat_content, this);
+                case 0x59:
+                    return std::make_shared<OPCode59>(addr, dat_content, this);
+                case 0x5A:
+                    return std::make_shared<OPCode5A>(addr, dat_content, this);
+                case 0x5B:
+                    return std::make_shared<OPCode5B>(addr, dat_content, this);
+                case 0x5C:
+                    return std::make_shared<OPCode5C>(addr, dat_content, this);
+                case 0x5D:
+                    return std::make_shared<OPCode5D>(addr, dat_content, this);
+                case 0x5E:
+                    return std::make_shared<OPCode5E>(addr, dat_content, this);
+                case 0x5F:
+                    return std::make_shared<OPCode5F>(addr, dat_content, this);
+                case 0x60:
+                    return std::make_shared<OPCode60>(addr, dat_content, this);
+                case 0x61:
+                    return std::make_shared<OPCode61>(addr, dat_content, this);
+                case 0x62:
+                    return std::make_shared<OPCode62>(addr, dat_content, this);
+                case 0x63:
+                    return std::make_shared<OPCode63>(addr, dat_content, this);
+                case 0x64:
+                    return std::make_shared<OPCode64>(addr, dat_content, this);
+                case 0x65:
+                    return std::make_shared<OPCode65>(addr, dat_content, this);
+                case 0x66:
+                    return std::make_shared<OPCode66>(addr, dat_content, this);
+                case 0x67:
+                    return std::make_shared<OPCode67>(addr, dat_content, this);
+                case 0x68:
+                    return std::make_shared<OPCode68>(addr, dat_content, this);
+                case 0x69:
+                    return std::make_shared<OPCode69>(addr, dat_content, this);
+                case 0x6A:
+                    return std::make_shared<OPCode6A>(addr, dat_content, this);
+                case 0x6B:
+                    return std::make_shared<OPCode6B>(addr, dat_content, this);
+                case 0x6C:
+                    return std::make_shared<OPCode6C>(addr, dat_content, this);
+                case 0x6D:
+                    return std::make_shared<OPCode6D>(addr, dat_content, this);
+                case 0x6E:
+                    return std::make_shared<OPCode6E>(addr, dat_content, this);
+                case 0x6F:
+                    return std::make_shared<OPCode6F>(addr, dat_content, this);
+                case 0x70:
+                    return std::make_shared<OPCode70>(addr, dat_content, this);
+                case 0x71:
+                    return std::make_shared<OPCode71>(addr, dat_content, this);
+                case 0x72:
+                    return std::make_shared<OPCode72>(addr, dat_content, this);
+                case 0x73:
+                    return std::make_shared<OPCode73>(addr, dat_content, this);
+                case 0x74:
+                    return std::make_shared<OPCode74>(addr, dat_content, this);
 
-                case 0x77: return std::make_shared<OPCode77>(addr,dat_content,this);
-                case 0x78: return std::make_shared<OPCode78>(addr,dat_content,this);
-                case 0x79: return std::make_shared<OPCode79>(addr,dat_content,this);
-                case 0x7A: return std::make_shared<OPCode7A>(addr,dat_content,this);
-                case 0x7B: return std::make_shared<OPCode7B>(addr,dat_content,this);
+                case 0x77:
+                    return std::make_shared<OPCode77>(addr, dat_content, this);
+                case 0x78:
+                    return std::make_shared<OPCode78>(addr, dat_content, this);
+                case 0x79:
+                    return std::make_shared<OPCode79>(addr, dat_content, this);
+                case 0x7A:
+                    return std::make_shared<OPCode7A>(addr, dat_content, this);
+                case 0x7B:
+                    return std::make_shared<OPCode7B>(addr, dat_content, this);
 
-                case 0x7D: return std::make_shared<OPCode7D>(addr,dat_content,this);
-                case 0x7E: return std::make_shared<OPCode7E>(addr,dat_content,this);
-                case 0x7F: return std::make_shared<OPCode7F>(addr,dat_content,this);
-                case 0x80: return std::make_shared<OPCode80>(addr,dat_content,this);
-                case 0x81: return std::make_shared<OPCode81>(addr,dat_content,this);
-                case 0x82: return std::make_shared<OPCode82>(addr,dat_content,this);
-                case 0x83: return std::make_shared<OPCode83>(addr,dat_content,this);
-                case 0x84: return std::make_shared<OPCode84>(addr,dat_content,this);
-                case 0x85: return std::make_shared<OPCode85>(addr,dat_content,this);
-                case 0x86: return std::make_shared<OPCode86>(addr,dat_content,this);
-                case 0x87: return std::make_shared<OPCode87>(addr,dat_content,this);
-                case 0x88: return std::make_shared<OPCode88>(addr,dat_content,this);
-                case 0x89: return std::make_shared<OPCode89>(addr,dat_content,this);
-                case 0x8A: return std::make_shared<OPCode8A>(addr,dat_content,this);
-                case 0x8B: return std::make_shared<OPCode8B>(addr,dat_content,this);
-                case 0x8C: return std::make_shared<OPCode8C>(addr,dat_content,this);
-                case 0x8D: return std::make_shared<OPCode8D>(addr,dat_content,this);
-                case 0x8E: return std::make_shared<OPCode8E>(addr,dat_content,this);
+                case 0x7D:
+                    return std::make_shared<OPCode7D>(addr, dat_content, this);
+                case 0x7E:
+                    return std::make_shared<OPCode7E>(addr, dat_content, this);
+                case 0x7F:
+                    return std::make_shared<OPCode7F>(addr, dat_content, this);
+                case 0x80:
+                    return std::make_shared<OPCode80>(addr, dat_content, this);
+                case 0x81:
+                    return std::make_shared<OPCode81>(addr, dat_content, this);
+                case 0x82:
+                    return std::make_shared<OPCode82>(addr, dat_content, this);
+                case 0x83:
+                    return std::make_shared<OPCode83>(addr, dat_content, this);
+                case 0x84:
+                    return std::make_shared<OPCode84>(addr, dat_content, this);
+                case 0x85:
+                    return std::make_shared<OPCode85>(addr, dat_content, this);
+                case 0x86:
+                    return std::make_shared<OPCode86>(addr, dat_content, this);
+                case 0x87:
+                    return std::make_shared<OPCode87>(addr, dat_content, this);
+                case 0x88:
+                    return std::make_shared<OPCode88>(addr, dat_content, this);
+                case 0x89:
+                    return std::make_shared<OPCode89>(addr, dat_content, this);
+                case 0x8A:
+                    return std::make_shared<OPCode8A>(addr, dat_content, this);
+                case 0x8B:
+                    return std::make_shared<OPCode8B>(addr, dat_content, this);
+                case 0x8C:
+                    return std::make_shared<OPCode8C>(addr, dat_content, this);
+                case 0x8D:
+                    return std::make_shared<OPCode8D>(addr, dat_content, this);
+                case 0x8E:
+                    return std::make_shared<OPCode8E>(addr, dat_content, this);
 
-                case 0x90: return std::make_shared<OPCode90>(addr,dat_content,this);
-                case 0x91: return std::make_shared<OPCode91>(addr,dat_content,this);
-                case 0x92: return std::make_shared<OPCode92>(addr,dat_content,this);
-                case 0x93: return std::make_shared<OPCode93>(addr,dat_content,this);
-                case 0x94: return std::make_shared<OPCode94>(addr,dat_content,this);
-                case 0x95: return std::make_shared<OPCode95>(addr,dat_content,this);
-                case 0x96: return std::make_shared<OPCode96>(addr,dat_content,this);
-                case 0x97: return std::make_shared<OPCode97>(addr,dat_content,this);
-                case 0x98: return std::make_shared<OPCode98>(addr,dat_content,this);
-                case 0x99: return std::make_shared<OPCode99>(addr,dat_content,this);
-                case 0x9A: return std::make_shared<OPCode9A>(addr,dat_content,this);
-                case 0x9B: return std::make_shared<OPCode9B>(addr,dat_content,this);
-                case 0x9D: return std::make_shared<OPCode9D>(addr,dat_content,this);
-                case 0x9E: return std::make_shared<OPCode9E>(addr,dat_content,this);
-                case 0x9F: return std::make_shared<OPCode9F>(addr,dat_content,this);
+                case 0x90:
+                    return std::make_shared<OPCode90>(addr, dat_content, this);
+                case 0x91:
+                    return std::make_shared<OPCode91>(addr, dat_content, this);
+                case 0x92:
+                    return std::make_shared<OPCode92>(addr, dat_content, this);
+                case 0x93:
+                    return std::make_shared<OPCode93>(addr, dat_content, this);
+                case 0x94:
+                    return std::make_shared<OPCode94>(addr, dat_content, this);
+                case 0x95:
+                    return std::make_shared<OPCode95>(addr, dat_content, this);
+                case 0x96:
+                    return std::make_shared<OPCode96>(addr, dat_content, this);
+                case 0x97:
+                    return std::make_shared<OPCode97>(addr, dat_content, this);
+                case 0x98:
+                    return std::make_shared<OPCode98>(addr, dat_content, this);
+                case 0x99:
+                    return std::make_shared<OPCode99>(addr, dat_content, this);
+                case 0x9A:
+                    return std::make_shared<OPCode9A>(addr, dat_content, this);
+                case 0x9B:
+                    return std::make_shared<OPCode9B>(addr, dat_content, this);
+                case 0x9D:
+                    return std::make_shared<OPCode9D>(addr, dat_content, this);
+                case 0x9E:
+                    return std::make_shared<OPCode9E>(addr, dat_content, this);
+                case 0x9F:
+                    return std::make_shared<OPCode9F>(addr, dat_content, this);
                 default:
-                std::stringstream stream;
-                stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
+                    std::stringstream stream;
+                    stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
 
-                error = true;
-                /*std::string result( stream.str() );
-                qFatal(result.c_str());*/
+                    error = true;
+                    /*std::string result( stream.str() );
+                    qFatal(result.c_str());*/
 
-                return std::shared_ptr<Instruction>();
+                    return std::shared_ptr<Instruction>();
             }
-        }
-        else if (function_type==1){//the function is a "CreateMonsters" function
+        } else if (function_type == 1) { // the function is a "CreateMonsters" function
 
-            return std::make_shared<CreateMonsters>(addr,dat_content,this);
-        }
-        else if (function_type==2){//the function is a "effect" function
+            return std::make_shared<CreateMonsters>(addr, dat_content, this);
+        } else if (function_type == 2) { // the function is a "effect" function
 
-            return std::make_shared<EffectsInstr>(addr,dat_content,this);
-        }
-        else if (function_type==3){
+            return std::make_shared<EffectsInstr>(addr, dat_content, this);
+        } else if (function_type == 3) {
 
-            return std::make_shared<ActionTable>(addr,dat_content,this);
-        }
-        else if (function_type==4){
+            return std::make_shared<ActionTable>(addr, dat_content, this);
+        } else if (function_type == 4) {
 
-            return std::make_shared<AlgoTable>(addr,dat_content,this);
-        }
-        else if (function_type==5){
+            return std::make_shared<AlgoTable>(addr, dat_content, this);
+        } else if (function_type == 5) {
 
-            return std::make_shared<WeaponAttTable>(addr,dat_content,this);
-        }
-        else if (function_type==6){
+            return std::make_shared<WeaponAttTable>(addr, dat_content, this);
+        } else if (function_type == 6) {
 
-            return std::make_shared<BreakTable>(addr,dat_content,this);
-        }
-        else if (function_type==7){
+            return std::make_shared<BreakTable>(addr, dat_content, this);
+        } else if (function_type == 7) {
 
-            return std::make_shared<SummonTable>(addr,dat_content,this);
-        }
-        else if (function_type==8){
+            return std::make_shared<SummonTable>(addr, dat_content, this);
+        } else if (function_type == 8) {
 
-            return std::make_shared<ReactionTable>(addr,dat_content,this);
-        }
-        else if (function_type==9){
+            return std::make_shared<ReactionTable>(addr, dat_content, this);
+        } else if (function_type == 9) {
 
-            return std::make_shared<PartTable>(addr,dat_content,this);
-        }
-        else if (function_type==10){
+            return std::make_shared<PartTable>(addr, dat_content, this);
+        } else if (function_type == 10) {
 
-            return std::make_shared<AnimeClipTable>(addr,dat_content,this);
-        }
-        else if (function_type==11){
+            return std::make_shared<AnimeClipTable>(addr, dat_content, this);
+        } else if (function_type == 11) {
 
-            return std::make_shared<FieldMonsterData>(addr,dat_content,this);
-        }
-        else if (function_type==12){
+            return std::make_shared<FieldMonsterData>(addr, dat_content, this);
+        } else if (function_type == 12) {
 
-            return std::make_shared<FieldFollowData>(addr,dat_content,this);
-        }
-        else if (function_type==13){
+            return std::make_shared<FieldFollowData>(addr, dat_content, this);
+        } else if (function_type == 13) {
 
-            return std::make_shared<FC_autoX>(addr,dat_content,this);
-        }
-        else if (function_type==14){
+            return std::make_shared<FC_autoX>(addr, dat_content, this);
+        } else if (function_type == 14) {
 
-            return std::make_shared<BookData99>(addr,dat_content,this);
-        }
-        else if (function_type==15){
+            return std::make_shared<BookData99>(addr, dat_content, this);
+        } else if (function_type == 15) {
 
-            return std::make_shared<BookDataX>(addr,dat_content,this);
-        }
-        else if (function_type==16){
+            return std::make_shared<BookDataX>(addr, dat_content, this);
+        } else if (function_type == 16) {
 
-            return std::make_shared<AddCollision>(addr,dat_content,this);
+            return std::make_shared<AddCollision>(addr, dat_content, this);
         }
 
         return std::shared_ptr<Instruction>();
     }
-    bool CreateHeaderFromDAT(QByteArray &dat_content){
+    bool CreateHeaderFromDAT(QByteArray& dat_content) {
 
-        //Header structure:
-        //The first 0x20 is something used to check if the file is a valid file: it will always be that value
-        //The second 0x20 is the offset for the file name (shouldn't change too)
-        //The next integer is the position of the first pointer
-        //The 4th: probably the length in bytes of the pointer section
-        //The fifth: probably the position of the "names positions" section (right after the pointer section)
-        //The sixth: the number of functions inside the file
-        //the seventh: the position one byte after the 0x00 separator at the end of the functions section
-        //the eighth: 0xABCDEF00 => seems to always be there (no idea why)
-        //Then the name of the file
-        //Then the pointer section
-        //Then the "names positions" section
-        //Then the functions section
-        //Done; here the "function" objects holds the number of functions, the addr, name positions
-        //everything else can be deduced to recreate the header
+        // Header structure:
+        // The first 0x20 is something used to check if the file is a valid file: it will always be that value
+        // The second 0x20 is the offset for the file name (shouldn't change too)
+        // The next integer is the position of the first pointer
+        // The 4th: probably the length in bytes of the pointer section
+        // The fifth: probably the position of the "names positions" section (right after the pointer section)
+        // The sixth: the number of functions inside the file
+        // the seventh: the position one byte after the 0x00 separator at the end of the functions section
+        // the eighth: 0xABCDEF00 => seems to always be there (no idea why)
+        // Then the name of the file
+        // Then the pointer section
+        // Then the "names positions" section
+        // Then the functions section
+        // Done; here the "function" objects holds the number of functions, the addr, name positions
+        // everything else can be deduced to recreate the header
         display_text("Reading header...");
         uint nb_functions = ReadIntegerFromByteArray(0x14, dat_content);
         uint position_filename = ReadIntegerFromByteArray(0x4, dat_content);
@@ -5480,207 +6341,371 @@ class CS1Builder : public Builder
         QString filename = ReadStringFromByteArray(position, dat_content);
         SceneName = filename;
         int start_offset_area = ReadIntegerFromByteArray(0x8, dat_content);
-        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++){
-            position = start_offset_area + 4*idx_fun;
-            next_position = start_offset_area + 4*(idx_fun+1);
+        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++) {
+            position = start_offset_area + 4 * idx_fun;
+            next_position = start_offset_area + 4 * (idx_fun + 1);
             int addr = ReadIntegerFromByteArray(position, dat_content);
-            position = start_offset_area + 4*nb_functions + 2 * idx_fun;
+            position = start_offset_area + 4 * nb_functions + 2 * idx_fun;
             short name_pos = ReadShortFromByteArray(position, dat_content);
             int name_pos_int = name_pos;
             QString function_name = ReadStringFromByteArray(name_pos_int, dat_content);
             int end_addr;
-            if (idx_fun == nb_functions-1) //we are at the last function, so it ends at the end of the file
+            if (idx_fun == nb_functions - 1) // we are at the last function, so it ends at the end of the file
                 end_addr = dat_content.size();
-            else
-            {
+            else {
                 end_addr = ReadIntegerFromByteArray(next_position, dat_content);
             }
-            FunctionsToParse.push_back(function(idx_fun,function_name,name_pos,addr,end_addr));
-
+            FunctionsToParse.push_back(function(idx_fun, function_name, name_pos, addr, end_addr));
         }
         display_text("Header parsed.");
         return true;
     }
-    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int &addr, int row, QXlsx::Document &xls_content){
+    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int& addr, int row, QXlsx::Document& xls_content) {
 
-        uint OP = xls_content.read(row+1, 2).toInt();
+        uint OP = xls_content.read(row + 1, 2).toInt();
         int i = CS1UIFiles.indexOf(SceneName);
-        if ((i != -1)&&(OP == 0x13)) return std::make_shared<UI_OP13>(addr,row, xls_content,this);
+        if ((i != -1) && (OP == 0x13)) return std::make_shared<UI_OP13>(addr, row, xls_content, this);
 
-        switch(OP){
-        case 0x00: return std::make_shared<OPCode0>(addr,row, xls_content,this);
-        case 0x01: return std::make_shared<OPCode1>(addr,row, xls_content,this);
-        case 0x02: return std::make_shared<OPCode02>(addr,row, xls_content,this);
-        case 0x03: return std::make_shared<OPCode03>(addr,row, xls_content,this);
-        case 0x04: return std::make_shared<OPCode04>(addr,row, xls_content,this);
-        case 0x05: return std::make_shared<OPCode05>(addr,row, xls_content,this);
-        case 0x06: return std::make_shared<OPCode06>(addr,row, xls_content,this);
-        case 0x07: return std::make_shared<OPCode07>(addr,row, xls_content,this);
-        case 0x08: return std::make_shared<OPCode08>(addr,row, xls_content,this);
-        case 0x0A: return std::make_shared<OPCode0A>(addr,row, xls_content,this);
-        case 0x0C: return std::make_shared<OPCode0C>(addr,row, xls_content,this);
-        case 0x0D: return std::make_shared<OPCode0D>(addr,row, xls_content,this);
-        case 0x0E: return std::make_shared<OPCode0E>(addr,row, xls_content,this);
-        case 0x0F: return std::make_shared<OPCode0F>(addr,row, xls_content,this);
-        case 0x10: return std::make_shared<OPCode10>(addr,row, xls_content,this);
-        case 0x11: return std::make_shared<OPCode11>(addr,row, xls_content,this);
-        case 0x12: return std::make_shared<OPCode12>(addr,row, xls_content,this);
-        case 0x13: return std::make_shared<OPCode13>(addr,row, xls_content,this);
-        case 0x14: return std::make_shared<OPCode14>(addr,row, xls_content,this);
-        case 0x15: return std::make_shared<OPCode15>(addr,row, xls_content,this);
-        case 0x16: return std::make_shared<OPCode16>(addr,row, xls_content,this);
-        case 0x17: return std::make_shared<OPCode17>(addr,row, xls_content,this);
-        case 0x18: return std::make_shared<OPCode18>(addr,row, xls_content,this);
-        case 0x19: return std::make_shared<OPCode19>(addr,row, xls_content,this);
-        case 0x1A: return std::make_shared<OPCode1A>(addr,row, xls_content,this);
-        case 0x1B: return std::make_shared<OPCode1B>(addr,row, xls_content,this);
-        case 0x1C: return std::make_shared<OPCode1C>(addr,row, xls_content,this);
-        case 0x1D: return std::make_shared<OPCode1D>(addr,row, xls_content,this);
-        case 0x1E: return std::make_shared<OPCode1E>(addr,row, xls_content,this);
-        case 0x1F: return std::make_shared<OPCode1F>(addr,row, xls_content,this);
-        case 0x20: return std::make_shared<OPCode20>(addr,row, xls_content,this);
-        case 0x21: return std::make_shared<OPCode21>(addr,row, xls_content,this);
-        case 0x22: return std::make_shared<OPCode22>(addr,row, xls_content,this);
-        case 0x23: return std::make_shared<OPCode23>(addr,row, xls_content,this);
-        case 0x24: return std::make_shared<OPCode24>(addr,row, xls_content,this);
-        case 0x25: return std::make_shared<OPCode25>(addr,row, xls_content,this);
-        case 0x26: return std::make_shared<OPCode26>(addr,row, xls_content,this);
-        case 0x27: return std::make_shared<OPCode27>(addr,row, xls_content,this);
-        case 0x28: return std::make_shared<OPCode28>(addr,row, xls_content,this);
-        case 0x29: return std::make_shared<OPCode29>(addr,row, xls_content,this);
-        case 0x2A: return std::make_shared<OPCode2A>(addr,row, xls_content,this);
-        case 0x2B: return std::make_shared<OPCode2B>(addr,row, xls_content,this);
-        case 0x2C: return std::make_shared<OPCode2C>(addr,row, xls_content,this);
-        case 0x2D: return std::make_shared<OPCode2D>(addr,row, xls_content,this);
-        case 0x2E: return std::make_shared<OPCode2E>(addr,row, xls_content,this);
-        case 0x2F: return std::make_shared<OPCode2F>(addr,row, xls_content,this);
-        case 0x30: return std::make_shared<OPCode30>(addr,row, xls_content,this);
-        case 0x31: return std::make_shared<OPCode31>(addr,row, xls_content,this);
-        case 0x32: return std::make_shared<OPCode32>(addr,row, xls_content,this);
-        case 0x33: return std::make_shared<OPCode33>(addr,row, xls_content,this);
-        case 0x34: return std::make_shared<OPCode34>(addr,row, xls_content,this);
-        case 0x35: return std::make_shared<OPCode35>(addr,row, xls_content,this);
-        case 0x36: return std::make_shared<OPCode36>(addr,row, xls_content,this);
-        case 0x37: return std::make_shared<OPCode37>(addr,row, xls_content,this);
-        case 0x38: return std::make_shared<OPCode38>(addr,row, xls_content,this);
-        case 0x39: return std::make_shared<OPCode39>(addr,row, xls_content,this);
-        case 0x3A: return std::make_shared<OPCode3A>(addr,row, xls_content,this);
-        case 0x3B: return std::make_shared<OPCode3B>(addr,row, xls_content,this);
-        case 0x3C: return std::make_shared<OPCode3C>(addr,row, xls_content,this);
-        case 0x3D: return std::make_shared<OPCode3D>(addr,row, xls_content,this);
-        case 0x3E: return std::make_shared<OPCode3E>(addr,row, xls_content,this);
-        case 0x3F: return std::make_shared<OPCode3F>(addr,row, xls_content,this);
-        case 0x40: return std::make_shared<OPCode40>(addr,row, xls_content,this);
-        case 0x41: return std::make_shared<OPCode41>(addr,row, xls_content,this);
-        case 0x42: return std::make_shared<OPCode42>(addr,row, xls_content,this);
-        case 0x43: return std::make_shared<OPCode43>(addr,row, xls_content,this);
-        case 0x44: return std::make_shared<OPCode44>(addr,row, xls_content,this);
-        case 0x45: return std::make_shared<OPCode45>(addr,row, xls_content,this);
-        case 0x46: return std::make_shared<OPCode46>(addr,row, xls_content,this);
-        case 0x47: return std::make_shared<OPCode47>(addr,row, xls_content,this);
-        case 0x48: return std::make_shared<OPCode48>(addr,row, xls_content,this);
-        case 0x49: return std::make_shared<OPCode49>(addr,row, xls_content,this);
-        case 0x4A: return std::make_shared<OPCode4A>(addr,row, xls_content,this);
-        case 0x4B: return std::make_shared<OPCode4B>(addr,row, xls_content,this);
-        case 0x4C: return std::make_shared<OPCode4C>(addr,row, xls_content,this);
-        case 0x4D: return std::make_shared<OPCode4D>(addr,row, xls_content,this);
-        //case 0x4E: return std::make_shared<OPCode4E>(addr,row, xls_content,this);
-        case 0x4F: return std::make_shared<OPCode4F>(addr,row, xls_content,this);
-        //case 0x50: return std::make_shared<OPCode50>(addr,row, xls_content,this);
-        case 0x51: return std::make_shared<OPCode51>(addr,row, xls_content,this);
-        case 0x52: return std::make_shared<OPCode52>(addr,row, xls_content,this);
-        case 0x53: return std::make_shared<OPCode53>(addr,row, xls_content,this);
+        switch (OP) {
+            case 0x00:
+                return std::make_shared<OPCode0>(addr, row, xls_content, this);
+            case 0x01:
+                return std::make_shared<OPCode1>(addr, row, xls_content, this);
+            case 0x02:
+                return std::make_shared<OPCode02>(addr, row, xls_content, this);
+            case 0x03:
+                return std::make_shared<OPCode03>(addr, row, xls_content, this);
+            case 0x04:
+                return std::make_shared<OPCode04>(addr, row, xls_content, this);
+            case 0x05:
+                return std::make_shared<OPCode05>(addr, row, xls_content, this);
+            case 0x06:
+                return std::make_shared<OPCode06>(addr, row, xls_content, this);
+            case 0x07:
+                return std::make_shared<OPCode07>(addr, row, xls_content, this);
+            case 0x08:
+                return std::make_shared<OPCode08>(addr, row, xls_content, this);
+            case 0x0A:
+                return std::make_shared<OPCode0A>(addr, row, xls_content, this);
+            case 0x0C:
+                return std::make_shared<OPCode0C>(addr, row, xls_content, this);
+            case 0x0D:
+                return std::make_shared<OPCode0D>(addr, row, xls_content, this);
+            case 0x0E:
+                return std::make_shared<OPCode0E>(addr, row, xls_content, this);
+            case 0x0F:
+                return std::make_shared<OPCode0F>(addr, row, xls_content, this);
+            case 0x10:
+                return std::make_shared<OPCode10>(addr, row, xls_content, this);
+            case 0x11:
+                return std::make_shared<OPCode11>(addr, row, xls_content, this);
+            case 0x12:
+                return std::make_shared<OPCode12>(addr, row, xls_content, this);
+            case 0x13:
+                return std::make_shared<OPCode13>(addr, row, xls_content, this);
+            case 0x14:
+                return std::make_shared<OPCode14>(addr, row, xls_content, this);
+            case 0x15:
+                return std::make_shared<OPCode15>(addr, row, xls_content, this);
+            case 0x16:
+                return std::make_shared<OPCode16>(addr, row, xls_content, this);
+            case 0x17:
+                return std::make_shared<OPCode17>(addr, row, xls_content, this);
+            case 0x18:
+                return std::make_shared<OPCode18>(addr, row, xls_content, this);
+            case 0x19:
+                return std::make_shared<OPCode19>(addr, row, xls_content, this);
+            case 0x1A:
+                return std::make_shared<OPCode1A>(addr, row, xls_content, this);
+            case 0x1B:
+                return std::make_shared<OPCode1B>(addr, row, xls_content, this);
+            case 0x1C:
+                return std::make_shared<OPCode1C>(addr, row, xls_content, this);
+            case 0x1D:
+                return std::make_shared<OPCode1D>(addr, row, xls_content, this);
+            case 0x1E:
+                return std::make_shared<OPCode1E>(addr, row, xls_content, this);
+            case 0x1F:
+                return std::make_shared<OPCode1F>(addr, row, xls_content, this);
+            case 0x20:
+                return std::make_shared<OPCode20>(addr, row, xls_content, this);
+            case 0x21:
+                return std::make_shared<OPCode21>(addr, row, xls_content, this);
+            case 0x22:
+                return std::make_shared<OPCode22>(addr, row, xls_content, this);
+            case 0x23:
+                return std::make_shared<OPCode23>(addr, row, xls_content, this);
+            case 0x24:
+                return std::make_shared<OPCode24>(addr, row, xls_content, this);
+            case 0x25:
+                return std::make_shared<OPCode25>(addr, row, xls_content, this);
+            case 0x26:
+                return std::make_shared<OPCode26>(addr, row, xls_content, this);
+            case 0x27:
+                return std::make_shared<OPCode27>(addr, row, xls_content, this);
+            case 0x28:
+                return std::make_shared<OPCode28>(addr, row, xls_content, this);
+            case 0x29:
+                return std::make_shared<OPCode29>(addr, row, xls_content, this);
+            case 0x2A:
+                return std::make_shared<OPCode2A>(addr, row, xls_content, this);
+            case 0x2B:
+                return std::make_shared<OPCode2B>(addr, row, xls_content, this);
+            case 0x2C:
+                return std::make_shared<OPCode2C>(addr, row, xls_content, this);
+            case 0x2D:
+                return std::make_shared<OPCode2D>(addr, row, xls_content, this);
+            case 0x2E:
+                return std::make_shared<OPCode2E>(addr, row, xls_content, this);
+            case 0x2F:
+                return std::make_shared<OPCode2F>(addr, row, xls_content, this);
+            case 0x30:
+                return std::make_shared<OPCode30>(addr, row, xls_content, this);
+            case 0x31:
+                return std::make_shared<OPCode31>(addr, row, xls_content, this);
+            case 0x32:
+                return std::make_shared<OPCode32>(addr, row, xls_content, this);
+            case 0x33:
+                return std::make_shared<OPCode33>(addr, row, xls_content, this);
+            case 0x34:
+                return std::make_shared<OPCode34>(addr, row, xls_content, this);
+            case 0x35:
+                return std::make_shared<OPCode35>(addr, row, xls_content, this);
+            case 0x36:
+                return std::make_shared<OPCode36>(addr, row, xls_content, this);
+            case 0x37:
+                return std::make_shared<OPCode37>(addr, row, xls_content, this);
+            case 0x38:
+                return std::make_shared<OPCode38>(addr, row, xls_content, this);
+            case 0x39:
+                return std::make_shared<OPCode39>(addr, row, xls_content, this);
+            case 0x3A:
+                return std::make_shared<OPCode3A>(addr, row, xls_content, this);
+            case 0x3B:
+                return std::make_shared<OPCode3B>(addr, row, xls_content, this);
+            case 0x3C:
+                return std::make_shared<OPCode3C>(addr, row, xls_content, this);
+            case 0x3D:
+                return std::make_shared<OPCode3D>(addr, row, xls_content, this);
+            case 0x3E:
+                return std::make_shared<OPCode3E>(addr, row, xls_content, this);
+            case 0x3F:
+                return std::make_shared<OPCode3F>(addr, row, xls_content, this);
+            case 0x40:
+                return std::make_shared<OPCode40>(addr, row, xls_content, this);
+            case 0x41:
+                return std::make_shared<OPCode41>(addr, row, xls_content, this);
+            case 0x42:
+                return std::make_shared<OPCode42>(addr, row, xls_content, this);
+            case 0x43:
+                return std::make_shared<OPCode43>(addr, row, xls_content, this);
+            case 0x44:
+                return std::make_shared<OPCode44>(addr, row, xls_content, this);
+            case 0x45:
+                return std::make_shared<OPCode45>(addr, row, xls_content, this);
+            case 0x46:
+                return std::make_shared<OPCode46>(addr, row, xls_content, this);
+            case 0x47:
+                return std::make_shared<OPCode47>(addr, row, xls_content, this);
+            case 0x48:
+                return std::make_shared<OPCode48>(addr, row, xls_content, this);
+            case 0x49:
+                return std::make_shared<OPCode49>(addr, row, xls_content, this);
+            case 0x4A:
+                return std::make_shared<OPCode4A>(addr, row, xls_content, this);
+            case 0x4B:
+                return std::make_shared<OPCode4B>(addr, row, xls_content, this);
+            case 0x4C:
+                return std::make_shared<OPCode4C>(addr, row, xls_content, this);
+            case 0x4D:
+                return std::make_shared<OPCode4D>(addr, row, xls_content, this);
+            // case 0x4E: return std::make_shared<OPCode4E>(addr,row, xls_content,this);
+            case 0x4F:
+                return std::make_shared<OPCode4F>(addr, row, xls_content, this);
+            // case 0x50: return std::make_shared<OPCode50>(addr,row, xls_content,this);
+            case 0x51:
+                return std::make_shared<OPCode51>(addr, row, xls_content, this);
+            case 0x52:
+                return std::make_shared<OPCode52>(addr, row, xls_content, this);
+            case 0x53:
+                return std::make_shared<OPCode53>(addr, row, xls_content, this);
 
-        case 0x55: return std::make_shared<OPCode55>(addr,row, xls_content,this);
-        case 0x56: return std::make_shared<OPCode56>(addr,row, xls_content,this);
-        case 0x57: return std::make_shared<OPCode57>(addr,row, xls_content,this);
-        case 0x58: return std::make_shared<OPCode58>(addr,row, xls_content,this);
-        case 0x59: return std::make_shared<OPCode59>(addr,row, xls_content,this);
-        case 0x5A: return std::make_shared<OPCode5A>(addr,row, xls_content,this);
-        case 0x5B: return std::make_shared<OPCode5B>(addr,row, xls_content,this);
-        case 0x5C: return std::make_shared<OPCode5C>(addr,row, xls_content,this);
-        case 0x5D: return std::make_shared<OPCode5D>(addr,row, xls_content,this);
-        case 0x5E: return std::make_shared<OPCode5E>(addr,row, xls_content,this);
-        case 0x5F: return std::make_shared<OPCode5F>(addr,row, xls_content,this);
-        case 0x60: return std::make_shared<OPCode60>(addr,row, xls_content,this);
-        case 0x61: return std::make_shared<OPCode61>(addr,row, xls_content,this);
-        case 0x62: return std::make_shared<OPCode62>(addr,row, xls_content,this);
-        case 0x63: return std::make_shared<OPCode63>(addr,row, xls_content,this);
-        case 0x64: return std::make_shared<OPCode64>(addr,row, xls_content,this);
-        case 0x65: return std::make_shared<OPCode65>(addr,row, xls_content,this);
-        case 0x66: return std::make_shared<OPCode66>(addr,row, xls_content,this);
-        case 0x67: return std::make_shared<OPCode67>(addr,row, xls_content,this);
-        case 0x68: return std::make_shared<OPCode68>(addr,row, xls_content,this);
-        case 0x69: return std::make_shared<OPCode69>(addr,row, xls_content,this);
-        case 0x6A: return std::make_shared<OPCode6A>(addr,row, xls_content,this);
-        case 0x6B: return std::make_shared<OPCode6B>(addr,row, xls_content,this);
-        case 0x6C: return std::make_shared<OPCode6C>(addr,row, xls_content,this);
-        case 0x6D: return std::make_shared<OPCode6D>(addr,row, xls_content,this);
-        case 0x6E: return std::make_shared<OPCode6E>(addr,row, xls_content,this);
-        case 0x6F: return std::make_shared<OPCode6F>(addr,row, xls_content,this);
-        case 0x70: return std::make_shared<OPCode70>(addr,row, xls_content,this);
-        case 0x71: return std::make_shared<OPCode71>(addr,row, xls_content,this);
-        case 0x72: return std::make_shared<OPCode72>(addr,row, xls_content,this);
-        case 0x73: return std::make_shared<OPCode73>(addr,row, xls_content,this);
-        case 0x74: return std::make_shared<OPCode74>(addr,row, xls_content,this);
+            case 0x55:
+                return std::make_shared<OPCode55>(addr, row, xls_content, this);
+            case 0x56:
+                return std::make_shared<OPCode56>(addr, row, xls_content, this);
+            case 0x57:
+                return std::make_shared<OPCode57>(addr, row, xls_content, this);
+            case 0x58:
+                return std::make_shared<OPCode58>(addr, row, xls_content, this);
+            case 0x59:
+                return std::make_shared<OPCode59>(addr, row, xls_content, this);
+            case 0x5A:
+                return std::make_shared<OPCode5A>(addr, row, xls_content, this);
+            case 0x5B:
+                return std::make_shared<OPCode5B>(addr, row, xls_content, this);
+            case 0x5C:
+                return std::make_shared<OPCode5C>(addr, row, xls_content, this);
+            case 0x5D:
+                return std::make_shared<OPCode5D>(addr, row, xls_content, this);
+            case 0x5E:
+                return std::make_shared<OPCode5E>(addr, row, xls_content, this);
+            case 0x5F:
+                return std::make_shared<OPCode5F>(addr, row, xls_content, this);
+            case 0x60:
+                return std::make_shared<OPCode60>(addr, row, xls_content, this);
+            case 0x61:
+                return std::make_shared<OPCode61>(addr, row, xls_content, this);
+            case 0x62:
+                return std::make_shared<OPCode62>(addr, row, xls_content, this);
+            case 0x63:
+                return std::make_shared<OPCode63>(addr, row, xls_content, this);
+            case 0x64:
+                return std::make_shared<OPCode64>(addr, row, xls_content, this);
+            case 0x65:
+                return std::make_shared<OPCode65>(addr, row, xls_content, this);
+            case 0x66:
+                return std::make_shared<OPCode66>(addr, row, xls_content, this);
+            case 0x67:
+                return std::make_shared<OPCode67>(addr, row, xls_content, this);
+            case 0x68:
+                return std::make_shared<OPCode68>(addr, row, xls_content, this);
+            case 0x69:
+                return std::make_shared<OPCode69>(addr, row, xls_content, this);
+            case 0x6A:
+                return std::make_shared<OPCode6A>(addr, row, xls_content, this);
+            case 0x6B:
+                return std::make_shared<OPCode6B>(addr, row, xls_content, this);
+            case 0x6C:
+                return std::make_shared<OPCode6C>(addr, row, xls_content, this);
+            case 0x6D:
+                return std::make_shared<OPCode6D>(addr, row, xls_content, this);
+            case 0x6E:
+                return std::make_shared<OPCode6E>(addr, row, xls_content, this);
+            case 0x6F:
+                return std::make_shared<OPCode6F>(addr, row, xls_content, this);
+            case 0x70:
+                return std::make_shared<OPCode70>(addr, row, xls_content, this);
+            case 0x71:
+                return std::make_shared<OPCode71>(addr, row, xls_content, this);
+            case 0x72:
+                return std::make_shared<OPCode72>(addr, row, xls_content, this);
+            case 0x73:
+                return std::make_shared<OPCode73>(addr, row, xls_content, this);
+            case 0x74:
+                return std::make_shared<OPCode74>(addr, row, xls_content, this);
 
-        case 0x77: return std::make_shared<OPCode77>(addr,row, xls_content,this);
-        case 0x78: return std::make_shared<OPCode78>(addr,row, xls_content,this);
-        case 0x79: return std::make_shared<OPCode79>(addr,row, xls_content,this);
-        case 0x7A: return std::make_shared<OPCode7A>(addr,row, xls_content,this);
-        case 0x7B: return std::make_shared<OPCode7B>(addr,row, xls_content,this);
+            case 0x77:
+                return std::make_shared<OPCode77>(addr, row, xls_content, this);
+            case 0x78:
+                return std::make_shared<OPCode78>(addr, row, xls_content, this);
+            case 0x79:
+                return std::make_shared<OPCode79>(addr, row, xls_content, this);
+            case 0x7A:
+                return std::make_shared<OPCode7A>(addr, row, xls_content, this);
+            case 0x7B:
+                return std::make_shared<OPCode7B>(addr, row, xls_content, this);
 
-        case 0x7D: return std::make_shared<OPCode7D>(addr,row, xls_content,this);
-        case 0x7E: return std::make_shared<OPCode7E>(addr,row, xls_content,this);
-        case 0x7F: return std::make_shared<OPCode7F>(addr,row, xls_content,this);
-        case 0x80: return std::make_shared<OPCode80>(addr,row, xls_content,this);
-        case 0x81: return std::make_shared<OPCode81>(addr,row, xls_content,this);
-        case 0x82: return std::make_shared<OPCode82>(addr,row, xls_content,this);
-        case 0x83: return std::make_shared<OPCode83>(addr,row, xls_content,this);
-        case 0x84: return std::make_shared<OPCode84>(addr,row, xls_content,this);
-        case 0x85: return std::make_shared<OPCode85>(addr,row, xls_content,this);
-        case 0x86: return std::make_shared<OPCode86>(addr,row, xls_content,this);
-        case 0x87: return std::make_shared<OPCode87>(addr,row, xls_content,this);
-        case 0x88: return std::make_shared<OPCode88>(addr,row, xls_content,this);
-        case 0x89: return std::make_shared<OPCode89>(addr,row, xls_content,this);
-        case 0x8A: return std::make_shared<OPCode8A>(addr,row, xls_content,this);
-        case 0x8B: return std::make_shared<OPCode8B>(addr,row, xls_content,this);
-        case 0x8C: return std::make_shared<OPCode8C>(addr,row, xls_content,this);
-        case 0x8D: return std::make_shared<OPCode8D>(addr,row, xls_content,this);
-        case 0x8E: return std::make_shared<OPCode8E>(addr,row, xls_content,this);
+            case 0x7D:
+                return std::make_shared<OPCode7D>(addr, row, xls_content, this);
+            case 0x7E:
+                return std::make_shared<OPCode7E>(addr, row, xls_content, this);
+            case 0x7F:
+                return std::make_shared<OPCode7F>(addr, row, xls_content, this);
+            case 0x80:
+                return std::make_shared<OPCode80>(addr, row, xls_content, this);
+            case 0x81:
+                return std::make_shared<OPCode81>(addr, row, xls_content, this);
+            case 0x82:
+                return std::make_shared<OPCode82>(addr, row, xls_content, this);
+            case 0x83:
+                return std::make_shared<OPCode83>(addr, row, xls_content, this);
+            case 0x84:
+                return std::make_shared<OPCode84>(addr, row, xls_content, this);
+            case 0x85:
+                return std::make_shared<OPCode85>(addr, row, xls_content, this);
+            case 0x86:
+                return std::make_shared<OPCode86>(addr, row, xls_content, this);
+            case 0x87:
+                return std::make_shared<OPCode87>(addr, row, xls_content, this);
+            case 0x88:
+                return std::make_shared<OPCode88>(addr, row, xls_content, this);
+            case 0x89:
+                return std::make_shared<OPCode89>(addr, row, xls_content, this);
+            case 0x8A:
+                return std::make_shared<OPCode8A>(addr, row, xls_content, this);
+            case 0x8B:
+                return std::make_shared<OPCode8B>(addr, row, xls_content, this);
+            case 0x8C:
+                return std::make_shared<OPCode8C>(addr, row, xls_content, this);
+            case 0x8D:
+                return std::make_shared<OPCode8D>(addr, row, xls_content, this);
+            case 0x8E:
+                return std::make_shared<OPCode8E>(addr, row, xls_content, this);
 
-        case 0x90: return std::make_shared<OPCode90>(addr,row, xls_content,this);
-        case 0x91: return std::make_shared<OPCode91>(addr,row, xls_content,this);
-        case 0x92: return std::make_shared<OPCode92>(addr,row, xls_content,this);
-        case 0x93: return std::make_shared<OPCode93>(addr,row, xls_content,this);
-        case 0x94: return std::make_shared<OPCode94>(addr,row, xls_content,this);
-        case 0x95: return std::make_shared<OPCode95>(addr,row, xls_content,this);
-        case 0x96: return std::make_shared<OPCode96>(addr,row, xls_content,this);
-        case 0x97: return std::make_shared<OPCode97>(addr,row, xls_content,this);
-        case 0x98: return std::make_shared<OPCode98>(addr,row, xls_content,this);
-        case 0x99: return std::make_shared<OPCode99>(addr,row, xls_content,this);
-        case 0x9A: return std::make_shared<OPCode9A>(addr,row, xls_content,this);
-        case 0x9B: return std::make_shared<OPCode9B>(addr,row, xls_content,this);
-        case 0x9D: return std::make_shared<OPCode9D>(addr,row, xls_content,this);
-        case 0x9E: return std::make_shared<OPCode9E>(addr,row, xls_content,this);
-        case 0x9F: return std::make_shared<OPCode9F>(addr,row, xls_content,this);
+            case 0x90:
+                return std::make_shared<OPCode90>(addr, row, xls_content, this);
+            case 0x91:
+                return std::make_shared<OPCode91>(addr, row, xls_content, this);
+            case 0x92:
+                return std::make_shared<OPCode92>(addr, row, xls_content, this);
+            case 0x93:
+                return std::make_shared<OPCode93>(addr, row, xls_content, this);
+            case 0x94:
+                return std::make_shared<OPCode94>(addr, row, xls_content, this);
+            case 0x95:
+                return std::make_shared<OPCode95>(addr, row, xls_content, this);
+            case 0x96:
+                return std::make_shared<OPCode96>(addr, row, xls_content, this);
+            case 0x97:
+                return std::make_shared<OPCode97>(addr, row, xls_content, this);
+            case 0x98:
+                return std::make_shared<OPCode98>(addr, row, xls_content, this);
+            case 0x99:
+                return std::make_shared<OPCode99>(addr, row, xls_content, this);
+            case 0x9A:
+                return std::make_shared<OPCode9A>(addr, row, xls_content, this);
+            case 0x9B:
+                return std::make_shared<OPCode9B>(addr, row, xls_content, this);
+            case 0x9D:
+                return std::make_shared<OPCode9D>(addr, row, xls_content, this);
+            case 0x9E:
+                return std::make_shared<OPCode9E>(addr, row, xls_content, this);
+            case 0x9F:
+                return std::make_shared<OPCode9F>(addr, row, xls_content, this);
 
-        case 256: return std::make_shared<CreateMonsters>(addr, row, xls_content,this);
-                    case 257: return std::make_shared<EffectsInstr>(addr, row, xls_content,this);
-                    case 258: return std::make_shared<ActionTable>(addr, row, xls_content,this);
-                    case 259: return std::make_shared<AlgoTable>(addr, row, xls_content,this);
-                    case 260: return std::make_shared<WeaponAttTable>(addr, row, xls_content,this);
-                    case 261: return std::make_shared<BreakTable>(addr, row, xls_content,this);
-                    case 262: return std::make_shared<SummonTable>(addr, row, xls_content,this);
-                    case 263: return std::make_shared<ReactionTable>(addr, row, xls_content,this);
-                    case 264: return std::make_shared<PartTable>(addr, row, xls_content,this);
-                    case 265: return std::make_shared<AnimeClipTable>(addr, row, xls_content,this);
-                    case 266: return std::make_shared<FieldMonsterData>(addr, row, xls_content,this);
-                    case 267: return std::make_shared<FieldFollowData>(addr, row, xls_content,this);
-                    case 268: return std::make_shared<FC_autoX>(addr, row, xls_content,this);
-                    case 269: return std::make_shared<BookData99>(addr, row, xls_content,this);
-                    case 270: return std::make_shared<BookDataX>(addr, row, xls_content,this);
-                    case 271: return std::make_shared<AddCollision>(addr, row, xls_content,this);
+            case 256:
+                return std::make_shared<CreateMonsters>(addr, row, xls_content, this);
+            case 257:
+                return std::make_shared<EffectsInstr>(addr, row, xls_content, this);
+            case 258:
+                return std::make_shared<ActionTable>(addr, row, xls_content, this);
+            case 259:
+                return std::make_shared<AlgoTable>(addr, row, xls_content, this);
+            case 260:
+                return std::make_shared<WeaponAttTable>(addr, row, xls_content, this);
+            case 261:
+                return std::make_shared<BreakTable>(addr, row, xls_content, this);
+            case 262:
+                return std::make_shared<SummonTable>(addr, row, xls_content, this);
+            case 263:
+                return std::make_shared<ReactionTable>(addr, row, xls_content, this);
+            case 264:
+                return std::make_shared<PartTable>(addr, row, xls_content, this);
+            case 265:
+                return std::make_shared<AnimeClipTable>(addr, row, xls_content, this);
+            case 266:
+                return std::make_shared<FieldMonsterData>(addr, row, xls_content, this);
+            case 267:
+                return std::make_shared<FieldFollowData>(addr, row, xls_content, this);
+            case 268:
+                return std::make_shared<FC_autoX>(addr, row, xls_content, this);
+            case 269:
+                return std::make_shared<BookData99>(addr, row, xls_content, this);
+            case 270:
+                return std::make_shared<BookDataX>(addr, row, xls_content, this);
+            case 271:
+                return std::make_shared<AddCollision>(addr, row, xls_content, this);
             default:
                 std::stringstream stream;
                 stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << this->SceneName.toStdString();
@@ -5694,8 +6719,7 @@ class CS1Builder : public Builder
         }
     }
 
-
-    QByteArray CreateHeaderBytes(){
+    QByteArray CreateHeaderBytes() {
 
         QByteArray header;
 
@@ -5704,44 +6728,43 @@ class CS1Builder : public Builder
         int size_of_scene_name = scene_name_bytes.length();
         header.append(GetBytesFromInt(0x20));
         header.append(GetBytesFromInt(0x20));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name));
-        header.append(GetBytesFromInt(FunctionsParsed.size()*4));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name));
+        header.append(GetBytesFromInt(FunctionsParsed.size() * 4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4));
         header.append(GetBytesFromInt(FunctionsParsed.size()));
         int length_of_names_section = 0;
-        for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + length_of_names_section));
+        for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++)
+            length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
+        header.append(
+          GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + length_of_names_section));
         header.append(GetBytesFromInt(0xABCDEF00));
         header.append(scene_name_bytes);
-        if (FunctionsParsed.size()>0){
+        if (FunctionsParsed.size() > 0) {
             QByteArray position_names;
             QByteArray actual_names;
             int offset_names = 0;
-            for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) {
+            for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++) {
                 header.append(GetBytesFromInt(FunctionsParsed[idx_fun].actual_addr));
                 QByteArray name = FunctionsParsed[idx_fun].name.toUtf8();
                 name.append('\x0');
-                position_names.append(GetBytesFromShort(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + offset_names));
+                position_names.append(
+                  GetBytesFromShort(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + offset_names));
                 actual_names.append(name);
                 offset_names = offset_names + name.size();
-
-
             }
             header.append(position_names);
             header.append(actual_names);
             int multiple = 4;
             if (FunctionsParsed[0].name.startsWith("_")) multiple = 0x10;
-            int nb_byte_to_add = (((int) ceil((float)header.size()/multiple)))*multiple - header.size();
+            int nb_byte_to_add = (((int)ceil((float)header.size() / multiple))) * multiple - header.size();
             QByteArray remaining;
-            for (int i = 0; i < nb_byte_to_add;i++) {
+            for (int i = 0; i < nb_byte_to_add; i++) {
                 remaining.push_back('\x0');
             }
             header.append(remaining);
         }
         return header;
     }
-
 };
-
 
 #endif // CS1INSTRUCTIONSSET_H

--- a/headers/CS2InstructionsSet.h
+++ b/headers/CS2InstructionsSet.h
@@ -1,176 +1,165 @@
 #ifndef CS2INSTRUCTIONSSET_H
 #define CS2INSTRUCTIONSSET_H
-#include "headers/utilities.h"
 #include "headers/functions.h"
 #include "headers/translationfile.h"
+#include "headers/utilities.h"
 
 #include <QString>
 
-
-
-class CS2TranslationFile : public TranslationFile
-{
-    public:
-    CS2TranslationFile():TranslationFile(){}
-
+class CS2TranslationFile : public TranslationFile {
+  public:
+    CS2TranslationFile()
+      : TranslationFile() {}
 };
-class CS2Builder : public Builder
-{
-    public:
-    CS2Builder(){
+class CS2Builder : public Builder {
+  public:
+    CS2Builder() {}
 
-    }
+    QVector<QString> CS2UIFiles = { "battle_menu", "camp_menu",   "camp_menu_v", "note_menu",   "note_menu_v",
+                                    "shop_menu",   "shop_menu_v", "title_menu",  "title_menu_v" };
 
-    QVector<QString> CS2UIFiles = {"battle_menu","camp_menu", "camp_menu_v","note_menu","note_menu_v","shop_menu","shop_menu_v","title_menu","title_menu_v"};
-
-    static void reading_dialog(int &addr, QByteArray &content, Instruction * instr){
+    static void reading_dialog(int& addr, QByteArray& content, Instruction* instr) {
 
         QByteArray current_op_value;
         int addr_ = addr;
 
         bool start_text = false;
         int cnt = 0;
-        do{
+        do {
             unsigned char current_byte = content[addr];
 
-            switch(current_byte){
+            switch (current_byte) {
                 case 0x00:
                     current_op_value.clear();
                     current_op_value[0] = 0;
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     addr++;
                     return;
                 case 0x01:
 
                     if (start_text)
                         current_op_value.push_back(current_byte);
-                    else{
+                    else {
 
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         current_op_value.clear();
                     }
                     addr++;
                     break;
                 case 0x02:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
                     break;
                 case 0x10:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x17:
                 case 0x19:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x11:
                 case 0x12:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x23:
                     current_op_value.push_back(0x23);
                     addr_ = addr;
                     addr++;
                     current_byte = content[addr];
-                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) ||
-                           (current_byte == 0x42)||(current_byte == 0x48)||(current_byte == 0x56)||(current_byte == 0x4b) ||
-                            (current_byte == 0x6b) || (current_byte == 0x46)) {
+                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) || (current_byte == 0x42) ||
+                        (current_byte == 0x48) || (current_byte == 0x56) || (current_byte == 0x4b) || (current_byte == 0x6b) ||
+                        (current_byte == 0x46)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
+
+                        if (current_byte != 0x5f) {
+                            if (current_byte == 0x5b) {
+                                do {
+                                    current_op_value.push_back(current_byte);
+                                    addr++;
+                                    current_byte = content[addr];
+                                } while (current_byte != 0x5D);
+                                current_op_value.push_back(current_byte);
+                                addr++;
+                                current_byte = content[addr];
+                            }
+                            break;
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
-
-                              if (current_byte != 0x5f) {
-                                  if (current_byte == 0x5b) {
-                                      do{
-                                          current_op_value.push_back(current_byte);
-                                          addr++;
-                                          current_byte = content[addr];
-                                      }
-                                      while(current_byte!=0x5D);
-                                      current_op_value.push_back(current_byte);
-                                      addr++;
-                                      current_byte = content[addr];
-                                  }
-                                  break;
-                              }
-                              else{
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  break;
-                              }
-
-                           }
-                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
-                                 (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
-                                 (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
-                                 current_op_value.push_back(current_byte);
-                                 addr++;
-                                 current_byte = content[addr];
-                                 break;
+                            current_op_value.push_back(current_byte);
+                            addr++;
+                            current_byte = content[addr];
+                            break;
                         }
+
+                    } else if ((((current_byte + 0xb7) & 0xdf) == 0) || (current_byte == 0x50) || (current_byte == 0x54) ||
+                               (current_byte == 0x57) || (current_byte == 0x53) || (current_byte == 0x73) || (current_byte == 0x43) ||
+                               (current_byte == 99) || (current_byte == 0x78) || (current_byte == 0x79) || (current_byte == 0x47) ||
+                               (current_byte == 0x44) || (current_byte == 0x55) || (current_byte == 0x52)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
                         break;
+                    }
+                    break;
                 default:
-                    if (current_byte < 0x20){
-                        if (current_op_value.size()>0) {
-                            instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_byte < 0x20) {
+                        if (current_op_value.size() > 0) {
+                            instr->AddOperande(operande(addr_, "dialog", current_op_value));
                         }
                         start_text = false;
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         addr++;
                         current_op_value.clear();
-                    }
-                    else {
+                    } else {
                         if (!(start_text)) start_text = true;
 
-                        if ((current_byte < 0xE0)&&(current_byte >= 0xC0)){
+                        if ((current_byte < 0xE0) && (current_byte >= 0xC0)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte >= 0xE0)&&(current_byte <= 0xF7)){
+                        } else if ((current_byte >= 0xE0) && (current_byte <= 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
@@ -179,12 +168,10 @@ class CS2Builder : public Builder
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte > 0xF7)){
+                        } else if ((current_byte > 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else{
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                         }
@@ -192,3829 +179,4247 @@ class CS2Builder : public Builder
                     break;
             }
 
-
             cnt++;
-        }
-        while(cnt<9999);
-
+        } while (cnt < 9999);
     }
 
-
-    static void fun_1403c90e0(int &addr, QByteArray &content, Instruction * instr, int param){
+    static void fun_1403c90e0(int& addr, QByteArray& content, Instruction* instr, int param) {
         QByteArray control_byte3_arr = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte3_arr));
+        instr->AddOperande(operande(addr, "byte", control_byte3_arr));
         unsigned char control_byte3 = (unsigned char)control_byte3_arr[0];
 
-        if (control_byte3 == '\x11'){
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+        if (control_byte3 == '\x11') {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-        }
-        else if (control_byte3 != '3'){
+        } else if (control_byte3 != '3') {
 
-            if (control_byte3 == '\"'){
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            if (control_byte3 == '\"') {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-            }
-            else if (control_byte3 != 0x44){
+            } else if (control_byte3 != 0x44) {
 
-                if (control_byte3 == 0xDD){
+                if (control_byte3 == 0xDD) {
 
-                    //there is a XOR,XOR EDI which causes a jump that ignores the strcpy
-                    if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                }
-                else if (control_byte3 == 0xFF){
-                    instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                }
-                else{
-                    if (control_byte3 != 0xEE){
+                    // there is a XOR,XOR EDI which causes a jump that ignores the strcpy
+                    if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                } else if (control_byte3 == 0xFF) {
+                    instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                } else {
+                    if (control_byte3 != 0xEE) {
 
-                    }
-                    else{
-                        instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    } else {
+                        instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     }
                 }
 
-
-            }
-            else{
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            } else {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
 
-        }
-        else{
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+        } else {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     }
-    static void sub05(int &addr, QByteArray &content, Instruction * instr){
+    static void sub05(int& addr, QByteArray& content, Instruction* instr) {
         QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte));
+        instr->AddOperande(operande(addr, "byte", control_byte));
 
-        while ((int)control_byte[0]!=1){
+        while ((int)control_byte[0] != 1) {
 
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x0:
-                    case 0x24:
-                        instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x24:
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-                    case 0x1c:{
-                        //the next byte is the OP code for a new instruction
+                case 0x1c: {
+                    // the next byte is the OP code for a new instruction
 
-                        std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content,0);
+                    std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content, 0);
 
-                        operande op = operande(addr,"instruction", instr2->getBytes());
-                        instr->AddOperande(op);
+                    operande op = operande(addr, "instruction", instr2->getBytes());
+                    instr->AddOperande(op);
 
-
-                        break;
-                    }
-                    case 0x1e:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x1f:
-                    case 0x20:
-                    case 0x23:
-
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x21:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x25:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    default:
-                        ;
+                    break;
                 }
+                case 0x1e:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x1f:
+                case 0x20:
+                case 0x23:
 
-                control_byte = ReadSubByteArray(content, addr, 1);
-
-                instr->AddOperande(operande(addr,"byte", control_byte));
-
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x21:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x25:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                default:;
             }
 
+            control_byte = ReadSubByteArray(content, addr, 1);
+
+            instr->AddOperande(operande(addr, "byte", control_byte));
+        }
     }
-    class CreateMonsters : public Instruction
-    {
-        public:
-        CreateMonsters():Instruction(-1,256,nullptr){}
-        CreateMonsters(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"CreateMonsters", 256,Maker){}
-        CreateMonsters(int addr, Builder *Maker):Instruction(addr,"CreateMonsters", 256, Maker){}
-        CreateMonsters(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"CreateMonsters", 256,Maker){
+    class CreateMonsters : public Instruction {
+      public:
+        CreateMonsters()
+          : Instruction(-1, 256, nullptr) {}
+        CreateMonsters(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int addr, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {
             int initial_addr = addr;
             int max_nb_monsters = 8;
-            if (Maker->goal<addr+0x20){
+            if (Maker->goal < addr + 0x20) {
 
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            int first = ReadIntegerFromByteArray(addr,content);
+            int first = ReadIntegerFromByteArray(addr, content);
 
-            if ((first == -1)&&(addr + 0x20 == Maker->goal)){
+            if ((first == -1) && (addr + 0x20 == Maker->goal)) {
 
-                this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
+                this->AddOperande(
+                  operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
                 Maker->flag_monsters = true;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            int check1 = ReadIntegerFromByteArray(addr,content);
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            int check1 = ReadIntegerFromByteArray(addr, content);
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            int check2 = ReadIntegerFromByteArray(addr,content);
-            if (check1 && check2 != 0){ //bad
+            int check2 = ReadIntegerFromByteArray(addr, content);
+            if (check1 && check2 != 0) { // bad
 
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2))); //0x10
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2))); //0x1A
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4))); //0x1C
-            //0x20
-
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x10
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x1A
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 0x1C
+            // 0x20
 
             int cnt = 0;
-            do{
-
+            do {
 
                 QByteArray array = ReadSubByteArray(content, addr, 4);
-                first = ReadIntegerFromByteArray(0,array);
-                this->AddOperande(operande(addr,"int", array));
+                first = ReadIntegerFromByteArray(0, array);
+                this->AddOperande(operande(addr, "int", array));
 
                 int counter = 0;
 
-                if (first == -2){
+                if (first == -2) {
 
                     QByteArray array = ReadSubByteArray(content, addr, 4);
-                    this->AddOperande(operande(addr,"int", array));
+                    this->AddOperande(operande(addr, "int", array));
                     max_nb_monsters = 4;
-                }
-                else if (first == -1){
-                    this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x18))); //?? it's empty
+                } else if (first == -1) {
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x18))); //?? it's empty
                     Maker->flag_monsters = true;
                     return;
-                }
-                else max_nb_monsters = 8;
+                } else
+                    max_nb_monsters = 8;
 
-                if (Maker->goal<addr + (0x10)*max_nb_monsters + max_nb_monsters*2){
+                if (Maker->goal < addr + (0x10) * max_nb_monsters + max_nb_monsters * 2) {
 
                     addr = initial_addr;
                     Maker->flag_monsters = false;
                     return;
                 }
 
-                do{
+                do {
                     counter++;
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10-monsters_name.size()-1);
-                    operande fill = operande(addr,"fill", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "fill", remaining);
                     fill.setBytesToFill(0x10);
                     this->AddOperande(fill);
 
-                }
-                while(counter < max_nb_monsters);
+                } while (counter < max_nb_monsters);
 
-                for (int idx_byte = 0; idx_byte < max_nb_monsters; idx_byte++) this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                for (int idx_byte = 0; idx_byte < max_nb_monsters; idx_byte++)
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                if ((unsigned char) content[addr] == 0)this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, max_nb_monsters))); //??
+                if ((unsigned char)content[addr] == 0)
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, max_nb_monsters))); //??
                 else {
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 12-monsters_name.size()-1);
-                    operande fill = operande(addr,"bytearray", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 12 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "bytearray", remaining);
                     fill.setBytesToFill(12);
                     this->AddOperande(fill);
-
-
                 }
 
-                first = ReadIntegerFromByteArray(addr,content);
+                first = ReadIntegerFromByteArray(addr, content);
 
                 cnt++;
 
-            }
-            while((first != -1)&&(addr != Maker->goal - 4));
+            } while ((first != -1) && (addr != Maker->goal - 4));
             if (addr == Maker->goal - 4) {
-                first = ReadIntegerFromByteArray(addr,content);
-                if (first != 1){
+                first = ReadIntegerFromByteArray(addr, content);
+                if (first != 1) {
                     addr = initial_addr;
                     Maker->flag_monsters = false;
                     return;
-                }
-                else{
+                } else {
                     Maker->flag_monsters = true;
                     return;
                 }
-
             }
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
+            this->AddOperande(
+              operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
             Maker->flag_monsters = true;
         }
-
-
     };
-    class EffectsInstr : public Instruction
-    {
-        public:
-        EffectsInstr():Instruction(-1,257,nullptr){}
-        EffectsInstr(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"EffectsInstr", 257,Maker){}
-        EffectsInstr(int addr, Builder *Maker):Instruction(addr,"EffectsInstr", 257, Maker){}
-        EffectsInstr(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"EffectsInstr", 257,Maker){
-            bool bytes_blocks_remain = Maker->goal >= addr+0x28;
+    class EffectsInstr : public Instruction {
+      public:
+        EffectsInstr()
+          : Instruction(-1, 257, nullptr) {}
+        EffectsInstr(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int addr, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {
+            bool bytes_blocks_remain = Maker->goal >= addr + 0x28;
 
-            while (bytes_blocks_remain){
+            while (bytes_blocks_remain) {
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
+                this->AddOperande(operande(addr, "string", str));
 
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
 
-
-                operande fill = operande(addr,"fill", remaining);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
-                bytes_blocks_remain = Maker->goal >= addr+0x28;
-
+                bytes_blocks_remain = Maker->goal >= addr + 0x28;
             }
         }
-
-
     };
-    class ActionTable : public Instruction
-    {
-        public:
-        ActionTable():Instruction(-1,258,nullptr){}
-        ActionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ActionTable", 258,Maker){}
-        ActionTable(int addr, Builder *Maker):Instruction(addr,"ActionTable", 258, Maker){}
-        ActionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ActionTable", 258,Maker){
+    class ActionTable : public Instruction {
+      public:
+        ActionTable()
+          : Instruction(-1, 258, nullptr) {}
+        ActionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ActionTable", 258, Maker) {}
+        ActionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {}
+        ActionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {
 
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
+            while (cnt < current_byte) {
 
-
-
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", short_bytes));//2
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-46
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-45
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-44
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-43
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-42
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-41
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-40
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-3F
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-3E
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-3D
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-3C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-38
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-34
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-30
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-2C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-28
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-24
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+                this->AddOperande(operande(addr, "short", short_bytes));                       // 2
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-46
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-45
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-44
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-43
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-42
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-41
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-40
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-3F
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-3E
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-3D
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-3C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-38
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-34
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-30
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-2C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-28
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-24
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
 
                 QByteArray str_ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str_));
-                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20-str_.size()-1);
-                operande fill_ = operande(addr,"fill", remaining_);
+                this->AddOperande(operande(addr, "string", str_));
+                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20 - str_.size() - 1);
+                operande fill_ = operande(addr, "fill", remaining_);
                 fill_.setBytesToFill(0x20);
                 this->AddOperande(fill_);
 
-
                 QByteArray str__ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str__));
-                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x30-str__.size()-1);
-                operande fill__ = operande(addr,"fill", remaining__);
+                this->AddOperande(operande(addr, "string", str__));
+                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x30 - str__.size() - 1);
+                operande fill__ = operande(addr, "fill", remaining__);
                 fill__.setBytesToFill(0x30);
                 this->AddOperande(fill__);
 
                 cnt++;
-          }
-
-
-        }
-
-
-    };
-    class AddCollision : public Instruction
-    {
-        public:
-        AddCollision():Instruction(-1,271,nullptr){}
-        AddCollision(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AddCollision", 271,Maker){}
-        AddCollision(int addr, Builder *Maker):Instruction(addr,"AddCollision", 271, Maker){}
-        AddCollision(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AddCollision", 271,Maker){
-
-
-            unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            int cnt = 0;
-            while(cnt < current_byte){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                cnt++;
-          }
-
-
-        }
-
-
-    };
-    class ConditionTable : public Instruction
-    {
-        public:
-        ConditionTable():Instruction(-1,272,nullptr){}
-        ConditionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ConditionTable", 272,Maker){}
-        ConditionTable(int addr, Builder *Maker):Instruction(addr,"ConditionTable", 272, Maker){}
-        ConditionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ConditionTable", 272,Maker){
-
-            unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            int cnt = 0;
-            while(cnt < current_byte){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//EBP-52
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-50
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-4C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-48
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-44
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-40
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-3C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-38
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-34
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-30
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-2C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-28
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-24
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-20
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-1C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-18
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-14
-                cnt++;
-          }
-
-
-        }
-
-
-    };
-    class AlgoTable : public Instruction //42d177
-    {
-        public:
-        AlgoTable():Instruction(-1,259,nullptr){}
-        AlgoTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AlgoTable", 259,Maker){}
-        AlgoTable(int addr, Builder *Maker):Instruction(addr,"AlgoTable", 259, Maker){}
-        AlgoTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AlgoTable", 259,Maker){
-            int cnt = 0;
-            unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//3
-            while(cnt < current_byte){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-
-                this->AddOperande(operande(addr,"short", short_bytes));
-
-
-                this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-                if (addr+0x20 > Maker->goal) return;
-                cnt++;
             }
-
-            //this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-
         }
     };
-    class WeaponAttTable : public Instruction
-    {
-        public:
-        WeaponAttTable():Instruction(-1,260,nullptr){}
-        WeaponAttTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"WeaponAttTable", 260,Maker){}
-        WeaponAttTable(int addr, Builder *Maker):Instruction(addr,"WeaponAttTable", 260, Maker){}
-        WeaponAttTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"WeaponAttTable", 260,Maker){
+    class AddCollision : public Instruction {
+      public:
+        AddCollision()
+          : Instruction(-1, 271, nullptr) {}
+        AddCollision(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AddCollision", 271, Maker) {}
+        AddCollision(int addr, Builder* Maker)
+          : Instruction(addr, "AddCollision", 271, Maker) {}
+        AddCollision(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AddCollision", 271, Maker) {
 
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class BreakTable : public Instruction
-    {
-        public:
-        BreakTable():Instruction(-1,261,nullptr){}
-        BreakTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BreakTable", 261,Maker){}
-        BreakTable(int addr, Builder *Maker):Instruction(addr,"BreakTable", 261, Maker){}
-        BreakTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BreakTable", 261,Maker){
-            int cnt = 0;
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//3
-            while(cnt < current_byte){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            int cnt = 0;
+            while (cnt < current_byte) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
                 cnt++;
             }
         }
     };
-    class SummonTable : public Instruction //140142002
-    {
-        public:
-        SummonTable():Instruction(-1,262,nullptr){}
-        SummonTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"SummonTable", 262,Maker){}
-        SummonTable(int addr, Builder *Maker):Instruction(addr,"SummonTable", 262, Maker){}
-        SummonTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"SummonTable", 262,Maker){
+    class ConditionTable : public Instruction {
+      public:
+        ConditionTable()
+          : Instruction(-1, 272, nullptr) {}
+        ConditionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ConditionTable", 272, Maker) {}
+        ConditionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ConditionTable", 272, Maker) {}
+        ConditionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ConditionTable", 272, Maker) {
 
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            while (cnt < current_byte) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // EBP-52
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-50
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-4C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-48
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-44
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-40
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-3C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-38
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-34
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-30
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-2C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-28
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-24
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-20
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-1C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-18
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-14
+                cnt++;
+            }
+        }
+    };
+    class AlgoTable
+      : public Instruction // 42d177
+    {
+      public:
+        AlgoTable()
+          : Instruction(-1, 259, nullptr) {}
+        AlgoTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AlgoTable", 259, Maker) {}
+        AlgoTable(int addr, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {}
+        AlgoTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {
+            int cnt = 0;
+            unsigned char current_byte = content[addr];
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // 3
+            while (cnt < current_byte) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+
+                this->AddOperande(operande(addr, "short", short_bytes));
+
+                this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1E)));
+                if (addr + 0x20 > Maker->goal) return;
+                cnt++;
+            }
+
+            // this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
+        }
+    };
+    class WeaponAttTable : public Instruction {
+      public:
+        WeaponAttTable()
+          : Instruction(-1, 260, nullptr) {}
+        WeaponAttTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int addr, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {
+
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class BreakTable : public Instruction {
+      public:
+        BreakTable()
+          : Instruction(-1, 261, nullptr) {}
+        BreakTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BreakTable", 261, Maker) {}
+        BreakTable(int addr, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {}
+        BreakTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {
+            int cnt = 0;
+            unsigned char current_byte = content[addr];
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // 3
+            while (cnt < current_byte) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                cnt++;
+            }
+        }
+    };
+    class SummonTable
+      : public Instruction // 140142002
+    {
+      public:
+        SummonTable()
+          : Instruction(-1, 262, nullptr) {}
+        SummonTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "SummonTable", 262, Maker) {}
+        SummonTable(int addr, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {}
+        SummonTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {
+
+            unsigned char current_byte = content[addr];
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            int cnt = 0;
+            while (cnt < current_byte) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 ushort shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0xFFFF) break;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
                 cnt++;
             }
-
         }
     };
-    class ReactionTable : public Instruction //140142002
+    class ReactionTable
+      : public Instruction // 140142002
     {
-        public:
-        ReactionTable():Instruction(-1,263,nullptr){}
-        ReactionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ReactionTable", 263,Maker){}
-        ReactionTable(int addr, Builder *Maker):Instruction(addr,"ReactionTable", 263, Maker){}
-        ReactionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ReactionTable", 263,Maker){
+      public:
+        ReactionTable()
+          : Instruction(-1, 263, nullptr) {}
+        ReactionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ReactionTable", 263, Maker) {}
+        ReactionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {}
+        ReactionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {
             int cnt = 0;
-            ushort current_shrt = ReadShortFromByteArray(addr,content);
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            ushort current_shrt = ReadShortFromByteArray(addr, content);
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            while(cnt < current_shrt){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            while (cnt < current_shrt) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
 
-                this->AddOperande(operande(addr,"short", short_bytes));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                this->AddOperande(operande(addr, "short", short_bytes));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                 cnt++;
             }
         }
     };
-    class PartTable : public Instruction //14019797c
+    class PartTable
+      : public Instruction // 14019797c
     {
-        public:
-        PartTable():Instruction(-1,264,nullptr){}
-        PartTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"PartTable", 264,Maker){}
-        PartTable(int addr, Builder *Maker):Instruction(addr,"PartTable", 264, Maker){}
-        PartTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"PartTable", 264,Maker){
+      public:
+        PartTable()
+          : Instruction(-1, 264, nullptr) {}
+        PartTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "PartTable", 264, Maker) {}
+        PartTable(int addr, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {}
+        PartTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
+            while (cnt < current_byte) {
 
-                QByteArray int_bytes = ReadSubByteArray(content, addr,4);
-                this->AddOperande(operande(addr,"int", int_bytes));
+                QByteArray int_bytes = ReadSubByteArray(content, addr, 4);
+                this->AddOperande(operande(addr, "int", int_bytes));
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 cnt++;
             }
-
         }
     };
 
-    class AnimeClipTable : public Instruction // from CS3
+    class AnimeClipTable
+      : public Instruction // from CS3
     {
-        public:
-        AnimeClipTable():Instruction(-1,265,nullptr){}
-        AnimeClipTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipTable", 265,Maker){}
-        AnimeClipTable(int addr, Builder *Maker):Instruction(addr,"AnimeClipTable", 265, Maker){}
-        AnimeClipTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipTable", 265,Maker){
+      public:
+        AnimeClipTable()
+          : Instruction(-1, 265, nullptr) {}
+        AnimeClipTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {
 
             int first_integer;
             first_integer = ReadIntegerFromByteArray(addr, content);
             std::vector<function>::iterator itt_current_fun = find_function_by_ID(Maker->FunctionsToParse, Maker->idx_current_fun);
-            while(first_integer != 0){
-                itt_current_fun->AddInstruction(std::make_shared<AnimeClipData>(addr, content,Maker));
+            while (first_integer != 0) {
+                itt_current_fun->AddInstruction(std::make_shared<AnimeClipData>(addr, content, Maker));
                 first_integer = ReadIntegerFromByteArray(addr, content);
-
             }
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class AnimeClipData : public Instruction
-    {
-        public:
-        AnimeClipData():Instruction(-1,273,nullptr){}
-        AnimeClipData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipData", 273,Maker){}
-        AnimeClipData(int addr, Builder *Maker):Instruction(addr,"AnimeClipData", 273, Maker){}
-        AnimeClipData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipData", 273,Maker){
+    class AnimeClipData : public Instruction {
+      public:
+        AnimeClipData()
+          : Instruction(-1, 273, nullptr) {}
+        AnimeClipData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipData", 273, Maker) {}
+        AnimeClipData(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipData", 273, Maker) {}
+        AnimeClipData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipData", 273, Maker) {
 
-
-                QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-                this->AddOperande(operande(addr,"int", first_integer_bytes));
-                QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
-                fill.setBytesToFill((0x20));
-                this->AddOperande(fill);
-                str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                fill = operande(addr,"fill", remaining);
-                fill.setBytesToFill((0x20));
-                this->AddOperande(fill);
-
-
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            QByteArray str = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", str));
+            QByteArray remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+            operande fill = operande(addr, "fill", remaining);
+            fill.setBytesToFill((0x20));
+            this->AddOperande(fill);
+            str = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", str));
+            remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+            fill = operande(addr, "fill", remaining);
+            fill.setBytesToFill((0x20));
+            this->AddOperande(fill);
         }
     };
-    class FieldMonsterData : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
+    class FieldMonsterData
+      : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
     {
-        public:
-        FieldMonsterData():Instruction(-1,266,nullptr){}
-        FieldMonsterData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 266,Maker){}
-        FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
-        FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
+      public:
+        FieldMonsterData()
+          : Instruction(-1, 266, nullptr) {}
+        FieldMonsterData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {
 
-
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FieldFollowData : public Instruction //
+    class FieldFollowData
+      : public Instruction //
     {
-        public:
-        FieldFollowData():Instruction(-1,267,nullptr){}
-        FieldFollowData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 267,Maker){}
-        FieldFollowData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 267, Maker){}
-        FieldFollowData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 267,Maker){
+      public:
+        FieldFollowData()
+          : Instruction(-1, 267, nullptr) {}
+        FieldFollowData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FC_autoX : public Instruction //
+    class FC_autoX
+      : public Instruction //
     {
-        public:
-        FC_autoX():Instruction(-1,268,nullptr){}
-        FC_autoX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FC_autoX", 268,Maker){}
-        FC_autoX(int addr, Builder *Maker):Instruction(addr,"FC_autoX", 268, Maker){}
-        FC_autoX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FC_autoX", 268,Maker){
+      public:
+        FC_autoX()
+          : Instruction(-1, 268, nullptr) {}
+        FC_autoX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FC_autoX", 268, Maker) {}
+        FC_autoX(int addr, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {}
+        FC_autoX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {
 
             QByteArray things = ReadStringSubByteArray(content, addr);
-            this->AddOperande(operande(addr,"string", things));
+            this->AddOperande(operande(addr, "string", things));
         }
     };
-    class BookData99 : public Instruction //
+    class BookData99
+      : public Instruction //
     {
-        public:
-        BookData99():Instruction(-1,269,nullptr){}
-        BookData99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookData99", 269,Maker){}
-        BookData99(int addr, Builder *Maker):Instruction(addr,"BookData99", 269, Maker){}
-        BookData99(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookData99", 269,Maker){
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+      public:
+        BookData99()
+          : Instruction(-1, 269, nullptr) {}
+        BookData99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookData99", 269, Maker) {}
+        BookData99(int addr, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {}
+        BookData99(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class BookDataX: public Instruction
-    {
-        public:
-        BookDataX():Instruction(-1,270,nullptr){}
-        BookDataX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookDataX", 270,Maker){}
-        BookDataX(int addr, Builder *Maker):Instruction(addr,"BookDataX", 270, Maker){}
-        BookDataX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookDataX", 270,Maker){
+    class BookDataX : public Instruction {
+      public:
+        BookDataX()
+          : Instruction(-1, 270, nullptr) {}
+        BookDataX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookDataX", 270, Maker) {}
+        BookDataX(int addr, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {}
+        BookDataX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             short control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));//3
-            if (control>0){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", control_short)); // 3
+            if (control > 0) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 QByteArray title = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", title));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-title.size()-1);
-                operande fill = operande(addr,"bytearray", remaining);
+                this->AddOperande(operande(addr, "string", title));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - title.size() - 1);
+                operande fill = operande(addr, "bytearray", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x12
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x14
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x16
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x18
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1E
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x20
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x22
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x24
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            }
-            else
-            {
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x12
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x14
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x16
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x18
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1A
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1C
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1E
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x20
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x22
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x24
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            } else {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
         }
     };
 
-
-    class OPCode0 : public Instruction
-    {
-        public:
-        OPCode0():Instruction(-1,0,nullptr){}
-        OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
-        OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
-            addr++;
-
-        }
-
-
-    };
-    class OPCode1 : public Instruction
-    {
-        public:
-        OPCode1():Instruction(-1,1,nullptr){}
-        OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
-        OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+    class OPCode0 : public Instruction {
+      public:
+        OPCode0()
+          : Instruction(-1, 0, nullptr) {}
+        OPCode0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Instruction 0", 0, Maker) {}
+        OPCode0(int addr, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {}
+        OPCode0(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {
             addr++;
         }
-
-
     };
-
-    class UI_OP13: public Instruction{
-    public:
-        UI_OP13():Instruction(-1,0x13,nullptr){}
-        UI_OP13(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x13,Maker){}
-        UI_OP13(int addr, Builder *Maker):Instruction(addr,"???",0x13,Maker){}
-        UI_OP13(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x13,Maker){
-        addr++;
-
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch ((unsigned char) control_byte[0])  {
-
-            case 0x00:{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x01:{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case 10:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0xb:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0xc:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-
-            case 0x26:
-            case 0xd:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0xe:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0xf:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x10:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x11:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x12:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x13:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x14:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x15:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x16:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x17:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x18:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x19:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1B:
-            case 0x1A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x20:
-            case 0x1F:
-            case 0x1E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x21:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x22:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-
-            case 0x23:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x24:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x25:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x27:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x28:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x29:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2B:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x30:
-            case 0x2F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x33:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x34:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x35:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x36:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x37:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x3B:
-            case 0x38:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x3A:
-            case 0x39:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x3C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x41:
-            case 0x3D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x3E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x3F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x40:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x44:
-            case 0x43:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x65:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                break;
-             }
-            case 0x68:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                break;
-             }
-            case 0x76:
-            case 0x69:
-            case 0x75:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                break;
-             }
-            case 0x6B:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-             }
-            case 0x6A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-             }
-            case 0x6C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-             }
-            case 0x70:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                break;
-             }
-            case 0x71:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-             }
-            case 0x72:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-             }
-            case 0x73:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-             }
-
-            case 0x32:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-             }
-            case 0x31:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-             }
-            default:{
-                qFatal("not analyzed yet");
-            }
-            }
-        }
-
-    };
-    //SCENARIO FILES INSTRUCTIONS
-    //0x05
-    class OPCode05: public Instruction{
-    public:
-        OPCode05():Instruction(-1,0x05,nullptr){}
-        OPCode05(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x05,Maker){}
-        OPCode05(int addr, Builder *Maker):Instruction(addr,"???",0x05,Maker){}
-        OPCode05(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x05,Maker){
+    class OPCode1 : public Instruction {
+      public:
+        OPCode1()
+          : Instruction(-1, 1, nullptr) {}
+        OPCode1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Return", 1, Maker) {}
+        OPCode1(int addr, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {}
+        OPCode1(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {
             addr++;
-            sub05(addr, content, this);
-
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr, 4)));
         }
     };
 
-    //0x02
-    class OPCode02: public Instruction{
-    public:
-        OPCode02():Instruction(-1,0x02,nullptr){}
-        OPCode02(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x02,Maker){}
-        OPCode02(int addr, Builder *Maker):Instruction(addr,"???",0x02,Maker){}
-        OPCode02(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x02,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-    //0x03
-    class OPCode03: public Instruction{
-    public:
-        OPCode03():Instruction(-1,0x03,nullptr){}
-        OPCode03(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x03,Maker){}
-        OPCode03(int addr, Builder *Maker):Instruction(addr,"???",0x03,Maker){}
-        OPCode03(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x03,Maker){
+    class UI_OP13 : public Instruction {
+      public:
+        UI_OP13()
+          : Instruction(-1, 0x13, nullptr) {}
+        UI_OP13(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x13, Maker) {}
+        UI_OP13(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {}
+        UI_OP13(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
 
-        }
-    };
-    //0x04
-    class OPCode04: public Instruction{
-        public:
-        OPCode04():Instruction(-1,0x04,nullptr){}
-        OPCode04(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x04,Maker){}
-        OPCode04(int addr, Builder *Maker):Instruction(addr,"???",0x04,Maker){}
-        OPCode04(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x04,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-    //0x06
-    class OPCode06: public Instruction{
-        public:
-            OPCode06():Instruction(-1,0x06,nullptr){}
-            OPCode06(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x06,Maker){}
-            OPCode06(int addr, Builder *Maker):Instruction(addr,"???",0x06,Maker){}
-            OPCode06(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x06,Maker){
-            addr++;
-            sub05(addr, content, this);
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
 
-            if ((unsigned char) control_byte[0] != 0){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
+                case 0x00: {
 
-                for (unsigned char i = 0; i<(unsigned char)control_byte[0]; i++){
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    break;
+                }
+                case 0x01: {
 
-                    this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
+                    break;
+                }
+                case 10: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0xb: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xc: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+
+                case 0x26:
+                case 0xd: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xe: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0xf: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x10: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x11: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x13: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x16: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x18: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x19: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1B:
+                case 0x1A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x20:
+                case 0x1F:
+                case 0x1E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x21: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x22: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+
+                case 0x23: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x24: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x25: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x27: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x28: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x29: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x30:
+                case 0x2F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x33: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x34: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x35: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x36: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x37: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x3B:
+                case 0x38: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x3A:
+                case 0x39: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x3C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x41:
+                case 0x3D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x3E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x3F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x40: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x44:
+                case 0x43: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x65: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x68: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x76:
+                case 0x69:
+                case 0x75: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x6B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x6A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x6C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x70: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x71: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x72: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x73: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+
+                case 0x32: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x31: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                default: {
+                    qFatal("not analyzed yet");
                 }
             }
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
-           }
-
-    };
-    //0x07
-    class OPCode07: public Instruction{
-    public:
-        OPCode07():Instruction(-1,0x07,nullptr){}
-        OPCode07(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x07,Maker){}
-        OPCode07(int addr, Builder *Maker):Instruction(addr,"???",0x07,Maker){}
-        OPCode07(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x07,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
         }
-
     };
-    //0x08
-    class OPCode08: public Instruction{
-    public:
-        OPCode08():Instruction(-1,0x08,nullptr){}
-        OPCode08(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x08,Maker){}
-        OPCode08(int addr, Builder *Maker):Instruction(addr,"???",0x08,Maker){}
-        OPCode08(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x08,Maker){
+    // SCENARIO FILES INSTRUCTIONS
+    // 0x05
+    class OPCode05 : public Instruction {
+      public:
+        OPCode05()
+          : Instruction(-1, 0x05, nullptr) {}
+        OPCode05(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x05, Maker) {}
+        OPCode05(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x05, Maker) {}
+        OPCode05(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x05, Maker) {
+            addr++;
+            sub05(addr, content, this);
+
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+
+    // 0x02
+    class OPCode02 : public Instruction {
+      public:
+        OPCode02()
+          : Instruction(-1, 0x02, nullptr) {}
+        OPCode02(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x02, Maker) {}
+        OPCode02(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x02, Maker) {}
+        OPCode02(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x02, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x03
+    class OPCode03 : public Instruction {
+      public:
+        OPCode03()
+          : Instruction(-1, 0x03, nullptr) {}
+        OPCode03(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x03, Maker) {}
+        OPCode03(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x03, Maker) {}
+        OPCode03(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x03, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x04
+    class OPCode04 : public Instruction {
+      public:
+        OPCode04()
+          : Instruction(-1, 0x04, nullptr) {}
+        OPCode04(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x04, Maker) {}
+        OPCode04(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x04, Maker) {}
+        OPCode04(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x04, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x06
+    class OPCode06 : public Instruction {
+      public:
+        OPCode06()
+          : Instruction(-1, 0x06, nullptr) {}
+        OPCode06(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x06, Maker) {}
+        OPCode06(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x06, Maker) {}
+        OPCode06(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x06, Maker) {
+            addr++;
+            sub05(addr, content, this);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            if ((unsigned char)control_byte[0] != 0) {
+
+                for (unsigned char i = 0; i < (unsigned char)control_byte[0]; i++) {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+                }
+            }
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x07
+    class OPCode07 : public Instruction {
+      public:
+        OPCode07()
+          : Instruction(-1, 0x07, nullptr) {}
+        OPCode07(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x07, Maker) {}
+        OPCode07(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x07, Maker) {}
+        OPCode07(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x07, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x08
+    class OPCode08 : public Instruction {
+      public:
+        OPCode08()
+          : Instruction(-1, 0x08, nullptr) {}
+        OPCode08(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x08, Maker) {}
+        OPCode08(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x08, Maker) {}
+        OPCode08(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x08, Maker) {
             addr++;
             sub05(addr, content, this);
         }
-
     };
-    //0x0A
-    class OPCode0A: public Instruction{
-    public:
-        OPCode0A():Instruction(-1,0x0A,nullptr){}
-        OPCode0A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0A,Maker){}
-        OPCode0A(int addr, Builder *Maker):Instruction(addr,"???",0x0A,Maker){}
-        OPCode0A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0A,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        sub05(addr, content, this);
-
-        }
-    };
-    //0x0C
-    class OPCode0C: public Instruction{
-    public:
-        OPCode0C():Instruction(-1,0x0C,nullptr){}
-        OPCode0C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0C,Maker){}
-        OPCode0C(int addr, Builder *Maker):Instruction(addr,"???",0x0C,Maker){}
-        OPCode0C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0C,Maker){
+    // 0x0A
+    class OPCode0A : public Instruction {
+      public:
+        OPCode0A()
+          : Instruction(-1, 0x0A, nullptr) {}
+        OPCode0A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0A, Maker) {}
+        OPCode0A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0A, Maker) {}
+        OPCode0A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x0D
-    class OPCode0D: public Instruction{
-    public:
-        OPCode0D():Instruction(-1,0x0D,nullptr){}
-        OPCode0D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0D,Maker){}
-        OPCode0D(int addr, Builder *Maker):Instruction(addr,"???",0x0D,Maker){}
-        OPCode0D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0D,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x0E
-    class OPCode0E: public Instruction{
-    public:
-        OPCode0E():Instruction(-1,0x0E,nullptr){}
-        OPCode0E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0E,Maker){}
-        OPCode0E(int addr, Builder *Maker):Instruction(addr,"???",0x0E,Maker){}
-        OPCode0E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0E,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-       }
-    };
-    //0x0F
-    class OPCode0F: public Instruction{
-    public:
-        OPCode0F():Instruction(-1,0x0F,nullptr){}
-        OPCode0F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0F,Maker){}
-        OPCode0F(int addr, Builder *Maker):Instruction(addr,"???",0x0F,Maker){}
-        OPCode0F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x10
-    class OPCode10: public Instruction{
-    public:
-        OPCode10():Instruction(-1,0x10,nullptr){}
-        OPCode10(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x10,Maker){}
-        OPCode10(int addr, Builder *Maker):Instruction(addr,"???",0x10,Maker){}
-        OPCode10(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x10,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x11
-    class OPCode11: public Instruction{
-    public:
-        OPCode11():Instruction(-1,0x11,nullptr){}
-        OPCode11(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x11,Maker){}
-        OPCode11(int addr, Builder *Maker):Instruction(addr,"???",0x11,Maker){}
-        OPCode11(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x11,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x12
-    class OPCode12: public Instruction{
-    public:
-        OPCode12():Instruction(-1,0x12,nullptr){}
-        OPCode12(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x12,Maker){}
-        OPCode12(int addr, Builder *Maker):Instruction(addr,"???",0x12,Maker){}
-        OPCode12(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x12,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             sub05(addr, content, this);
         }
     };
-    //0x13
-    class OPCode13: public Instruction{
-    public:
-        OPCode13():Instruction(-1,0x13,nullptr){}
-        OPCode13(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x13,Maker){}
-        OPCode13(int addr, Builder *Maker):Instruction(addr,"???",0x13,Maker){}
-        OPCode13(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x13,Maker){
+    // 0x0C
+    class OPCode0C : public Instruction {
+      public:
+        OPCode0C()
+          : Instruction(-1, 0x0C, nullptr) {}
+        OPCode0C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0C, Maker) {}
+        OPCode0C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0C, Maker) {}
+        OPCode0C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0C, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//i think this one is the id of the battle function it triggers
-
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-
-    //0x14
-    class OPCode14: public Instruction{
-    public:
-        OPCode14():Instruction(-1,0x14,nullptr){}
-        OPCode14(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x14,Maker){}
-        OPCode14(int addr, Builder *Maker):Instruction(addr,"???",0x14,Maker){}
-        OPCode14(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x14,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-
-    };
-    //0x15
-    class OPCode15: public Instruction{
-    public:
-        OPCode15():Instruction(-1,0x15,nullptr){}
-        OPCode15(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x15,Maker){}
-        OPCode15(int addr, Builder *Maker):Instruction(addr,"???",0x15,Maker){}
-        OPCode15(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x15,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x16
-    class OPCode16: public Instruction{
-    public:
-        OPCode16():Instruction(-1,0x16,nullptr){}
-        OPCode16(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x16,Maker){}
-        OPCode16(int addr, Builder *Maker):Instruction(addr,"???",0x16,Maker){}
-        OPCode16(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x16,Maker){
+    // 0x0D
+    class OPCode0D : public Instruction {
+      public:
+        OPCode0D()
+          : Instruction(-1, 0x0D, nullptr) {}
+        OPCode0D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0D, Maker) {}
+        OPCode0D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {}
+        OPCode0D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-          }
-
-    };
-    //0x17
-    class OPCode17: public Instruction{
-    public:
-        OPCode17():Instruction(-1,0x17,nullptr){}
-        OPCode17(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x17,Maker){}
-        OPCode17(int addr, Builder *Maker):Instruction(addr,"???",0x17,Maker){}
-        OPCode17(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x17,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x18
-    class OPCode18: public Instruction{
-    public:
-        OPCode18():Instruction(-1,0x18,nullptr){}
-        OPCode18(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x18,Maker){}
-        OPCode18(int addr, Builder *Maker):Instruction(addr,"???",0x18,Maker){}
-        OPCode18(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x18,Maker){
+    // 0x0E
+    class OPCode0E : public Instruction {
+      public:
+        OPCode0E()
+          : Instruction(-1, 0x0E, nullptr) {}
+        OPCode0E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0E, Maker) {}
+        OPCode0E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0E, Maker) {}
+        OPCode0E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            //this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0x0F
+    class OPCode0F : public Instruction {
+      public:
+        OPCode0F()
+          : Instruction(-1, 0x0F, nullptr) {}
+        OPCode0F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0F, Maker) {}
+        OPCode0F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0F, Maker) {}
+        OPCode0F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x10
+    class OPCode10 : public Instruction {
+      public:
+        OPCode10()
+          : Instruction(-1, 0x10, nullptr) {}
+        OPCode10(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x10, Maker) {}
+        OPCode10(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {}
+        OPCode10(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x11
+    class OPCode11 : public Instruction {
+      public:
+        OPCode11()
+          : Instruction(-1, 0x11, nullptr) {}
+        OPCode11(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x11, Maker) {}
+        OPCode11(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {}
+        OPCode11(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x12
+    class OPCode12 : public Instruction {
+      public:
+        OPCode12()
+          : Instruction(-1, 0x12, nullptr) {}
+        OPCode12(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x12, Maker) {}
+        OPCode12(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {}
+        OPCode12(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            sub05(addr, content, this);
+        }
+    };
+    // 0x13
+    class OPCode13 : public Instruction {
+      public:
+        OPCode13()
+          : Instruction(-1, 0x13, nullptr) {}
+        OPCode13(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x13, Maker) {}
+        OPCode13(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {}
+        OPCode13(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(
+              operande(addr, "int", ReadSubByteArray(content, addr, 4))); // i think this one is the id of the battle function it triggers
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+
+    // 0x14
+    class OPCode14 : public Instruction {
+      public:
+        OPCode14()
+          : Instruction(-1, 0x14, nullptr) {}
+        OPCode14(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x14, Maker) {}
+        OPCode14(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {}
+        OPCode14(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x15
+    class OPCode15 : public Instruction {
+      public:
+        OPCode15()
+          : Instruction(-1, 0x15, nullptr) {}
+        OPCode15(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x15, Maker) {}
+        OPCode15(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {}
+        OPCode15(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x16
+    class OPCode16 : public Instruction {
+      public:
+        OPCode16()
+          : Instruction(-1, 0x16, nullptr) {}
+        OPCode16(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x16, Maker) {}
+        OPCode16(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {}
+        OPCode16(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x17
+    class OPCode17 : public Instruction {
+      public:
+        OPCode17()
+          : Instruction(-1, 0x17, nullptr) {}
+        OPCode17(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x17, Maker) {}
+        OPCode17(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {}
+        OPCode17(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x18
+    class OPCode18 : public Instruction {
+      public:
+        OPCode18()
+          : Instruction(-1, 0x18, nullptr) {}
+        OPCode18(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x18, Maker) {}
+        OPCode18(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {}
+        OPCode18(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            // this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
             reading_dialog(addr, content, this);
         }
-
     };
-    //0x19
-    class OPCode19: public Instruction{
-    public:
-        OPCode19():Instruction(-1,0x19,nullptr){}
-        OPCode19(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x19,Maker){}
-        OPCode19(int addr, Builder *Maker):Instruction(addr,"???",0x19,Maker){}
-        OPCode19(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x19,Maker){
+    // 0x19
+    class OPCode19 : public Instruction {
+      public:
+        OPCode19()
+          : Instruction(-1, 0x19, nullptr) {}
+        OPCode19(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x19, Maker) {}
+        OPCode19(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x19, Maker) {}
+        OPCode19(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x19, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x05:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
             }
         }
-
     };
-    //0x1A
-    class OPCode1A: public Instruction{
-    public:
-        OPCode1A():Instruction(-1,0x1A,nullptr){}
-        OPCode1A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1A,Maker){}
-        OPCode1A(int addr, Builder *Maker):Instruction(addr,"???",0x1A,Maker){}
-        OPCode1A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1A,Maker){
+    // 0x1A
+    class OPCode1A : public Instruction {
+      public:
+        OPCode1A()
+          : Instruction(-1, 0x1A, nullptr) {}
+        OPCode1A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1A, Maker) {}
+        OPCode1A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {}
+        OPCode1A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             reading_dialog(addr, content, this);
         }
-
     };
-    //0x1B
-    class OPCode1B: public Instruction{
-    public:
-        OPCode1B():Instruction(-1,0x1B,nullptr){}
-        OPCode1B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1B,Maker){}
-        OPCode1B(int addr, Builder *Maker):Instruction(addr,"???",0x1B,Maker){}
-        OPCode1B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1B,Maker){
+    // 0x1B
+    class OPCode1B : public Instruction {
+      public:
+        OPCode1B()
+          : Instruction(-1, 0x1B, nullptr) {}
+        OPCode1B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1B, Maker) {}
+        OPCode1B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1B, Maker) {}
+        OPCode1B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x1C
-    class OPCode1C: public Instruction{
-    public:
-        OPCode1C():Instruction(-1,0x1C,nullptr){}
-        OPCode1C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1C,Maker){}
-        OPCode1C(int addr, Builder *Maker):Instruction(addr,"???",0x1C,Maker){}
-        OPCode1C(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
+    // 0x1C
+    class OPCode1C : public Instruction {
+      public:
+        OPCode1C()
+          : Instruction(-1, 0x1C, nullptr) {}
+        OPCode1C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1C, Maker) {}
+        OPCode1C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1C, Maker) {}
+        OPCode1C(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1C, Maker) {
             addr++;
         }
-
     };
-    //0x1D
-    class OPCode1D: public Instruction{
-    public:
-        OPCode1D():Instruction(-1,0x1D,nullptr){}
-        OPCode1D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1D,Maker){}
-        OPCode1D(int addr, Builder *Maker):Instruction(addr,"???",0x1D,Maker){}
-        OPCode1D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1D,Maker){
+    // 0x1D
+    class OPCode1D : public Instruction {
+      public:
+        OPCode1D()
+          : Instruction(-1, 0x1D, nullptr) {}
+        OPCode1D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1D, Maker) {}
+        OPCode1D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {}
+        OPCode1D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x1E
-    class OPCode1E: public Instruction{
-    public:
-        OPCode1E():Instruction(-1,0x1E,nullptr){}
-        OPCode1E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1E,Maker){}
-        OPCode1E(int addr, Builder *Maker):Instruction(addr,"???",0x1E,Maker){}
-        OPCode1E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1E,Maker){
+    // 0x1E
+    class OPCode1E : public Instruction {
+      public:
+        OPCode1E()
+          : Instruction(-1, 0x1E, nullptr) {}
+        OPCode1E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1E, Maker) {}
+        OPCode1E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {}
+        OPCode1E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x1F
-    class OPCode1F: public Instruction{
-    public:
-        OPCode1F():Instruction(-1,0x1F,nullptr){}
-        OPCode1F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1F,Maker){}
-        OPCode1F(int addr, Builder *Maker):Instruction(addr,"???",0x1F,Maker){}
-        OPCode1F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1F,Maker){
+    // 0x1F
+    class OPCode1F : public Instruction {
+      public:
+        OPCode1F()
+          : Instruction(-1, 0x1F, nullptr) {}
+        OPCode1F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1F, Maker) {}
+        OPCode1F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {}
+        OPCode1F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
-        if ((unsigned char)control_byte2[0]<0x4){
-            switch((unsigned char)control_byte[0]) {
+            this->AddOperande(operande(addr, "byte", control_byte2));
+            if ((unsigned char)control_byte2[0] < 0x4) {
+                switch ((unsigned char)control_byte[0]) {
 
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
+                    case 0x00: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    }
 
-                case 0x01:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                }
-                case 0x04:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                }
-                case 0x05:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x07:
-                case 0x06:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    case 0x01: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x02: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    }
+                    case 0x04: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    }
+                    case 0x05: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x07:
+                    case 0x06: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    break;
+                        break;
+                    }
+                    case 0x08: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    }
+                    case 0x09: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    }
+                    case 0x0B: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x0C: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
                 }
-                case 0x08:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x09:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x0B:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-
-
             }
         }
-
-        }
-
     };
-    //0x20
-    class OPCode20: public Instruction{
-        public:
-        OPCode20():Instruction(-1,0x20,nullptr){}
-        OPCode20(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x20,Maker){}
-        OPCode20(int addr, Builder *Maker):Instruction(addr,"???",0x20,Maker){}
-        OPCode20(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x20,Maker){
+    // 0x20
+    class OPCode20 : public Instruction {
+      public:
+        OPCode20()
+          : Instruction(-1, 0x20, nullptr) {}
+        OPCode20(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x20, Maker) {}
+        OPCode20(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {}
+        OPCode20(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch ((unsigned char)control_byte[0])  {
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x02:
                 case 0x01:
                 case 0x03:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-
             }
         }
-
-
     };
-    //0x21
-    class OPCode21: public Instruction{
-        public:
-        OPCode21():Instruction(-1,0x21,nullptr){}
-        OPCode21(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x21,Maker){}
-        OPCode21(int addr, Builder *Maker):Instruction(addr,"???",0x21,Maker){}
-        OPCode21(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x21,Maker){
+    // 0x21
+    class OPCode21 : public Instruction {
+      public:
+        OPCode21()
+          : Instruction(-1, 0x21, nullptr) {}
+        OPCode21(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x21, Maker) {}
+        OPCode21(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {}
+        OPCode21(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            switch ((unsigned char)control_byte[0])  {
-                case 0x00:
-                {
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
-                case 0x01:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-
             }
         }
-
     };
-    //0x22
-    class OPCode22: public Instruction{
-        public:
-        OPCode22():Instruction(-1,0x22,nullptr){}
-        OPCode22(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x22,Maker){}
-        OPCode22(int addr, Builder *Maker):Instruction(addr,"???",0x22,Maker){}
-        OPCode22(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x22,Maker){
+    // 0x22
+    class OPCode22 : public Instruction {
+      public:
+        OPCode22()
+          : Instruction(-1, 0x22, nullptr) {}
+        OPCode22(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x22, Maker) {}
+        OPCode22(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {}
+        OPCode22(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x23
-    class OPCode23: public Instruction{
-        public:
-        OPCode23():Instruction(-1,0x23,nullptr){}
-        OPCode23(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x23,Maker){}
-        OPCode23(int addr, Builder *Maker):Instruction(addr,"???",0x23,Maker){}
-        OPCode23(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x23,Maker){
+    // 0x23
+    class OPCode23 : public Instruction {
+      public:
+        OPCode23()
+          : Instruction(-1, 0x23, nullptr) {}
+        OPCode23(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x23, Maker) {}
+        OPCode23(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {}
+        OPCode23(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x24
-    class OPCode24: public Instruction{
-        public:
-        OPCode24():Instruction(-1,0x24,nullptr){}
-        OPCode24(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x24,Maker){}
-        OPCode24(int addr, Builder *Maker):Instruction(addr,"???",0x24,Maker){}
-        OPCode24(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x24,Maker){
+    // 0x24
+    class OPCode24 : public Instruction {
+      public:
+        OPCode24()
+          : Instruction(-1, 0x24, nullptr) {}
+        OPCode24(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x24, Maker) {}
+        OPCode24(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {}
+        OPCode24(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {
             addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
                 case 1:
                 case 2:
                 case 4:
                 case 10:
                 case 0xB:
-                case 5:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 5: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
                 case 7:
-                case 6:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 6: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 9:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 9: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0xE:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0xE: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
-                case 8:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 8: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
-
             }
-
-
         }
-
     };
-    //0x25
-    class OPCode25: public Instruction{
-        public:
-        OPCode25():Instruction(-1,0x25,nullptr){}
-        OPCode25(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x25,Maker){}
-        OPCode25(int addr, Builder *Maker):Instruction(addr,"???",0x25,Maker){}
-        OPCode25(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x25,Maker){
+    // 0x25
+    class OPCode25 : public Instruction {
+      public:
+        OPCode25()
+          : Instruction(-1, 0x25, nullptr) {}
+        OPCode25(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x25, Maker) {}
+        OPCode25(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {}
+        OPCode25(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x26
-    class OPCode26: public Instruction{
-        public:
-        OPCode26():Instruction(-1,0x26,nullptr){}
-        OPCode26(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x26,Maker){}
-        OPCode26(int addr, Builder *Maker):Instruction(addr,"???",0x26,Maker){}
-        OPCode26(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
+    // 0x26
+    class OPCode26 : public Instruction {
+      public:
+        OPCode26()
+          : Instruction(-1, 0x26, nullptr) {}
+        OPCode26(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x26, Maker) {}
+        OPCode26(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {}
+        OPCode26(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x27
-    class OPCode27: public Instruction{
-        public:
-        OPCode27():Instruction(-1,0x27,nullptr){}
-        OPCode27(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x27,Maker){}
-        OPCode27(int addr, Builder *Maker):Instruction(addr,"???",0x27,Maker){}
-        OPCode27(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x27,Maker){
+    // 0x27
+    class OPCode27 : public Instruction {
+      public:
+        OPCode27()
+          : Instruction(-1, 0x27, nullptr) {}
+        OPCode27(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x27, Maker) {}
+        OPCode27(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {}
+        OPCode27(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 }
-                case 0x0B:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//0x03
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//0x05
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//0x07
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//0x09
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x03
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x05
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x07
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x09
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
 
-                case 0x0F:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
                 case 0x17:
-                case 0x12:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x13:
-                case 0x14:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x14: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x15:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x15: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 }
                 case 0xD:
-                case 0xE:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0xE: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
                     break;
                 }
                 case 0x11:
-                case 0x10:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x10: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-                case 0x16:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x16: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x18:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x18: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x19:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x19: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
-                case 0x1A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x1A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
             }
         }
-
     };
-    //0x28
-    class OPCode28: public Instruction{ //This one I copy pasted from CS1 hoping that it works; also checked few of them and they all fit
-    public:
-        OPCode28():Instruction(-1,0x28,nullptr){}
-        OPCode28(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x28,Maker){}
-        OPCode28(int addr, Builder *Maker):Instruction(addr,"???",0x28,Maker){}
-        OPCode28(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x28,Maker){
+    // 0x28
+    class OPCode28 : public Instruction { // This one I copy pasted from CS1 hoping that it works; also checked few of
+                                          // them and they all fit
+      public:
+        OPCode28()
+          : Instruction(-1, 0x28, nullptr) {}
+        OPCode28(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x28, Maker) {}
+        OPCode28(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {}
+        OPCode28(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case '\b':
+                case 0x06:
+                case 0x04: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case '\a':
+                case 0x05: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 'm':
+                case 'l':
+                case 'k':
+                case 'f':
+                case 'e':
+                case 'c':
+                case '\x1C':
+
+                case '\x14':
+                case '\r':
+                case '\x10':
+                case 'H':
+                case ']':
+                case '\t':
+                case '^':
+                case '_':
+                case '`':
+                case 's':
+                case 't':
+                case 'u':
+                case 'y': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '\x0f':
+                case '\n': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '\f':
+                case '4':
+                case 'Z':
+                case '\v': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '\x0e': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+
+                case '\x11':
+                case 'z': {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case '\x12': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    for (int i = 0; i < 8; i++)
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case '\x13': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '\x15': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '2': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case '5': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case '6': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case '7': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case '<': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 'F': {
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 'P': {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case '[': {
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '\\': {
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case 'a': {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 'd': {
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 'n': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '~':
+                case 'q': {
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case 'r': {
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case '{': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 'i': {
+
+                    break;
+                }
+                case 'j': {
+
+                    break;
+                }
+                case 0x51: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x91: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x1D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x27: {
+
+                    break;
+                }
+                case 0x26: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x28: {
+
+                    break;
+                }
+                case 0x29: {
+
+                    break;
+                }
+                case 0x2A: {
+
+                    break;
+                }
+                case 0x1A: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x19: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 'b': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x97: {
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x76: {
+
+                    break;
+                }
+                case 0x8D:
+                case 0x8C:
+                case 0x8B: {
+                    break;
+                }
+                case 0x47: {
+                    break;
+                }
+                case 0x53: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x68: {
+
+                    break;
+                }
+                case 0x92: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x93: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x96:
+                case 0x95: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x9D: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0xA0: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xA1: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xA2: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xA3: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xA4: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xA5: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x87: {
+
+                    break;
+                }
+                case 0x2B: {
+
+                    break;
+                }
+                case 0x9A: {
+
+                    break;
+                }
+                case 0x33: {
+
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x67: {
+
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x6F: {
+
+                    break;
+                }
+                case 0x70: {
+
+                    break;
+                }
+                case 0x83: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x85: {
+
+                    break;
+                }
+                case 0x86: {
+
+                    break;
+                }
+                case 0x1B: {
+
+                    break;
+                }
+                case 0x98: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x9E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x16: {
+
+                    break;
+                }
+                case 0x2E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x7F: {
+
+                    break;
+                }
+                case 0x89: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+
+                case 0x8A: {
+                    break;
+                }
+                case 0x52: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x1F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x18: {
+
+                    break;
+                }
+                case 0x1E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x2C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x2D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x20: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x22: {
+                    break;
+                }
+                case 0x24: {
+                    break;
+                }
+                case 0x25: {
+                    break;
+                }
+                case 0x23: {
+                    break;
+                }
+                case 0x21: {
+                    break;
+                }
+                case '\x17': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x8F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x8E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x99: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x9B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x9C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x7D: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x49: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x88: {
+
+                    break;
+                }
+                case 0x80: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x9F: {
+
+                    break;
+                }
+                case 0x81: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x82: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                default: {
+                    qFatal("not analyzed yet");
+                }
             }
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case '\b':
-            case 0x06:
-            case 0x04:
-            {
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case '\a':
-            case 0x05:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 'm':
-            case 'l':
-            case 'k':
-            case 'f':
-            case 'e':
-            case 'c':
-            case '\x1C':
-
-
-
-            case '\x14':
-            case '\r':
-            case '\x10':
-            case 'H':
-            case ']':
-            case '\t':
-            case '^':
-            case '_':
-            case '`':
-            case 's':
-            case 't':
-            case 'u':
-            case 'y':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '\x0f':
-            case '\n':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '\f':
-            case '4':
-            case 'Z':
-            case '\v':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '\x0e':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-
-            case '\x11':
-            case 'z':{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case '\x12':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                for (int i = 0; i<8; i++) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case '\x13':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '\x15':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '2':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case '5':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case '6':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case '7':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case '<':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 'F':{
-
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 'P':{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case '[':{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '\\':{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case 'a':{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 'd':{
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 'n':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '~':
-            case 'q':{
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case 'r':{
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case '{':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 'i':{
-
-
-
-                break;
-            }
-            case 'j':{
-
-
-                break;
-            }
-            case 0x51:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x91:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x1D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x27:{
-
-
-                break;
-            }
-            case 0x26:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x28:{
-
-                break;
-            }
-            case 0x29:{
-
-                break;
-            }
-            case 0x2A:{
-
-                break;
-            }
-            case 0x1A:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x19:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 'b':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0x97:{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0x76:{
-
-                break;
-            }
-            case 0x8D:
-            case 0x8C:
-            case 0x8B:{
-                break;
-            }
-            case 0x47:{
-                break;
-            }
-            case 0x53:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                break;
-            }
-            case 0x68:{
-
-                break;
-            }
-            case 0x92:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x93:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x96:
-            case 0x95:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x9D:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0xA0:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0xA1:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0xA2:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0xA3:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0xA4:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0xA5:{
-                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x87:{
-
-                break;
-            }
-            case 0x2B:{
-
-                break;
-            }
-            case 0x9A:{
-
-                break;
-            }
-            case 0x33:{
-
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x67:{
-
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x6F:{
-
-                break;
-            }
-            case 0x70:{
-
-                break;
-            }
-            case 0x83:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x85:{
-
-                break;
-            }
-            case 0x86:{
-
-                break;
-            }
-            case 0x1B:{
-
-                break;
-            }
-            case 0x98:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x9E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                break;
-            }
-            case 0x16:{
-
-                break;
-            }
-            case 0x2E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x7F:{
-
-                break;
-            }
-            case 0x89:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-
-            case 0x8A:{
-                break;
-            }
-            case 0x52:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0x1F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x18:{
-
-                break;
-            }
-            case 0x1E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                break;
-            }
-            case 0x2C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x2D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x20:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x22:{
-                break;
-            }
-            case 0x24:{
-                break;
-            }
-            case 0x25:{
-                break;
-            }
-            case 0x23:{
-                break;
-            }
-            case 0x21:{
-                break;
-            }
-            case '\x17':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x8F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x8E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x99:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0x9B:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x9C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x7D:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0x49:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x88:{
-
-                break;
-            }
-            case 0x80:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0x9F:{
-
-                break;
-            }
-            case 0x81:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x82:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                break;
-            }
-            default:{
-                qFatal("not analyzed yet");
-            }
-
         }
-
-
-        }
-
     };
-    //0x29
-    class OPCode29: public Instruction{
-    public:
-        OPCode29():Instruction(-1,0x29,nullptr){}
-        OPCode29(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x29,Maker){}
-        OPCode29(int addr, Builder *Maker):Instruction(addr,"???",0x29,Maker){}
-        OPCode29(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x29,Maker){
+    // 0x29
+    class OPCode29 : public Instruction {
+      public:
+        OPCode29()
+          : Instruction(-1, 0x29, nullptr) {}
+        OPCode29(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x29, Maker) {}
+        OPCode29(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {}
+        OPCode29(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x2A
-    class OPCode2A: public Instruction{
-    public:
-        OPCode2A():Instruction(-1,0x2A,nullptr){}
-        OPCode2A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2A,Maker){}
-        OPCode2A(int addr, Builder *Maker):Instruction(addr,"???",0x2A,Maker){}
-        OPCode2A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2A,Maker){
+    // 0x2A
+    class OPCode2A : public Instruction {
+      public:
+        OPCode2A()
+          : Instruction(-1, 0x2A, nullptr) {}
+        OPCode2A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2A, Maker) {}
+        OPCode2A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {}
+        OPCode2A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x2B
-    class OPCode2B: public Instruction{
-    public:
-        OPCode2B():Instruction(-1,0x2B,nullptr){}
-        OPCode2B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2B,Maker){}
-        OPCode2B(int addr, Builder *Maker):Instruction(addr,"???",0x2B,Maker){}
-        OPCode2B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2B,Maker){
+    // 0x2B
+    class OPCode2B : public Instruction {
+      public:
+        OPCode2B()
+          : Instruction(-1, 0x2B, nullptr) {}
+        OPCode2B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2B, Maker) {}
+        OPCode2B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {}
+        OPCode2B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
 
-    //0x2C
-    class OPCode2C: public Instruction{
-    public:
-        OPCode2C():Instruction(-1,0x2C,nullptr){}
-        OPCode2C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2C,Maker){}
-        OPCode2C(int addr, Builder *Maker):Instruction(addr,"???",0x2C,Maker){}
-        OPCode2C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2C,Maker){
+    // 0x2C
+    class OPCode2C : public Instruction {
+      public:
+        OPCode2C()
+          : Instruction(-1, 0x2C, nullptr) {}
+        OPCode2C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2C, Maker) {}
+        OPCode2C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {}
+        OPCode2C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x2D
-    class OPCode2D: public Instruction{
-    public:
-        OPCode2D():Instruction(-1,0x2D,nullptr){}
-        OPCode2D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2D,Maker){}
-        OPCode2D(int addr, Builder *Maker):Instruction(addr,"???",0x2D,Maker){}
-        OPCode2D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2D,Maker){
+    // 0x2D
+    class OPCode2D : public Instruction {
+      public:
+        OPCode2D()
+          : Instruction(-1, 0x2D, nullptr) {}
+        OPCode2D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2D, Maker) {}
+        OPCode2D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {}
+        OPCode2D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            case 0x02:{
+                case 0x02: {
 
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x14:
-            case 0x03:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x14:
+                case 0x03: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x04:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x05:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x07:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x08:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x09:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x0B:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0D:
-            case 0x0C:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0E:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x07: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x08: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x09: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0D:
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case 0x11:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x12:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    break;
+                }
+                case 0x11: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
-            }
-            case 0x13:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    break;
+                }
+                case 0x13: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x16: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x18:
+                case 0x19: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x1A: {
 
-                break;
-            }
-            case 0x15:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x16:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x17:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x18:
-            case 0x19:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x1A:{
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x1B: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                break;
-            }
-            case 0x1B:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    break;
+                }
+                case 0x1E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                break;
+                    break;
+                }
             }
-            case 0x1E:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                break;
-            }
-
         }
-        }
-
     };
-    //0x2E
-    class OPCode2E: public Instruction{
-    public:
-        OPCode2E():Instruction(-1,0x2E,nullptr){}
-        OPCode2E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2E,Maker){}
-        OPCode2E(int addr, Builder *Maker):Instruction(addr,"???",0x2E,Maker){}
-        OPCode2E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2E,Maker){
+    // 0x2E
+    class OPCode2E : public Instruction {
+      public:
+        OPCode2E()
+          : Instruction(-1, 0x2E, nullptr) {}
+        OPCode2E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2E, Maker) {}
+        OPCode2E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {}
+        OPCode2E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x2F
-    class OPCode2F: public Instruction{
-    public:
-        OPCode2F():Instruction(-1,0x2F,nullptr){}
-        OPCode2F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2F,Maker){}
-        OPCode2F(int addr, Builder *Maker):Instruction(addr,"???",0x2F,Maker){}
-        OPCode2F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2F,Maker){
+    // 0x2F
+    class OPCode2F : public Instruction {
+      public:
+        OPCode2F()
+          : Instruction(-1, 0x2F, nullptr) {}
+        OPCode2F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2F, Maker) {}
+        OPCode2F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {}
+        OPCode2F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x30
-    class OPCode30: public Instruction{
-    public:
-        OPCode30():Instruction(-1,0x30,nullptr){}
-        OPCode30(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x30,Maker){}
-        OPCode30(int addr, Builder *Maker):Instruction(addr,"???",0x30,Maker){}
-        OPCode30(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x30,Maker){
+    // 0x30
+    class OPCode30 : public Instruction {
+      public:
+        OPCode30()
+          : Instruction(-1, 0x30, nullptr) {}
+        OPCode30(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x30, Maker) {}
+        OPCode30(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {}
+        OPCode30(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x30
-    class OPCode31: public Instruction{
-    public:
-        OPCode31():Instruction(-1,0x31,nullptr){}
-        OPCode31(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x31,Maker){}
-        OPCode31(int addr, Builder *Maker):Instruction(addr,"???",0x31,Maker){}
-        OPCode31(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x31,Maker){
+    // 0x30
+    class OPCode31 : public Instruction {
+      public:
+        OPCode31()
+          : Instruction(-1, 0x31, nullptr) {}
+        OPCode31(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x31, Maker) {}
+        OPCode31(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {}
+        OPCode31(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0:{
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 1:{
+                case 1: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 2:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 2: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                default:{
+                default: {
                     break;
                 }
-                case 3:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 3: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 4:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 4: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 5:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 5: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 6:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 6: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
             }
         }
     };
-    //0x32
-    class OPCode32: public Instruction{
-    public:
-        OPCode32():Instruction(-1,0x32,nullptr){}
-        OPCode32(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x32,Maker){}
-        OPCode32(int addr, Builder *Maker):Instruction(addr,"???",0x32,Maker){}
-        OPCode32(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x32,Maker){
+    // 0x32
+    class OPCode32 : public Instruction {
+      public:
+        OPCode32()
+          : Instruction(-1, 0x32, nullptr) {}
+        OPCode32(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x32, Maker) {}
+        OPCode32(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {}
+        OPCode32(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
+            if ((unsigned char)control_byte[0] > 0xFD) {
+                if ((unsigned char)control_byte[0] == 0xFE) {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                } else if ((unsigned char)control_byte[0] == 0xFF) {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                }
 
-        if ((unsigned char)control_byte[0] > 0xFD){
-            if ((unsigned char)control_byte[0] == 0xFE){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                return;
             }
-            else if ((unsigned char)control_byte[0] == 0xFF){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            }
 
-            return;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                case 0x32: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x33:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 4:
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 0xb:
+                case 0xc:
+                case 0xd:
+                case 0xe:
+                case 0xf:
+                case 0x10:
+                case 0x11:
+                case 0x12:
+                case 0x13:
+                case 0x14:
+                case 0x15:
+                case 0x16:
+                case 0x17:
+                case 0x18:
+                case 0x19:
+                case 0x1a:
+                case 0x1b:
+                case 0x1c:
+                case 0x1d:
+                case 0x1e:
+                case 0x1f:
+                case 0x20:
+                case 0x21:
+                case 0x22:
+                case 0x23:
+                case 0x24:
+                case 0x25:
+                case 0x26:
+                case 0x27:
+                case 0x28:
+                case 0x29:
+                case 0x2a:
+                case 0x2b:
+                case 0x2c:
+                case 0x2d:
+                case 0x2e:
+                case 0x2f:
+                case 0x30:
+                case 0x31:
+                case 0x36:
+                case 0x38:
+                case 0x3b:
+                case 0x3c:
+                case 0x3d:
+                case 0x3e:
+                case 0x3f:
+                case 0x40:
+                case 0x41:
+                case 0x42:
+                case 0x43:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x47:
+                case 0x48:
+                case 0x49:
+                case 0x4a:
+                case 0x4b:
+                case 0x4c:
+                case 0x4d:
+                case 0x4e:
+                case 0x4f:
+                case 0x50:
+                case 0x51:
+                case 0x52:
+                case 0x53:
+                case 0x54:
+                case 0x55:
+                case 0x56:
+                case 0x57:
+                case 0x58:
+                case 0x59:
+                case 0x5a:
+                case 0x5b:
+                case 0x5c:
+                case 0x5d:
+                case 0x5e:
+                case 0x5f:
+                case 0x60:
+                case 0x61:
+                case 0x62:
+                case 99:
+                case 0x66:
+                case 0x67:
+                case 0x68:
+                case 0x69:
+                case 0x6a:
+                case 0x6b:
+                case 0x6c:
+                case 0x6d:
+                case 0x6e:
+                case 0x6f:
+                case 0x70:
+                case 0x71:
+                case 0x72:
+                case 0x73:
+                case 0x74:
+                case 0x75:
+                case 0x76:
+                case 0x77:
+                case 0x78:
+                case 0x79:
+                case 0x7a:
+                case 0x7b:
+                case 0x7c:
+                case 0x7d:
+                case 0x7e:
+                case 0x7f:
+                case 0x80:
+                case 0x81:
+                case 0x82:
+                case 0x83:
+                case 0x84:
+                case 0x85:
+                case 0x86:
+                case 0x87:
+                case 0x88:
+                case 0x89:
+                case 0x8a:
+                case 0x8b:
+                case 0x8c:
+                case 0x8d:
+                case 0x8e:
+                case 0x8f:
+                case 0x90:
+                case 0x91:
+                case 0x92:
+                case 0x93:
+                case 0x94:
+                case 0x95:
+                    break;
+                case 0x96:
+                case 0x39:
+                case 0x05:
+                case 0x37:
+                case 0x34:
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x35:
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x3A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 100: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x65: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+
+                default: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                }
+            }
         }
-
-
-
-        switch ((unsigned char)control_byte[0])  {
-            case 0x00:
-            case 0x32:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-                break;
-            }
-            case 0x33:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 4:
-            case 6:
-            case 7:
-            case 8:
-            case 9:
-            case 10:
-            case 0xb:
-            case 0xc:
-            case 0xd:
-            case 0xe:
-            case 0xf:
-            case 0x10:
-            case 0x11:
-            case 0x12:
-            case 0x13:
-            case 0x14:
-            case 0x15:
-            case 0x16:
-            case 0x17:
-            case 0x18:
-            case 0x19:
-            case 0x1a:
-            case 0x1b:
-            case 0x1c:
-            case 0x1d:
-            case 0x1e:
-            case 0x1f:
-            case 0x20:
-            case 0x21:
-            case 0x22:
-            case 0x23:
-            case 0x24:
-            case 0x25:
-            case 0x26:
-            case 0x27:
-            case 0x28:
-            case 0x29:
-            case 0x2a:
-            case 0x2b:
-            case 0x2c:
-            case 0x2d:
-            case 0x2e:
-            case 0x2f:
-            case 0x30:
-            case 0x31:
-            case 0x36:
-            case 0x38:
-            case 0x3b:
-            case 0x3c:
-            case 0x3d:
-            case 0x3e:
-            case 0x3f:
-            case 0x40:
-            case 0x41:
-            case 0x42:
-            case 0x43:
-            case 0x44:
-            case 0x45:
-            case 0x46:
-            case 0x47:
-            case 0x48:
-            case 0x49:
-            case 0x4a:
-            case 0x4b:
-            case 0x4c:
-            case 0x4d:
-            case 0x4e:
-            case 0x4f:
-            case 0x50:
-            case 0x51:
-            case 0x52:
-            case 0x53:
-            case 0x54:
-            case 0x55:
-            case 0x56:
-            case 0x57:
-            case 0x58:
-            case 0x59:
-            case 0x5a:
-            case 0x5b:
-            case 0x5c:
-            case 0x5d:
-            case 0x5e:
-            case 0x5f:
-            case 0x60:
-            case 0x61:
-            case 0x62:
-            case 99:
-            case 0x66:
-            case 0x67:
-            case 0x68:
-            case 0x69:
-            case 0x6a:
-            case 0x6b:
-            case 0x6c:
-            case 0x6d:
-            case 0x6e:
-            case 0x6f:
-            case 0x70:
-            case 0x71:
-            case 0x72:
-            case 0x73:
-            case 0x74:
-            case 0x75:
-            case 0x76:
-            case 0x77:
-            case 0x78:
-            case 0x79:
-            case 0x7a:
-            case 0x7b:
-            case 0x7c:
-            case 0x7d:
-            case 0x7e:
-            case 0x7f:
-            case 0x80:
-            case 0x81:
-            case 0x82:
-            case 0x83:
-            case 0x84:
-            case 0x85:
-            case 0x86:
-            case 0x87:
-            case 0x88:
-            case 0x89:
-            case 0x8a:
-            case 0x8b:
-            case 0x8c:
-            case 0x8d:
-            case 0x8e:
-            case 0x8f:
-            case 0x90:
-            case 0x91:
-            case 0x92:
-            case 0x93:
-            case 0x94:
-            case 0x95:
-                break;
-            case 0x96:
-            case 0x39:
-            case 0x05:
-            case 0x37:
-            case 0x34:
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x35:
-            case 0x03:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x3A:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 100:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x65:
-            {
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-
-            default:{this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));}
-
-
-        }
-        }
-
     };
-    //0x33
-    class OPCode33: public Instruction{
-    public:
-        OPCode33():Instruction(-1,0x33,nullptr){}
-        OPCode33(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x33,Maker){}
-        OPCode33(int addr, Builder *Maker):Instruction(addr,"???",0x33,Maker){}
-        OPCode33(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x33,Maker){
+    // 0x33
+    class OPCode33 : public Instruction {
+      public:
+        OPCode33()
+          : Instruction(-1, 0x33, nullptr) {}
+        OPCode33(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x33, Maker) {}
+        OPCode33(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {}
+        OPCode33(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x01:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                break;
-            }
-            case 0x04:
-            {
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                break;
+                    break;
+                }
             }
         }
+    };
+    // 0x34
+    class OPCode34 : public Instruction {
+      public:
+        OPCode34()
+          : Instruction(-1, 0x34, nullptr) {}
+        OPCode34(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x34, Maker) {}
+        OPCode34(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {}
+        OPCode34(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x34
-    class OPCode34: public Instruction{
-    public:
-        OPCode34():Instruction(-1,0x34,nullptr){}
-        OPCode34(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x34,Maker){}
-        OPCode34(int addr, Builder *Maker):Instruction(addr,"???",0x34,Maker){}
-        OPCode34(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x34,Maker){
+    // 0x35
+    class OPCode35 : public Instruction {
+      public:
+        OPCode35()
+          : Instruction(-1, 0x35, nullptr) {}
+        OPCode35(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x35, Maker) {}
+        OPCode35(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {}
+        OPCode35(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
-    //0x35
-    class OPCode35: public Instruction{
-    public:
-        OPCode35():Instruction(-1,0x35,nullptr){}
-        OPCode35(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x35,Maker){}
-        OPCode35(int addr, Builder *Maker):Instruction(addr,"???",0x35,Maker){}
-        OPCode35(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x35,Maker){
+    // 0x36
+    class OPCode36 : public Instruction {
+      public:
+        OPCode36()
+          : Instruction(-1, 0x36, nullptr) {}
+        OPCode36(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x36, Maker) {}
+        OPCode36(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {}
+        OPCode36(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-       }
-
-    };
-    //0x36
-    class OPCode36: public Instruction{
-    public:
-        OPCode36():Instruction(-1,0x36,nullptr){}
-        OPCode36(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x36,Maker){}
-        OPCode36(int addr, Builder *Maker):Instruction(addr,"???",0x36,Maker){}
-        OPCode36(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x36,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x37
-    class OPCode37: public Instruction{
-    public:
-        OPCode37():Instruction(-1,0x37,nullptr){}
-        OPCode37(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x37,Maker){}
-        OPCode37(int addr, Builder *Maker):Instruction(addr,"???",0x37,Maker){}
-        OPCode37(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x37,Maker){
+    // 0x37
+    class OPCode37 : public Instruction {
+      public:
+        OPCode37()
+          : Instruction(-1, 0x37, nullptr) {}
+        OPCode37(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x37, Maker) {}
+        OPCode37(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {}
+        OPCode37(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
             short second_arg = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            if ((second_arg == -0x1fe)||(second_arg == -0x1fd)){
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            if ((second_arg == -0x1fe) || (second_arg == -0x1fd)) {
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
             }
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            if (second_arg == -0x1fc){
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            if (second_arg == -0x1fc) {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
         }
-
     };
-    //0x38
-    class OPCode38: public Instruction{
-    public:
-        OPCode38():Instruction(-1,0x38,nullptr){}
-        OPCode38(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x38,Maker){}
-        OPCode38(int addr, Builder *Maker):Instruction(addr,"???",0x38,Maker){}
-        OPCode38(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x38,Maker){
+    // 0x38
+    class OPCode38 : public Instruction {
+      public:
+        OPCode38()
+          : Instruction(-1, 0x38, nullptr) {}
+        OPCode38(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x38, Maker) {}
+        OPCode38(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {}
+        OPCode38(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x39
-    class OPCode39: public Instruction{
-    public:
-        OPCode39():Instruction(-1,0x39,nullptr){}
-        OPCode39(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x39,Maker){}
-        OPCode39(int addr, Builder *Maker):Instruction(addr,"???",0x39,Maker){}
-        OPCode39(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x39,Maker){
+    // 0x39
+    class OPCode39 : public Instruction {
+      public:
+        OPCode39()
+          : Instruction(-1, 0x39, nullptr) {}
+        OPCode39(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x39, Maker) {}
+        OPCode39(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {}
+        OPCode39(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-       }
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
     };
-    //0x3A
-    class OPCode3A: public Instruction{
-    public:
-        OPCode3A():Instruction(-1,0x3A,nullptr){}
-        OPCode3A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3A,Maker){}
-        OPCode3A(int addr, Builder *Maker):Instruction(addr,"???",0x3A,Maker){}
-        OPCode3A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3A,Maker){
+    // 0x3A
+    class OPCode3A : public Instruction {
+      public:
+        OPCode3A()
+          : Instruction(-1, 0x3A, nullptr) {}
+        OPCode3A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3A, Maker) {}
+        OPCode3A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {}
+        OPCode3A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            if ((code != 0xC)&&(code != 0x5)&&(code != 0x69)&&(code != 0xA)&&(code != 0xB)&&(code != 0xFF)&&(code != 0xFE)){
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            if ((code != 0xC) && (code != 0x5) && (code != 0x69) && (code != 0xA) && (code != 0xB) && (code != 0xFF) && (code != 0xFE)) {
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
             }
-       }
-
-    };
-    //0x3B
-    class OPCode3B: public Instruction{
-    public:
-        OPCode3B():Instruction(-1,0x3B,nullptr){}
-        OPCode3B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3B,Maker){}
-        OPCode3B(int addr, Builder *Maker):Instruction(addr,"???",0x3B,Maker){}
-        OPCode3B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3B,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
-
     };
-    //0x3C
-    class OPCode3C: public Instruction{
-    public:
-        OPCode3C():Instruction(-1,0x3C,nullptr){}
-        OPCode3C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3C,Maker){}
-        OPCode3C(int addr, Builder *Maker):Instruction(addr,"???",0x3C,Maker){}
-        OPCode3C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3C,Maker){
+    // 0x3B
+    class OPCode3B : public Instruction {
+      public:
+        OPCode3B()
+          : Instruction(-1, 0x3B, nullptr) {}
+        OPCode3B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3B, Maker) {}
+        OPCode3B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {}
+        OPCode3B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x3D
-    static int FUN_00644350(ushort first_two_bytes){
+    // 0x3C
+    class OPCode3C : public Instruction {
+      public:
+        OPCode3C()
+          : Instruction(-1, 0x3C, nullptr) {}
+        OPCode3C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3C, Maker) {}
+        OPCode3C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {}
+        OPCode3C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x3D
+    static int FUN_00644350(ushort first_two_bytes) {
         if (first_two_bytes < 0x10) {
-          return 0;
+            return 0;
         }
         if (first_two_bytes == 0xFFFD) return 0;
         return 1;
     }
 
-    class OPCode3D: public Instruction{
-        public:
-        OPCode3D():Instruction(-1,0x3D,nullptr){}
-        OPCode3D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3D,Maker){}
-        OPCode3D(int addr, Builder *Maker):Instruction(addr,"???",0x3D,Maker){}
-        OPCode3D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3D,Maker){
+    class OPCode3D : public Instruction {
+      public:
+        OPCode3D()
+          : Instruction(-1, 0x3D, nullptr) {}
+        OPCode3D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3D, Maker) {}
+        OPCode3D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {}
+        OPCode3D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
             QByteArray control_short2 = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short2));
+            this->AddOperande(operande(addr, "short", control_short2));
             QByteArray control_short3 = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short3));
+            this->AddOperande(operande(addr, "short", control_short3));
             ushort short1 = ReadShortFromByteArray(0, control_short);
             ushort short2 = ReadShortFromByteArray(0, control_short2);
 
             int var2 = FUN_00644350(short1);
             int var3 = FUN_00644350(short2);
             if (((var2 == 0) || (var3 == 0)) || (var2 == var3)) {
-                if (short2 == 0xFFFF){
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                if (short2 == 0xFFFF) {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                 }
             }
-
         }
-
     };
-    //0x3E
-    class OPCode3E: public Instruction{
-    public:
-        OPCode3E():Instruction(-1,0x3E,nullptr){}
-        OPCode3E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3E,Maker){}
-        OPCode3E(int addr, Builder *Maker):Instruction(addr,"???",0x3E,Maker){}
-        OPCode3E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3E,Maker){
+    // 0x3E
+    class OPCode3E : public Instruction {
+      public:
+        OPCode3E()
+          : Instruction(-1, 0x3E, nullptr) {}
+        OPCode3E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3E, Maker) {}
+        OPCode3E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {}
+        OPCode3E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x3F
-    class OPCode3F: public Instruction{
-    public:
-        OPCode3F():Instruction(-1,0x3F,nullptr){}
-        OPCode3F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3F,Maker){}
-        OPCode3F(int addr, Builder *Maker):Instruction(addr,"???",0x3F,Maker){}
-        OPCode3F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3F,Maker){
+    // 0x3F
+    class OPCode3F : public Instruction {
+      public:
+        OPCode3F()
+          : Instruction(-1, 0x3F, nullptr) {}
+        OPCode3F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3F, Maker) {}
+        OPCode3F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {}
+        OPCode3F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x40
-    class OPCode40: public Instruction{
-    public:
-        OPCode40():Instruction(-1,0x40,nullptr){}
-        OPCode40(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x40,Maker){}
-        OPCode40(int addr, Builder *Maker):Instruction(addr,"???",0x40,Maker){}
-        OPCode40(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x40,Maker){
+    // 0x40
+    class OPCode40 : public Instruction {
+      public:
+        OPCode40()
+          : Instruction(-1, 0x40, nullptr) {}
+        OPCode40(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x40, Maker) {}
+        OPCode40(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {}
+        OPCode40(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x09:
                 case 0x0A:
                 case 0x0B:
@@ -4024,775 +4429,880 @@ class CS2Builder : public Builder
                 case 0x04:
                 case 0x10:
                 case 0x13:
-                case 0x00:{
+                case 0x00: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x08:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x08: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x0D:{
-                    for (int i = 0; i < 0x18; i++) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x0D: {
+                    for (int i = 0; i < 0x18; i++)
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x15:
-                case 0x11:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x11: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-
+            }
         }
-        }
-
     };
-    //0x41
-    class OPCode41: public Instruction{
-    public:
-        OPCode41():Instruction(-1,0x41,nullptr){}
-        OPCode41(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x41,Maker){}
-        OPCode41(int addr, Builder *Maker):Instruction(addr,"???",0x41,Maker){}
-        OPCode41(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x41,Maker){
+    // 0x41
+    class OPCode41 : public Instruction {
+      public:
+        OPCode41()
+          : Instruction(-1, 0x41, nullptr) {}
+        OPCode41(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x41, Maker) {}
+        OPCode41(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x41, Maker) {}
+        OPCode41(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x41, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x42
-    class OPCode42: public Instruction{
-    public:
-        OPCode42():Instruction(-1,0x42,nullptr){}
-        OPCode42(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x42,Maker){}
-        OPCode42(int addr, Builder *Maker):Instruction(addr,"???",0x42,Maker){}
-        OPCode42(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x42,Maker){
+    // 0x42
+    class OPCode42 : public Instruction {
+      public:
+        OPCode42()
+          : Instruction(-1, 0x42, nullptr) {}
+        OPCode42(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x42, Maker) {}
+        OPCode42(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {}
+        OPCode42(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
 
-    //0x43
-    class OPCode43: public Instruction{
-    public:
-        OPCode43():Instruction(-1,0x43,nullptr){}
-        OPCode43(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x43,Maker){}
-        OPCode43(int addr, Builder *Maker):Instruction(addr,"???",0x43,Maker){}
-        OPCode43(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x43,Maker){
+    // 0x43
+    class OPCode43 : public Instruction {
+      public:
+        OPCode43()
+          : Instruction(-1, 0x43, nullptr) {}
+        OPCode43(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x43, Maker) {}
+        OPCode43(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {}
+        OPCode43(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
 
-    //0x44
-    class OPCode44: public Instruction{
-    public:
-        OPCode44():Instruction(-1,0x44,nullptr){}
-        OPCode44(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x44,Maker){}
-        OPCode44(int addr, Builder *Maker):Instruction(addr,"???",0x44,Maker){}
-        OPCode44(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x44,Maker){
+    // 0x44
+    class OPCode44 : public Instruction {
+      public:
+        OPCode44()
+          : Instruction(-1, 0x44, nullptr) {}
+        OPCode44(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x44, Maker) {}
+        OPCode44(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x44, Maker) {}
+        OPCode44(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x44, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x45
-    class OPCode45: public Instruction{
-    public:
-        OPCode45():Instruction(-1,0x45,nullptr){}
-        OPCode45(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x45,Maker){}
-        OPCode45(int addr, Builder *Maker):Instruction(addr,"???",0x45,Maker){}
-        OPCode45(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x45,Maker){
+    // 0x45
+    class OPCode45 : public Instruction {
+      public:
+        OPCode45()
+          : Instruction(-1, 0x45, nullptr) {}
+        OPCode45(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x45, Maker) {}
+        OPCode45(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x45, Maker) {}
+        OPCode45(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x45, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
 
-                case 0x00:{
+                case 0x00: {
 
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x03:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x03: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
                 case 0x04:
-                case 0x05:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;}
-
-
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
             }
         }
-
     };
-    //0x46
-    class OPCode46: public Instruction{
-    public:
-        OPCode46():Instruction(-1,0x46,nullptr){}
-        OPCode46(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x46,Maker){}
-        OPCode46(int addr, Builder *Maker):Instruction(addr,"???",0x46,Maker){}
-        OPCode46(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x46,Maker){
+    // 0x46
+    class OPCode46 : public Instruction {
+      public:
+        OPCode46()
+          : Instruction(-1, 0x46, nullptr) {}
+        OPCode46(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x46, Maker) {}
+        OPCode46(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x46, Maker) {}
+        OPCode46(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x46, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    //0x47
-    class OPCode47: public Instruction{
-    public:
-        OPCode47():Instruction(-1,0x47,nullptr){}
-        OPCode47(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x47,Maker){}
-        OPCode47(int addr, Builder *Maker):Instruction(addr,"???",0x47,Maker){}
-        OPCode47(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x47,Maker){
+    // 0x47
+    class OPCode47 : public Instruction {
+      public:
+        OPCode47()
+          : Instruction(-1, 0x47, nullptr) {}
+        OPCode47(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x47, Maker) {}
+        OPCode47(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {}
+        OPCode47(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x48
-    class OPCode48: public Instruction{
-    public:
-        OPCode48():Instruction(-1,0x48,nullptr){}
-        OPCode48(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x48,Maker){}
-        OPCode48(int addr, Builder *Maker):Instruction(addr,"???",0x48,Maker){}
-        OPCode48(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x48,Maker){
+    // 0x48
+    class OPCode48 : public Instruction {
+      public:
+        OPCode48()
+          : Instruction(-1, 0x48, nullptr) {}
+        OPCode48(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x48, Maker) {}
+        OPCode48(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {}
+        OPCode48(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x49
-    class OPCode49: public Instruction{
-    public:
-        OPCode49():Instruction(-1,0x49,nullptr){}
-        OPCode49(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x49,Maker){}
-        OPCode49(int addr, Builder *Maker):Instruction(addr,"???",0x49,Maker){}
-        OPCode49(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x49,Maker){
+    // 0x49
+    class OPCode49 : public Instruction {
+      public:
+        OPCode49()
+          : Instruction(-1, 0x49, nullptr) {}
+        OPCode49(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x49, Maker) {}
+        OPCode49(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x49, Maker) {}
+        OPCode49(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x49, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-           }
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
     };
-    //0x4A
-    class OPCode4A: public Instruction{
-    public:
-        OPCode4A():Instruction(-1,0x4A,nullptr){}
-        OPCode4A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4A,Maker){}
-        OPCode4A(int addr, Builder *Maker):Instruction(addr,"???",0x4A,Maker){}
-        OPCode4A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4A,Maker){
+    // 0x4A
+    class OPCode4A : public Instruction {
+      public:
+        OPCode4A()
+          : Instruction(-1, 0x4A, nullptr) {}
+        OPCode4A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4A, Maker) {}
+        OPCode4A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4A, Maker) {}
+        OPCode4A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4A, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            case 0x0A:
-            case 0x05:
-            case 0x06:
-            case 0x04:
-            case 0x03:
-            case 0x02:
-            case 0x01:
-            case 0x00:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '\r':{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x0A:
+                case 0x05:
+                case 0x06:
+                case 0x04:
+                case 0x03:
+                case 0x02:
+                case 0x01:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '\r': {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x14:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
-            }
-            case 0x15:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
+                    break;
+                }
+                case 0xE: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
-                break;
-            }
-            case 0xE:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x18: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x19: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                break;
-            }
-            case 0x17:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x18:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x19:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x1C: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                break;
-            }
-            case 0x1C:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '!': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '(':
+                case '$':
+                case '#':
+                case '\v':
+                case '3': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '&': {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '!':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '(':
-            case '$':
-            case '#':
-            case '\v':
-            case '3':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '&':{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case ')': {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
-            }
-            case ')':{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    break;
+                }
+                case '+': {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
-            }
-            case '+':{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    break;
+                }
+                case '4':
+                case '0':
+                case ',': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case '4':
-            case '0':
-            case ',':{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    break;
+                }
+                case '5': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                break;
-            }
-            case '5':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case '7': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case '8': {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case '7':{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case '8':{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    break;
+                }
+                case '9': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
+                    break;
+                }
+                case ':': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case ';': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '<': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '=': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case '>': {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 'D':
+                case 'B':
+                case '@': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
             }
-            case '9':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case ':':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case ';':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '<':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '=':{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case '>':{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 'D':
-            case 'B':
-            case '@':{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-
         }
-        }
-
     };
-    //0x4A
-    class OPCode4B: public Instruction{
-    public:
-        OPCode4B():Instruction(-1,0x4B,nullptr){}
-        OPCode4B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4B,Maker){}
-        OPCode4B(int addr, Builder *Maker):Instruction(addr,"???",0x4B,Maker){}
-        OPCode4B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4B,Maker){
+    // 0x4A
+    class OPCode4B : public Instruction {
+      public:
+        OPCode4B()
+          : Instruction(-1, 0x4B, nullptr) {}
+        OPCode4B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4B, Maker) {}
+        OPCode4B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4B, Maker) {}
+        OPCode4B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x4B
-    class OPCode4C: public Instruction{
-    public:
-        OPCode4C():Instruction(-1,0x4C,nullptr){}
-        OPCode4C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4C,Maker){}
-        OPCode4C(int addr, Builder *Maker):Instruction(addr,"???",0x4C,Maker){}
-        OPCode4C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4C,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x4D
-    class OPCode4D: public Instruction{
-    public:
-        OPCode4D():Instruction(-1,0x4D,nullptr){}
-        OPCode4D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4D,Maker){}
-        OPCode4D(int addr, Builder *Maker):Instruction(addr,"???",0x4D,Maker){}
-        OPCode4D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4D,Maker){
+    // 0x4B
+    class OPCode4C : public Instruction {
+      public:
+        OPCode4C()
+          : Instruction(-1, 0x4C, nullptr) {}
+        OPCode4C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4C, Maker) {}
+        OPCode4C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4C, Maker) {}
+        OPCode4C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4C, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-        }
-
-    };
-    //0x4E
-    class OPCode4E: public Instruction{
-    public:
-        OPCode4E():Instruction(-1,0x4E,nullptr){}
-        OPCode4E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4E,Maker){}
-        OPCode4E(int addr, Builder *Maker):Instruction(addr,"???",0x4E,Maker){}
-        OPCode4E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4E,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-    };
-    //0x4F
-    class OPCode4F: public Instruction{
-    public:
-        OPCode4F():Instruction(-1,0x4F,nullptr){}
-        OPCode4F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4F,Maker){}
-        OPCode4F(int addr, Builder *Maker):Instruction(addr,"???",0x4F,Maker){}
-        OPCode4F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-    };
-    //0x50
-    class OPCode50: public Instruction{
-    public:
-        OPCode50():Instruction(-1,0x50,nullptr){}
-        OPCode50(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x50,Maker){}
-        OPCode50(int addr, Builder *Maker):Instruction(addr,"???",0x50,Maker){}
-        OPCode50(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x50,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x51
-    class OPCode51: public Instruction{
-    public:
-        OPCode51():Instruction(-1,0x51,nullptr){}
-        OPCode51(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x51,Maker){}
-        OPCode51(int addr, Builder *Maker):Instruction(addr,"???",0x51,Maker){}
-        OPCode51(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x51,Maker){
+    // 0x4D
+    class OPCode4D : public Instruction {
+      public:
+        OPCode4D()
+          : Instruction(-1, 0x4D, nullptr) {}
+        OPCode4D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4D, Maker) {}
+        OPCode4D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4D, Maker) {}
+        OPCode4D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0x4E
+    class OPCode4E : public Instruction {
+      public:
+        OPCode4E()
+          : Instruction(-1, 0x4E, nullptr) {}
+        OPCode4E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4E, Maker) {}
+        OPCode4E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4E, Maker) {}
+        OPCode4E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0x4F
+    class OPCode4F : public Instruction {
+      public:
+        OPCode4F()
+          : Instruction(-1, 0x4F, nullptr) {}
+        OPCode4F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4F, Maker) {}
+        OPCode4F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4F, Maker) {}
+        OPCode4F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0x50
+    class OPCode50 : public Instruction {
+      public:
+        OPCode50()
+          : Instruction(-1, 0x50, nullptr) {}
+        OPCode50(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x50, Maker) {}
+        OPCode50(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x50, Maker) {}
+        OPCode50(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x50, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x51
+    class OPCode51 : public Instruction {
+      public:
+        OPCode51()
+          : Instruction(-1, 0x51, nullptr) {}
+        OPCode51(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x51, Maker) {}
+        OPCode51(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x51, Maker) {}
+        OPCode51(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x51, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
             sub05(addr, content, this);
-       }
-
-    };
-    //0x52
-    class OPCode52: public Instruction{
-        public:
-            OPCode52():Instruction(-1,0x52,nullptr){}
-            OPCode52(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x52,Maker){}
-            OPCode52(int addr, Builder *Maker):Instruction(addr,"???",0x52,Maker){}
-            OPCode52(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x52,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            }
-
-    };
-    //0x53
-    class OPCode53: public Instruction{
-    public:
-        OPCode53():Instruction(-1,0x53,nullptr){}
-        OPCode53(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x53,Maker){}
-        OPCode53(int addr, Builder *Maker):Instruction(addr,"???",0x53,Maker){}
-        OPCode53(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x53,Maker){
-            addr++;
-
-
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x54
-    class OPCode54: public Instruction{
-    public:
-        OPCode54():Instruction(-1,0x54,nullptr){}
-        OPCode54(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x54,Maker){}
-        OPCode54(int addr, Builder *Maker):Instruction(addr,"???",0x54,Maker){}
-        OPCode54(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x54,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x56
-    class OPCode56: public Instruction{
-    public:
-        OPCode56():Instruction(-1,0x56,nullptr){}
-        OPCode56(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x56,Maker){}
-        OPCode56(int addr, Builder *Maker):Instruction(addr,"???",0x56,Maker){}
-        OPCode56(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x56,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-       }
-
-    };
-    //0x57
-    class OPCode57: public Instruction{
-    public:
-        OPCode57():Instruction(-1,0x57,nullptr){}
-        OPCode57(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x57,Maker){}
-        OPCode57(int addr, Builder *Maker):Instruction(addr,"???",0x57,Maker){}
-        OPCode57(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x57,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
     };
-    //0x58
-    class OPCode58: public Instruction{
-    public:
-        OPCode58():Instruction(-1,0x58,nullptr){}
-        OPCode58(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x58,Maker){}
-        OPCode58(int addr, Builder *Maker):Instruction(addr,"???",0x58,Maker){}
-        OPCode58(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x58,Maker){
+    // 0x52
+    class OPCode52 : public Instruction {
+      public:
+        OPCode52()
+          : Instruction(-1, 0x52, nullptr) {}
+        OPCode52(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x52, Maker) {}
+        OPCode52(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x52, Maker) {}
+        OPCode52(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x52, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x53
+    class OPCode53 : public Instruction {
+      public:
+        OPCode53()
+          : Instruction(-1, 0x53, nullptr) {}
+        OPCode53(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x53, Maker) {}
+        OPCode53(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x53, Maker) {}
+        OPCode53(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x53, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x54
+    class OPCode54 : public Instruction {
+      public:
+        OPCode54()
+          : Instruction(-1, 0x54, nullptr) {}
+        OPCode54(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x54, Maker) {}
+        OPCode54(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x54, Maker) {}
+        OPCode54(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x54, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x56
+    class OPCode56 : public Instruction {
+      public:
+        OPCode56()
+          : Instruction(-1, 0x56, nullptr) {}
+        OPCode56(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x56, Maker) {}
+        OPCode56(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x56, Maker) {}
+        OPCode56(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x56, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x57
+    class OPCode57 : public Instruction {
+      public:
+        OPCode57()
+          : Instruction(-1, 0x57, nullptr) {}
+        OPCode57(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x57, Maker) {}
+        OPCode57(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x57, Maker) {}
+        OPCode57(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x57, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x58
+    class OPCode58 : public Instruction {
+      public:
+        OPCode58()
+          : Instruction(-1, 0x58, nullptr) {}
+        OPCode58(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x58, Maker) {}
+        OPCode58(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x58, Maker) {}
+        OPCode58(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x58, Maker) {
             addr++;
         }
-
     };
-    //0x59
-    class OPCode59: public Instruction{
-    public:
-        OPCode59():Instruction(-1,0x59,nullptr){}
-        OPCode59(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x59,Maker){}
-        OPCode59(int addr, Builder *Maker):Instruction(addr,"???",0x59,Maker){}
-        OPCode59(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x59,Maker){
+    // 0x59
+    class OPCode59 : public Instruction {
+      public:
+        OPCode59()
+          : Instruction(-1, 0x59, nullptr) {}
+        OPCode59(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x59, Maker) {}
+        OPCode59(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x59, Maker) {}
+        OPCode59(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x59, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x59
+    // 0x59
     /*class OPCode59: public Instruction{
     public:
         OPCode59():Instruction(-1,0x59,nullptr){}
-        OPCode59(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x59,Maker){}
-        OPCode59(int addr, Builder *Maker):Instruction(addr,"???",0x59,Maker){}
-        OPCode59(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x59,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode59(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x59,Maker){} OPCode59(int addr, Builder *Maker):Instruction(addr,"???",0x59,Maker){} OPCode59(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x59,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2)));
 
         }
 
     };*/
-    //0x5B
-    class OPCode5B: public Instruction{
-    public:
-        OPCode5B():Instruction(-1,0x5B,nullptr){}
-        OPCode5B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5B,Maker){}
-        OPCode5B(int addr, Builder *Maker):Instruction(addr,"???",0x5B,Maker){}
-        OPCode5B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5B,Maker){
+    // 0x5B
+    class OPCode5B : public Instruction {
+      public:
+        OPCode5B()
+          : Instruction(-1, 0x5B, nullptr) {}
+        OPCode5B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5B, Maker) {}
+        OPCode5B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5B, Maker) {}
+        OPCode5B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x5C
-    class OPCode5C: public Instruction{
-    public:
-        OPCode5C():Instruction(-1,0x5C,nullptr){}
-        OPCode5C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5C,Maker){}
-        OPCode5C(int addr, Builder *Maker):Instruction(addr,"???",0x5C,Maker){}
-        OPCode5C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5C,Maker){
+    // 0x5C
+    class OPCode5C : public Instruction {
+      public:
+        OPCode5C()
+          : Instruction(-1, 0x5C, nullptr) {}
+        OPCode5C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5C, Maker) {}
+        OPCode5C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5C, Maker) {}
+        OPCode5C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5C, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x06:
                 case 0x04:
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
             }
         }
-
     };
-    //0x5D
-    class OPCode5D: public Instruction{
-    public:
-        OPCode5D():Instruction(-1,0x5D,nullptr){}
-        OPCode5D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5D,Maker){}
-        OPCode5D(int addr, Builder *Maker):Instruction(addr,"???",0x5D,Maker){}
-        OPCode5D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5D,Maker){
+    // 0x5D
+    class OPCode5D : public Instruction {
+      public:
+        OPCode5D()
+          : Instruction(-1, 0x5D, nullptr) {}
+        OPCode5D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5D, Maker) {}
+        OPCode5D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {}
+        OPCode5D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x01:
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-        }
-        }
-
-    };
-    //0x5E
-    class OPCode5E: public Instruction{
-    public:
-        OPCode5E():Instruction(-1,0x5E,nullptr){}
-        OPCode5E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5E,Maker){}
-        OPCode5E(int addr, Builder *Maker):Instruction(addr,"???",0x5E,Maker){}
-        OPCode5E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5E,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+            }
+        }
+    };
+    // 0x5E
+    class OPCode5E : public Instruction {
+      public:
+        OPCode5E()
+          : Instruction(-1, 0x5E, nullptr) {}
+        OPCode5E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5E, Maker) {}
+        OPCode5E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {}
+        OPCode5E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x04:
                 case 0x03:
-                case 0x02:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
 
-
-
-                case '\a':{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case '\a': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case '\b':{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case '\b': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case '\v':{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case '\v': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-
             }
         }
-
     };
-    //0x5F
-    class OPCode5F: public Instruction{
-    public:
-        OPCode5F():Instruction(-1,0x5F,nullptr){}
-        OPCode5F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5F,Maker){}
-        OPCode5F(int addr, Builder *Maker):Instruction(addr,"???",0x5F,Maker){}
-        OPCode5F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5F,Maker){
+    // 0x5F
+    class OPCode5F : public Instruction {
+      public:
+        OPCode5F()
+          : Instruction(-1, 0x5F, nullptr) {}
+        OPCode5F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5F, Maker) {}
+        OPCode5F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5F, Maker) {}
+        OPCode5F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5F, Maker) {
             addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x0B:
@@ -4801,1401 +5311,1580 @@ class CS2Builder : public Builder
                 case 0x08:
                 case 0x04:
                 case 0x13:
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
                 case 0x05:
                 case 0x03:
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x06:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x06: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x0E:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));;
+                case 0x0E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    ;
                     break;
                 }
                 case 0x0D:
                 case 0x0C:
                 case 0x0F:
-                case 0x12:{
+                case 0x12: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
                 case 0x10:
-                case 0x11:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x11: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-
-
             }
         }
-
     };
-    //0x60
-    class OPCode60: public Instruction{
-    public:
-        OPCode60():Instruction(-1,0x60,nullptr){}
-        OPCode60(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x60,Maker){}
-        OPCode60(int addr, Builder *Maker):Instruction(addr,"???",0x60,Maker){}
-        OPCode60(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x60,Maker){
+    // 0x60
+    class OPCode60 : public Instruction {
+      public:
+        OPCode60()
+          : Instruction(-1, 0x60, nullptr) {}
+        OPCode60(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x60, Maker) {}
+        OPCode60(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {}
+        OPCode60(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x00:
-                case 0x03:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x03: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x04:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x04: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
-                 }
-                case 0x05:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
-                 }
-
+                }
             }
         }
-
     };
-    //0x61
-    class OPCode61: public Instruction{
-    public:
-        OPCode61():Instruction(-1,0x61,nullptr){}
-        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x61,Maker){}
-        OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){}
-        OPCode61(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){
+    // 0x61
+    class OPCode61 : public Instruction {
+      public:
+        OPCode61()
+          : Instruction(-1, 0x61, nullptr) {}
+        OPCode61(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x61, Maker) {}
+        OPCode61(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {}
+        OPCode61(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {
             addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x61
+    // 0x61
     /*class OPCode61: public Instruction{
     public:
         OPCode61():Instruction(-1,0x61,nullptr){}
-        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x61,Maker){}
-        OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){}
-        OPCode61(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x61,Maker){} OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){} OPCode61(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2))); this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
         }
     };*/
-    //0x62
-    class OPCode62: public Instruction{
-    public:
-        OPCode62():Instruction(-1,0x62,nullptr){}
-        OPCode62(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x62,Maker){}
-        OPCode62(int addr, Builder *Maker):Instruction(addr,"???",0x62,Maker){}
-        OPCode62(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x62,Maker){
+    // 0x62
+    class OPCode62 : public Instruction {
+      public:
+        OPCode62()
+          : Instruction(-1, 0x62, nullptr) {}
+        OPCode62(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x62, Maker) {}
+        OPCode62(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x62, Maker) {}
+        OPCode62(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x62, Maker) {
             addr++;
 
-
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x64
-    class OPCode64: public Instruction{
-    public:
-        OPCode64():Instruction(-1,0x64,nullptr){}
-        OPCode64(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x64,Maker){}
-        OPCode64(int addr, Builder *Maker):Instruction(addr,"???",0x64,Maker){}
-        OPCode64(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x64,Maker){
+    // 0x64
+    class OPCode64 : public Instruction {
+      public:
+        OPCode64()
+          : Instruction(-1, 0x64, nullptr) {}
+        OPCode64(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x64, Maker) {}
+        OPCode64(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {}
+        OPCode64(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x65
-    class OPCode65: public Instruction{
-    public:
-        OPCode65():Instruction(-1,0x65,nullptr){}
-        OPCode65(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x65,Maker){}
-        OPCode65(int addr, Builder *Maker):Instruction(addr,"???",0x65,Maker){}
-        OPCode65(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x65,Maker){
+    // 0x65
+    class OPCode65 : public Instruction {
+      public:
+        OPCode65()
+          : Instruction(-1, 0x65, nullptr) {}
+        OPCode65(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x65, Maker) {}
+        OPCode65(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {}
+        OPCode65(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x66
-    class OPCode66: public Instruction{
-    public:
-        OPCode66():Instruction(-1,0x66,nullptr){}
-        OPCode66(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x66,Maker){}
-        OPCode66(int addr, Builder *Maker):Instruction(addr,"???",0x66,Maker){}
-        OPCode66(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x66,Maker){
+    // 0x66
+    class OPCode66 : public Instruction {
+      public:
+        OPCode66()
+          : Instruction(-1, 0x66, nullptr) {}
+        OPCode66(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x66, Maker) {}
+        OPCode66(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {}
+        OPCode66(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    break;
+                }
+                case 0x09:
+                case 0x04:
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
-                break;
-            }
-            case 0x09:
-            case 0x04:
-            case 0x0C:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    break;
+                }
 
-                break;
-            }
+                case 0x07:
+                case 0x0B:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x08: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x05:
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x06: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-            case 0x07:
-            case 0x0B:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x08:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x05:
-            case 0x03:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0x06:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
+                    break;
+                }
             }
-            case 0x0A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-                break;
-            }
-
         }
-
-        }
-
     };
 
-    //0x67
-    class OPCode67: public Instruction{
-    public:
-        OPCode67():Instruction(-1,0x67,nullptr){}
-        OPCode67(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x67,Maker){}
-        OPCode67(int addr, Builder *Maker):Instruction(addr,"???",0x67,Maker){}
-        OPCode67(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x67,Maker){
+    // 0x67
+    class OPCode67 : public Instruction {
+      public:
+        OPCode67()
+          : Instruction(-1, 0x67, nullptr) {}
+        OPCode67(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x67, Maker) {}
+        OPCode67(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {}
+        OPCode67(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x68
-    class OPCode68: public Instruction{
-    public:
-        OPCode68():Instruction(-1,0x68,nullptr){}
-        OPCode68(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x68,Maker){}
-        OPCode68(int addr, Builder *Maker):Instruction(addr,"???",0x68,Maker){}
-        OPCode68(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x68,Maker){
+    // 0x68
+    class OPCode68 : public Instruction {
+      public:
+        OPCode68()
+          : Instruction(-1, 0x68, nullptr) {}
+        OPCode68(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x68, Maker) {}
+        OPCode68(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {}
+        OPCode68(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             ushort control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-        switch(code){
-            case 0x02:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            switch (code) {
+                case 0x02:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
+                    break;
+                }
+                case 0x03:
+                case 0x04: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
             }
-            case 0x03:
-            case 0x04:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
+            if ((control != 0xFFFF) && (control <= 0x101) && (code == 0x6)) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             }
         }
-        if ((control != 0xFFFF) &&(control <= 0x101)&& (code == 0x6)){
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-        }
-
     };
-    //0x69
-    class OPCode69: public Instruction{
-    public:
-        OPCode69():Instruction(-1,0x69,nullptr){}
-        OPCode69(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x69,Maker){}
-        OPCode69(int addr, Builder *Maker):Instruction(addr,"???",0x69,Maker){}
-        OPCode69(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x69,Maker){
+    // 0x69
+    class OPCode69 : public Instruction {
+      public:
+        OPCode69()
+          : Instruction(-1, 0x69, nullptr) {}
+        OPCode69(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x69, Maker) {}
+        OPCode69(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {}
+        OPCode69(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                break;
-            }
-            case 0x00:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-
-                break;
+                    break;
+                }
             }
         }
-        }
-
     };
-    //0x69
-    class OPCode6A: public Instruction{
-    public:
-        OPCode6A():Instruction(-1,0x6A,nullptr){}
-        OPCode6A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6A,Maker){}
-        OPCode6A(int addr, Builder *Maker):Instruction(addr,"???",0x6A,Maker){}
-        OPCode6A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6A,Maker){
+    // 0x69
+    class OPCode6A : public Instruction {
+      public:
+        OPCode6A()
+          : Instruction(-1, 0x6A, nullptr) {}
+        OPCode6A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6A, Maker) {}
+        OPCode6A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {}
+        OPCode6A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x00:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
+                    break;
+                }
+
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
             }
-
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x14:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-
-
-
         }
-        }
-
     };
-    //0x6A
-   class OPCode6B: public Instruction{
-        public:
-            OPCode6B():Instruction(-1,0x6B,nullptr){}
-            OPCode6B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6B,Maker){}
-            OPCode6B(int addr, Builder *Maker):Instruction(addr,"???",0x6B,Maker){}
-            OPCode6B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6B,Maker){
+    // 0x6A
+    class OPCode6B : public Instruction {
+      public:
+        OPCode6B()
+          : Instruction(-1, 0x6B, nullptr) {}
+        OPCode6B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6B, Maker) {}
+        OPCode6B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6B, Maker) {}
+        OPCode6B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6B, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
+            this->AddOperande(operande(addr, "byte", control_byte2));
 
-            if ((unsigned char)control_byte2[0] < 4){
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x00:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    }
-
-                    case 0x01:{
-                        //reading_dialog(addr, content, this);
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x02:{
-
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                        break;
-                    }
-                    case 0x04:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            if ((unsigned char)control_byte2[0] < 4) {
+                switch ((unsigned char)control_byte[0]) {
+                    case 0x00: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                         break;
                     }
-                    case 0x05:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+
+                    case 0x01: {
+                        // reading_dialog(addr, content, this);
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x02: {
+
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+                        break;
+                    }
+                    case 0x04: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+
+                        break;
+                    }
+                    case 0x05: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                         break;
                     }
                     case 0x07:
-                    case 0x06:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    case 0x06: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                         break;
                     }
-
-
-
                 }
             }
-
         }
-
     };
-    //0x6C
-    class OPCode6C: public Instruction{
-    public:
-        OPCode6C():Instruction(-1,0x6C,nullptr){}
-        OPCode6C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6C,Maker){}
-        OPCode6C(int addr, Builder *Maker):Instruction(addr,"???",0x6C,Maker){}
-        OPCode6C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6C,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+    // 0x6C
+    class OPCode6C : public Instruction {
+      public:
+        OPCode6C()
+          : Instruction(-1, 0x6C, nullptr) {}
+        OPCode6C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6C, Maker) {}
+        OPCode6C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {}
+        OPCode6C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x6D
-    class OPCode6D: public Instruction{
-    public:
-        OPCode6D():Instruction(-1,0x6D,nullptr){}
-        OPCode6D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6D,Maker){}
-        OPCode6D(int addr, Builder *Maker):Instruction(addr,"???",0x6D,Maker){}
-        OPCode6D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6D,Maker){
-        addr++;
-
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-    //0x6E
-    class OPCode6E: public Instruction{
-    public:
-        OPCode6E():Instruction(-1,0x6E,nullptr){}
-        OPCode6E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6E,Maker){}
-        OPCode6E(int addr, Builder *Maker):Instruction(addr,"???",0x6E,Maker){}
-        OPCode6E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6E,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-
-    };
-    //0x6F
-    class OPCode6F: public Instruction{
-    public:
-        OPCode6F():Instruction(-1,0x6F,nullptr){}
-        OPCode6F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6F,Maker){}
-        OPCode6F(int addr, Builder *Maker):Instruction(addr,"???",0x6F,Maker){}
-        OPCode6F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6F,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x05:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-        }
-        }
-
-    };
-    //0x70
-    class OPCode70: public Instruction{
-        public:
-        OPCode70():Instruction(-1,0x70,nullptr){}
-        OPCode70(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x70,Maker){}
-        OPCode70(int addr, Builder *Maker):Instruction(addr,"???",0x70,Maker){}
-        OPCode70(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x70,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x00:{
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x02:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-        }
-        }
-
-    };
-    //0x71
-    class OPCode71: public Instruction{
-        public:
-        OPCode71():Instruction(-1,0x71,nullptr){}
-        OPCode71(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x71,Maker){}
-        OPCode71(int addr, Builder *Maker):Instruction(addr,"???",0x71,Maker){}
-        OPCode71(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x71,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        unsigned char code = control_byte[0];
-        if (code == 0x01){
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        }
-        }
-
-    };
-    //0x71
-    class OPCode72: public Instruction{
-    public:
-        OPCode72():Instruction(-1,0x72,nullptr){}
-        OPCode72(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x72,Maker){}
-        OPCode72(int addr, Builder *Maker):Instruction(addr,"???",0x72,Maker){}
-        OPCode72(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x72,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        unsigned char code = control_byte[0];
-        if (code == 0x00){
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-        }
-
-    };
-    //0x73
-    class OPCode73: public Instruction{
-    public:
-        OPCode73():Instruction(-1,0x73,nullptr){}
-        OPCode73(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x73,Maker){}
-        OPCode73(int addr, Builder *Maker):Instruction(addr,"???",0x73,Maker){}
-        OPCode73(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x73,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-    //0x74
-
-    class OPCode74: public Instruction{
-    public:
-        OPCode74():Instruction(-1,0x74,nullptr){}
-        OPCode74(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x74,Maker){}
-        OPCode74(int addr, Builder *Maker):Instruction(addr,"???",0x74,Maker){}
-        OPCode74(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x74,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x03:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x06:
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x04:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x05:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-
-
-
-        }
-        }
-
-    };
-    //0x75
-    class OPCode75: public Instruction{
-    public:
-        OPCode75():Instruction(-1,0x75,nullptr){}
-        OPCode75(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x75,Maker){}
-        OPCode75(int addr, Builder *Maker):Instruction(addr,"???",0x75,Maker){}
-        OPCode75(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x75,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x00:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-        }
-        }
-
-    };
-    //0x76
-    class OPCode76: public Instruction{
-    public:
-        OPCode76():Instruction(-1,0x76,nullptr){}
-        OPCode76(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x76,Maker){}
-        OPCode76(int addr, Builder *Maker):Instruction(addr,"???",0x76,Maker){}
-        OPCode76(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x76,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-        }
-
-    };
-    //0x78
-    class OPCode78: public Instruction{
-        public:
-            OPCode78():Instruction(-1,0x78,nullptr){}
-            OPCode78(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x78,Maker){}
-            OPCode78(int addr, Builder *Maker):Instruction(addr,"???",0x78,Maker){}
-            OPCode78(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x78,Maker){
+    // 0x6D
+    class OPCode6D : public Instruction {
+      public:
+        OPCode6D()
+          : Instruction(-1, 0x6D, nullptr) {}
+        OPCode6D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6D, Maker) {}
+        OPCode6D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6D, Maker) {}
+        OPCode6D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6D, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x6E
+    class OPCode6E : public Instruction {
+      public:
+        OPCode6E()
+          : Instruction(-1, 0x6E, nullptr) {}
+        OPCode6E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6E, Maker) {}
+        OPCode6E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {}
+        OPCode6E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x6F
+    class OPCode6F : public Instruction {
+      public:
+        OPCode6F()
+          : Instruction(-1, 0x6F, nullptr) {}
+        OPCode6F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6F, Maker) {}
+        OPCode6F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6F, Maker) {}
+        OPCode6F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6F, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
             }
-
-    };
-    //0x79
-    class OPCode79: public Instruction{
-    public:
-        OPCode79():Instruction(-1,0x79,nullptr){}
-        OPCode79(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x79,Maker){}
-        OPCode79(int addr, Builder *Maker):Instruction(addr,"???",0x79,Maker){}
-        OPCode79(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x79,Maker){
-        addr++;
-
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
-
     };
-    //0x7A
-    class OPCode7A: public Instruction{
-    public:
-        OPCode7A():Instruction(-1,0x7A,nullptr){}
-        OPCode7A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7A,Maker){}
-        OPCode7A(int addr, Builder *Maker):Instruction(addr,"???",0x7A,Maker){}
-        OPCode7A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7A,Maker){
+    // 0x70
+    class OPCode70 : public Instruction {
+      public:
+        OPCode70()
+          : Instruction(-1, 0x70, nullptr) {}
+        OPCode70(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x70, Maker) {}
+        OPCode70(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {}
+        OPCode70(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
 
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x02:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+            }
+        }
     };
-    //0x7B
-    class OPCode7B: public Instruction{
-    public:
-        OPCode7B():Instruction(-1,0x7B,nullptr){}
-        OPCode7B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7B,Maker){}
-        OPCode7B(int addr, Builder *Maker):Instruction(addr,"???",0x7B,Maker){}
-        OPCode7B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7B,Maker){
+    // 0x71
+    class OPCode71 : public Instruction {
+      public:
+        OPCode71()
+          : Instruction(-1, 0x71, nullptr) {}
+        OPCode71(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x71, Maker) {}
+        OPCode71(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x71, Maker) {}
+        OPCode71(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x71, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x01) {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+            }
+        }
+    };
+    // 0x71
+    class OPCode72 : public Instruction {
+      public:
+        OPCode72()
+          : Instruction(-1, 0x72, nullptr) {}
+        OPCode72(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x72, Maker) {}
+        OPCode72(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {}
+        OPCode72(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            }
+        }
+    };
+    // 0x73
+    class OPCode73 : public Instruction {
+      public:
+        OPCode73()
+          : Instruction(-1, 0x73, nullptr) {}
+        OPCode73(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x73, Maker) {}
+        OPCode73(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {}
+        OPCode73(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x74
+
+    class OPCode74 : public Instruction {
+      public:
+        OPCode74()
+          : Instruction(-1, 0x74, nullptr) {}
+        OPCode74(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x74, Maker) {}
+        OPCode74(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {}
+        OPCode74(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x03: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x06:
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+            }
+        }
+    };
+    // 0x75
+    class OPCode75 : public Instruction {
+      public:
+        OPCode75()
+          : Instruction(-1, 0x75, nullptr) {}
+        OPCode75(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x75, Maker) {}
+        OPCode75(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x75, Maker) {}
+        OPCode75(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x75, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+            }
+        }
+    };
+    // 0x76
+    class OPCode76 : public Instruction {
+      public:
+        OPCode76()
+          : Instruction(-1, 0x76, nullptr) {}
+        OPCode76(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x76, Maker) {}
+        OPCode76(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x76, Maker) {}
+        OPCode76(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x76, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x78
+    class OPCode78 : public Instruction {
+      public:
+        OPCode78()
+          : Instruction(-1, 0x78, nullptr) {}
+        OPCode78(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x78, Maker) {}
+        OPCode78(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {}
+        OPCode78(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
+    };
+    // 0x79
+    class OPCode79 : public Instruction {
+      public:
+        OPCode79()
+          : Instruction(-1, 0x79, nullptr) {}
+        OPCode79(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x79, Maker) {}
+        OPCode79(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {}
+        OPCode79(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {
+            addr++;
 
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x7A
+    class OPCode7A : public Instruction {
+      public:
+        OPCode7A()
+          : Instruction(-1, 0x7A, nullptr) {}
+        OPCode7A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7A, Maker) {}
+        OPCode7A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {}
+        OPCode7A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x7B
+    class OPCode7B : public Instruction {
+      public:
+        OPCode7B()
+          : Instruction(-1, 0x7B, nullptr) {}
+        OPCode7B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7B, Maker) {}
+        OPCode7B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {}
+        OPCode7B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
     };
 
-    //0x7C
-    class OPCode7C: public Instruction{
-    public:
-        OPCode7C():Instruction(-1,0x7C,nullptr){}
-        OPCode7C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7C,Maker){}
-        OPCode7C(int addr, Builder *Maker):Instruction(addr,"???",0x7C,Maker){}
-        OPCode7C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7C,Maker){
+    // 0x7C
+    class OPCode7C : public Instruction {
+      public:
+        OPCode7C()
+          : Instruction(-1, 0x7C, nullptr) {}
+        OPCode7C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7C, Maker) {}
+        OPCode7C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7C, Maker) {}
+        OPCode7C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7C, Maker) {
             addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            if ((unsigned char)control_byte[0] == 0xFF){
+            if ((unsigned char)control_byte[0] == 0xFF) {
                 /*this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
                 this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
                 return;*/
-            }; //really weird here, m5010 crashes on this special instruction, i think it's an error from falcom? not sure; for me this file is broken
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
+            }; // really weird here, m5010 crashes on this special instruction, i think it's an error from falcom? not
+               // sure; for me this file is broken
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x7E
-    class OPCode7E: public Instruction{
-    public:
-        OPCode7E():Instruction(-1,0x7E,nullptr){}
-        OPCode7E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7E,Maker){}
-        OPCode7E(int addr, Builder *Maker):Instruction(addr,"???",0x7E,Maker){}
-        OPCode7E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7E,Maker){
+    // 0x7E
+    class OPCode7E : public Instruction {
+      public:
+        OPCode7E()
+          : Instruction(-1, 0x7E, nullptr) {}
+        OPCode7E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7E, Maker) {}
+        OPCode7E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {}
+        OPCode7E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x7F
-    class OPCode7F: public Instruction{
-    public:
-        OPCode7F():Instruction(-1,0x7F,nullptr){}
-        OPCode7F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7F,Maker){}
-        OPCode7F(int addr, Builder *Maker):Instruction(addr,"???",0x7F,Maker){}
-        OPCode7F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7F,Maker){
+    // 0x7F
+    class OPCode7F : public Instruction {
+      public:
+        OPCode7F()
+          : Instruction(-1, 0x7F, nullptr) {}
+        OPCode7F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7F, Maker) {}
+        OPCode7F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7F, Maker) {}
+        OPCode7F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7F, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x80
-    class OPCode80: public Instruction{
-    public:
-        OPCode80():Instruction(-1,0x80,nullptr){}
-        OPCode80(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x80,Maker){}
-        OPCode80(int addr, Builder *Maker):Instruction(addr,"???",0x80,Maker){}
-        OPCode80(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x80,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch(control_byte[0]){
-            case 0x01   :
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case -2:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case -1:{
-
-                break;
-            }
-            default:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            }
-
-
-        }
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x81
-    class OPCode81: public Instruction{
-    public:
-        OPCode81():Instruction(-1,0x81,nullptr){}
-        OPCode81(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x81,Maker){}
-        OPCode81(int addr, Builder *Maker):Instruction(addr,"???",0x81,Maker){}
-        OPCode81(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x81,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    //0x82
-    class OPCode82: public Instruction{
-    public:
-        OPCode82():Instruction(-1,0x82,nullptr){}
-        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x82,Maker){}
-        OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){}
-        OPCode82(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){
+    // 0x80
+    class OPCode80 : public Instruction {
+      public:
+        OPCode80()
+          : Instruction(-1, 0x80, nullptr) {}
+        OPCode80(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x80, Maker) {}
+        OPCode80(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {}
+        OPCode80(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch (control_byte[0]) {
+                case 0x01:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case -2: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case -1: {
+
+                    break;
+                }
+                default: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                }
+            }
+        }
+    };
+    // 0x81
+    class OPCode81 : public Instruction {
+      public:
+        OPCode81()
+          : Instruction(-1, 0x81, nullptr) {}
+        OPCode81(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x81, Maker) {}
+        OPCode81(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x81, Maker) {}
+        OPCode81(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x81, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    // 0x82
+    class OPCode82 : public Instruction {
+      public:
+        OPCode82()
+          : Instruction(-1, 0x82, nullptr) {}
+        OPCode82(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x82, Maker) {}
+        OPCode82(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {}
+        OPCode82(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            if (code == 0x00) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            if (code == 0x00) this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x82
+    // 0x82
     /*class OPCode82: public Instruction{
     public:
         OPCode82():Instruction(-1,0x82,nullptr){}
-        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x82,Maker){}
-        OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){}
-        OPCode82(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x82,Maker){} OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){} OPCode82(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2))); this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
     };*/
-    //0x83
-    class OPCode83: public Instruction{
-    public:
-        OPCode83():Instruction(-1,0x83,nullptr){}
-        OPCode83(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x83,Maker){}
-        OPCode83(int addr, Builder *Maker):Instruction(addr,"???",0x83,Maker){}
-        OPCode83(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x83,Maker){
+    // 0x83
+    class OPCode83 : public Instruction {
+      public:
+        OPCode83()
+          : Instruction(-1, 0x83, nullptr) {}
+        OPCode83(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x83, Maker) {}
+        OPCode83(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {}
+        OPCode83(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x84
-    class OPCode84: public Instruction{
-    public:
-        OPCode84():Instruction(-1,0x84,nullptr){}
-        OPCode84(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x84,Maker){}
-        OPCode84(int addr, Builder *Maker):Instruction(addr,"???",0x84,Maker){}
-        OPCode84(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
+    // 0x84
+    class OPCode84 : public Instruction {
+      public:
+        OPCode84()
+          : Instruction(-1, 0x84, nullptr) {}
+        OPCode84(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x84, Maker) {}
+        OPCode84(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {}
+        OPCode84(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-       }
-    };
-    //0x85
-    class OPCode85: public Instruction{
-    public:
-        OPCode85():Instruction(-1,0x85,nullptr){}
-        OPCode85(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x85,Maker){}
-        OPCode85(int addr, Builder *Maker):Instruction(addr,"???",0x85,Maker){}
-        OPCode85(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x85,Maker){
-            addr++;
-
-
-       }
-    };
-    //0x86
-    class OPCode86: public Instruction{
-    public:
-        OPCode86():Instruction(-1,0x86,nullptr){}
-        OPCode86(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x86,Maker){}
-        OPCode86(int addr, Builder *Maker):Instruction(addr,"???",0x86,Maker){}
-        OPCode86(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x86,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x87
-    class OPCode87: public Instruction{
-    public:
-        OPCode87():Instruction(-1,0x87,nullptr){}
-        OPCode87(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x87,Maker){}
-        OPCode87(int addr, Builder *Maker):Instruction(addr,"???",0x87,Maker){}
-        OPCode87(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x87,Maker){
+    // 0x85
+    class OPCode85 : public Instruction {
+      public:
+        OPCode85()
+          : Instruction(-1, 0x85, nullptr) {}
+        OPCode85(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x85, Maker) {}
+        OPCode85(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x85, Maker) {}
+        OPCode85(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x85, Maker) {
+            addr++;
+        }
+    };
+    // 0x86
+    class OPCode86 : public Instruction {
+      public:
+        OPCode86()
+          : Instruction(-1, 0x86, nullptr) {}
+        OPCode86(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x86, Maker) {}
+        OPCode86(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x86, Maker) {}
+        OPCode86(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x86, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x87
+    class OPCode87 : public Instruction {
+      public:
+        OPCode87()
+          : Instruction(-1, 0x87, nullptr) {}
+        OPCode87(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x87, Maker) {}
+        OPCode87(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x87, Maker) {}
+        OPCode87(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x87, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch ((unsigned char)control_byte[0])  {
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
             }
         }
     };
-    //0x88
-    class OPCode88: public Instruction{
-    public:
-        OPCode88():Instruction(-1,0x88,nullptr){}
-        OPCode88(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x88,Maker){}
-        OPCode88(int addr, Builder *Maker):Instruction(addr,"???",0x88,Maker){}
-        OPCode88(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x88,Maker){
+    // 0x88
+    class OPCode88 : public Instruction {
+      public:
+        OPCode88()
+          : Instruction(-1, 0x88, nullptr) {}
+        OPCode88(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x88, Maker) {}
+        OPCode88(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x88, Maker) {}
+        OPCode88(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x88, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x89
-    class OPCode89: public Instruction{
-    public:
-        OPCode89():Instruction(-1,0x89,nullptr){}
-        OPCode89(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x89,Maker){}
-        OPCode89(int addr, Builder *Maker):Instruction(addr,"???",0x89,Maker){}
-        OPCode89(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x89,Maker){
+    // 0x89
+    class OPCode89 : public Instruction {
+      public:
+        OPCode89()
+          : Instruction(-1, 0x89, nullptr) {}
+        OPCode89(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x89, Maker) {}
+        OPCode89(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x89, Maker) {}
+        OPCode89(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x89, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            if (code == 0x00){
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            } else if ((code == 0x06) || (code == 0x07) || (code == 0x08)) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
             }
-            else if ((code == 0x06)||(code == 0x07)||(code == 0x08)){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            }
-
         }
     };
 
-    //0x8A
-    class OPCode8A: public Instruction{
-    public:
-        OPCode8A():Instruction(-1,0x8A,nullptr){}
-        OPCode8A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8A,Maker){}
-        OPCode8A(int addr, Builder *Maker):Instruction(addr,"???",0x8A,Maker){}
-        OPCode8A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8A,Maker){
+    // 0x8A
+    class OPCode8A : public Instruction {
+      public:
+        OPCode8A()
+          : Instruction(-1, 0x8A, nullptr) {}
+        OPCode8A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8A, Maker) {}
+        OPCode8A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8A, Maker) {}
+        OPCode8A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8A, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            if (code == 0x00){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
             }
         }
     };
-    //0x8B
-    class OPCode8B: public Instruction{
-    public:
-        OPCode8B():Instruction(-1,0x8B,nullptr){}
-        OPCode8B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8B,Maker){}
-        OPCode8B(int addr, Builder *Maker):Instruction(addr,"???",0x8B,Maker){}
-        OPCode8B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8B,Maker){
+    // 0x8B
+    class OPCode8B : public Instruction {
+      public:
+        OPCode8B()
+          : Instruction(-1, 0x8B, nullptr) {}
+        OPCode8B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8B, Maker) {}
+        OPCode8B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8B, Maker) {}
+        OPCode8B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8B, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            if (code == 0x00){
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             }
         }
     };
-    //0x8C
-    class OPCode8C: public Instruction{
-    public:
-        OPCode8C():Instruction(-1,0x8C,nullptr){}
-        OPCode8C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8C,Maker){}
-        OPCode8C(int addr, Builder *Maker):Instruction(addr,"???",0x8C,Maker){}
-        OPCode8C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8C,Maker){
+    // 0x8C
+    class OPCode8C : public Instruction {
+      public:
+        OPCode8C()
+          : Instruction(-1, 0x8C, nullptr) {}
+        OPCode8C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8C, Maker) {}
+        OPCode8C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8C, Maker) {}
+        OPCode8C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8C, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
-    //0x8D
-    class OPCode8D: public Instruction{
-    public:
-        OPCode8D():Instruction(-1,0x8D,nullptr){}
-        OPCode8D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8D,Maker){}
-        OPCode8D(int addr, Builder *Maker):Instruction(addr,"???",0x8D,Maker){}
-        OPCode8D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8D,Maker){
+    // 0x8D
+    class OPCode8D : public Instruction {
+      public:
+        OPCode8D()
+          : Instruction(-1, 0x8D, nullptr) {}
+        OPCode8D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8D, Maker) {}
+        OPCode8D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8D, Maker) {}
+        OPCode8D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x8E
-    class OPCode8E: public Instruction{
-    public:
-        OPCode8E():Instruction(-1,0x8E,nullptr){}
-        OPCode8E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8E,Maker){}
-        OPCode8E(int addr, Builder *Maker):Instruction(addr,"???",0x8E,Maker){}
-        OPCode8E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8E,Maker){
+    // 0x8E
+    class OPCode8E : public Instruction {
+      public:
+        OPCode8E()
+          : Instruction(-1, 0x8E, nullptr) {}
+        OPCode8E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8E, Maker) {}
+        OPCode8E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8E, Maker) {}
+        OPCode8E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8E, Maker) {
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             short control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));
-            switch (control){
+            this->AddOperande(operande(addr, "short", control_short));
+            switch (control) {
                 case 0x02:
-                case 0x01:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x03:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    break;
-                }
-            }
-        }
-    };
-    //0x8F
-    class OPCode8F: public Instruction{
-    public:
-        OPCode8F():Instruction(-1,0x8F,nullptr){}
-        OPCode8F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8F,Maker){}
-        OPCode8F(int addr, Builder *Maker):Instruction(addr,"???",0x8F,Maker){}
-        OPCode8F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x90
-    class OPCode90: public Instruction{
-    public:
-        OPCode90():Instruction(-1,0x90,nullptr){}
-        OPCode90(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x90,Maker){}
-        OPCode90(int addr, Builder *Maker):Instruction(addr,"???",0x90,Maker){}
-        OPCode90(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x90,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    //0x91
-    class OPCode91: public Instruction{
-    public:
-        OPCode91():Instruction(-1,0x91,nullptr){}
-        OPCode91(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x91,Maker){}
-        OPCode91(int addr, Builder *Maker):Instruction(addr,"???",0x91,Maker){}
-        OPCode91(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x91,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
             }
         }
     };
-    //0x92
-    class OPCode92: public Instruction{
-    public:
-        OPCode92():Instruction(-1,0x92,nullptr){}
-        OPCode92(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x92,Maker){}
-        OPCode92(int addr, Builder *Maker):Instruction(addr,"???",0x92,Maker){}
-        OPCode92(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x92,Maker){
+    // 0x8F
+    class OPCode8F : public Instruction {
+      public:
+        OPCode8F()
+          : Instruction(-1, 0x8F, nullptr) {}
+        OPCode8F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8F, Maker) {}
+        OPCode8F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8F, Maker) {}
+        OPCode8F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x90
+    class OPCode90 : public Instruction {
+      public:
+        OPCode90()
+          : Instruction(-1, 0x90, nullptr) {}
+        OPCode90(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x90, Maker) {}
+        OPCode90(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x90, Maker) {}
+        OPCode90(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x90, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x91
+    class OPCode91 : public Instruction {
+      public:
+        OPCode91()
+          : Instruction(-1, 0x91, nullptr) {}
+        OPCode91(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x91, Maker) {}
+        OPCode91(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x91, Maker) {}
+        OPCode91(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x91, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                    break;
-                }
-
             }
         }
     };
-    //0x93
-    class OPCode93: public Instruction{
-    public:
-        OPCode93():Instruction(-1,0x93,nullptr){}
-        OPCode93(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x93,Maker){}
-        OPCode93(int addr, Builder *Maker):Instruction(addr,"???",0x93,Maker){}
-        OPCode93(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x93,Maker){
+    // 0x92
+    class OPCode92 : public Instruction {
+      public:
+        OPCode92()
+          : Instruction(-1, 0x92, nullptr) {}
+        OPCode92(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x92, Maker) {}
+        OPCode92(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x92, Maker) {}
+        OPCode92(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x92, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
+                    break;
+                }
+            }
+        }
+    };
+    // 0x93
+    class OPCode93 : public Instruction {
+      public:
+        OPCode93()
+          : Instruction(-1, 0x93, nullptr) {}
+        OPCode93(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x93, Maker) {}
+        OPCode93(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x93, Maker) {}
+        OPCode93(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x93, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
 
-    //0x94
-    class OPCode94: public Instruction{
-    public:
-        OPCode94():Instruction(-1,0x94,nullptr){}
-        OPCode94(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x94,Maker){}
-        OPCode94(int addr, Builder *Maker):Instruction(addr,"???",0x94,Maker){}
-        OPCode94(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x94,Maker){
+    // 0x94
+    class OPCode94 : public Instruction {
+      public:
+        OPCode94()
+          : Instruction(-1, 0x94, nullptr) {}
+        OPCode94(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x94, Maker) {}
+        OPCode94(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x94, Maker) {}
+        OPCode94(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x94, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
                 case 0x0E:
                 case 0x0D:
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
             }
         }
     };
-    //0x95
-    class OPCode95: public Instruction{
-    public:
-        OPCode95():Instruction(-1,0x95,nullptr){}
-        OPCode95(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x95,Maker){}
-        OPCode95(int addr, Builder *Maker):Instruction(addr,"???",0x95,Maker){}
-        OPCode95(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x95,Maker){
+    // 0x95
+    class OPCode95 : public Instruction {
+      public:
+        OPCode95()
+          : Instruction(-1, 0x95, nullptr) {}
+        OPCode95(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x95, Maker) {}
+        OPCode95(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x95, Maker) {}
+        OPCode95(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x95, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x96
-    class OPCode96: public Instruction{
-    public:
-        OPCode96():Instruction(-1,0x96,nullptr){}
-        OPCode96(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x96,Maker){}
-        OPCode96(int addr, Builder *Maker):Instruction(addr,"???",0x96,Maker){}
-        OPCode96(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x96,Maker){
+    // 0x96
+    class OPCode96 : public Instruction {
+      public:
+        OPCode96()
+          : Instruction(-1, 0x96, nullptr) {}
+        OPCode96(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x96, Maker) {}
+        OPCode96(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x96, Maker) {}
+        OPCode96(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x96, Maker) {
             addr++;
-
         }
     };
-    //0x97
-    class OPCode97: public Instruction{
-    public:
-        OPCode97():Instruction(-1,0x97,nullptr){}
-        OPCode97(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x97,Maker){}
-        OPCode97(int addr, Builder *Maker):Instruction(addr,"???",0x97,Maker){}
-        OPCode97(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x97,Maker){
+    // 0x97
+    class OPCode97 : public Instruction {
+      public:
+        OPCode97()
+          : Instruction(-1, 0x97, nullptr) {}
+        OPCode97(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x97, Maker) {}
+        OPCode97(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x97, Maker) {}
+        OPCode97(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x97, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x98
-    class OPCode98: public Instruction{
-    public:
-        OPCode98():Instruction(-1,0x98,nullptr){}
-        OPCode98(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x98,Maker){}
-        OPCode98(int addr, Builder *Maker):Instruction(addr,"???",0x98,Maker){}
-        OPCode98(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x98,Maker){
+    // 0x98
+    class OPCode98 : public Instruction {
+      public:
+        OPCode98()
+          : Instruction(-1, 0x98, nullptr) {}
+        OPCode98(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x98, Maker) {}
+        OPCode98(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x98, Maker) {}
+        OPCode98(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x98, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x98
+    // 0x98
     /*class OPCode98: public Instruction{
     public:
         OPCode98():Instruction(-1,0x98,nullptr){}
-        OPCode98(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x98,Maker){}
-        OPCode98(int addr, Builder *Maker):Instruction(addr,"???",0x98,Maker){}
-        OPCode98(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x98,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode98(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x98,Maker){} OPCode98(int addr, Builder *Maker):Instruction(addr,"???",0x98,Maker){} OPCode98(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x98,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2))); this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
     };*/
-    //0x99
-    class OPCode99: public Instruction{
-    public:
-        OPCode99():Instruction(-1,0x99,nullptr){}
-        OPCode99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x99,Maker){}
-        OPCode99(int addr, Builder *Maker):Instruction(addr,"???",0x99,Maker){}
-        OPCode99(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
+    // 0x99
+    class OPCode99 : public Instruction {
+      public:
+        OPCode99()
+          : Instruction(-1, 0x99, nullptr) {}
+        OPCode99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x99, Maker) {}
+        OPCode99(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x99, Maker) {}
+        OPCode99(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x99, Maker) {
             addr++;
-
         }
     };
-    //0x9A
-    class OPCode9A: public Instruction{
-    public:
-        OPCode9A():Instruction(-1,0x9A,nullptr){}
-        OPCode9A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9A,Maker){}
-        OPCode9A(int addr, Builder *Maker):Instruction(addr,"???",0x9A,Maker){}
-        OPCode9A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9A,Maker){
+    // 0x9A
+    class OPCode9A : public Instruction {
+      public:
+        OPCode9A()
+          : Instruction(-1, 0x9A, nullptr) {}
+        OPCode9A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9A, Maker) {}
+        OPCode9A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9A, Maker) {}
+        OPCode9A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x9B
-    class OPCode9B: public Instruction{
-    public:
-        OPCode9B():Instruction(-1,0x9B,nullptr){}
-        OPCode9B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9B,Maker){}
-        OPCode9B(int addr, Builder *Maker):Instruction(addr,"???",0x9B,Maker){}
-        OPCode9B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9B,Maker){
+    // 0x9B
+    class OPCode9B : public Instruction {
+      public:
+        OPCode9B()
+          : Instruction(-1, 0x9B, nullptr) {}
+        OPCode9B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9B, Maker) {}
+        OPCode9B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9B, Maker) {}
+        OPCode9B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9B, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x01:
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
                 case 0x03:
-                case 0x04:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
             }
         }
     };
-    //0x9C
-    class OPCode9C: public Instruction{
-        public:
-            OPCode9C():Instruction(-1,0x9C,nullptr){}
-            OPCode9C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9C,Maker){}
-            OPCode9C(int addr, Builder *Maker):Instruction(addr,"???",0x9C,Maker){}
-            OPCode9C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+    // 0x9C
+    class OPCode9C : public Instruction {
+      public:
+        OPCode9C()
+          : Instruction(-1, 0x9C, nullptr) {}
+        OPCode9C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9C, Maker) {}
+        OPCode9C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9C, Maker) {}
+        OPCode9C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x9E
-    class OPCode9E: public Instruction{
-        public:
-            OPCode9E():Instruction(-1,0x9E,nullptr){}
-            OPCode9E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9E,Maker){}
-            OPCode9E(int addr, Builder *Maker):Instruction(addr,"???",0x9E,Maker){}
-            OPCode9E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+    // 0x9E
+    class OPCode9E : public Instruction {
+      public:
+        OPCode9E()
+          : Instruction(-1, 0x9E, nullptr) {}
+        OPCode9E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9E, Maker) {}
+        OPCode9E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9E, Maker) {}
+        OPCode9E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x9F
-    class OPCode9F: public Instruction{
-        public:
-            OPCode9F():Instruction(-1,0x9F,nullptr){}
-            OPCode9F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9F,Maker){}
-            OPCode9F(int addr, Builder *Maker):Instruction(addr,"???",0x9F,Maker){}
-            OPCode9F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9F,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+    // 0x9F
+    class OPCode9F : public Instruction {
+      public:
+        OPCode9F()
+          : Instruction(-1, 0x9F, nullptr) {}
+        OPCode9F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9F, Maker) {}
+        OPCode9F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9F, Maker) {}
+        OPCode9F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    //0x9F
+    // 0x9F
     /*class OPCode9F: public Instruction{
     public:
         OPCode9F():Instruction(-1,0x9F,nullptr){}
-        OPCode9F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9F,Maker){}
-        OPCode9F(int addr, Builder *Maker):Instruction(addr,"???",0x9F,Maker){}
-        OPCode9F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode9F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x9F,Maker){} OPCode9F(int addr, Builder *Maker):Instruction(addr,"???",0x9F,Maker){} OPCode9F(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x9F,Maker){ addr++; this->AddOperande(operande(addr,"byte",
+    ReadSubByteArray(content, addr, 1)));; this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
@@ -6216,790 +6905,994 @@ class CS2Builder : public Builder
 
         }
     };*/
-    //0xA0
-    class OPCodeA0: public Instruction{
-    public:
-        OPCodeA0():Instruction(-1,0xA0,nullptr){}
-        OPCodeA0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA0,Maker){}
-        OPCodeA0(int addr, Builder *Maker):Instruction(addr,"???",0xA0,Maker){}
-        OPCodeA0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA0,Maker){
+    // 0xA0
+    class OPCodeA0 : public Instruction {
+      public:
+        OPCodeA0()
+          : Instruction(-1, 0xA0, nullptr) {}
+        OPCodeA0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA0, Maker) {}
+        OPCodeA0(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA0, Maker) {}
+        OPCodeA0(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA0, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    //0xA1
-    class OPCodeA1: public Instruction{
-    public:
-        OPCodeA1():Instruction(-1,0xA1,nullptr){}
-        OPCodeA1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA1,Maker){}
-        OPCodeA1(int addr, Builder *Maker):Instruction(addr,"???",0xA1,Maker){}
-        OPCodeA1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA1,Maker){
+    // 0xA1
+    class OPCodeA1 : public Instruction {
+      public:
+        OPCodeA1()
+          : Instruction(-1, 0xA1, nullptr) {}
+        OPCodeA1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA1, Maker) {}
+        OPCodeA1(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA1, Maker) {}
+        OPCodeA1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA1, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x00:
-                case 0x04:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
                 case 0x02:
-                case 0x05:
-                {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x05: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x03:
-                {
+                case 0x03: {
 
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-
             }
         }
     };
-    //0xA2
-    class OPCodeA2: public Instruction{
-    public:
-        OPCodeA2():Instruction(-1,0xA2,nullptr){}
-        OPCodeA2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA2,Maker){}
-        OPCodeA2(int addr, Builder *Maker):Instruction(addr,"???",0xA2,Maker){}
-        OPCodeA2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA2,Maker){
+    // 0xA2
+    class OPCodeA2 : public Instruction {
+      public:
+        OPCodeA2()
+          : Instruction(-1, 0xA2, nullptr) {}
+        OPCodeA2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA2, Maker) {}
+        OPCodeA2(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA2, Maker) {}
+        OPCodeA2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA2, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
                 case 0x03:
                 case 0x04:
                 case 0x02:
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
             }
         }
     };
-    //0xA3
-    class OPCodeA3: public Instruction{
-    public:
-        OPCodeA3():Instruction(-1,0xA3,nullptr){}
-        OPCodeA3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA3,Maker){}
-        OPCodeA3(int addr, Builder *Maker):Instruction(addr,"???",0xA3,Maker){}
-        OPCodeA3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA3,Maker){
+    // 0xA3
+    class OPCodeA3 : public Instruction {
+      public:
+        OPCodeA3()
+          : Instruction(-1, 0xA3, nullptr) {}
+        OPCodeA3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA3, Maker) {}
+        OPCodeA3(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA3, Maker) {}
+        OPCodeA3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA3, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    //0xA4
-    class OPCodeA4: public Instruction{
-    public:
-        OPCodeA4():Instruction(-1,0xA4,nullptr){}
-        OPCodeA4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA4,Maker){}
-        OPCodeA4(int addr, Builder *Maker):Instruction(addr,"???",0xA4,Maker){}
-        OPCodeA4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA4,Maker){
+    // 0xA4
+    class OPCodeA4 : public Instruction {
+      public:
+        OPCodeA4()
+          : Instruction(-1, 0xA4, nullptr) {}
+        OPCodeA4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA4, Maker) {}
+        OPCodeA4(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA4, Maker) {}
+        OPCodeA4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA4, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0xA5
-    class OPCodeA5: public Instruction{
-    public:
-        OPCodeA5():Instruction(-1,0xA5,nullptr){}
-        OPCodeA5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA5,Maker){}
-        OPCodeA5(int addr, Builder *Maker):Instruction(addr,"???",0xA5,Maker){}
-        OPCodeA5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA5,Maker){
+    // 0xA5
+    class OPCodeA5 : public Instruction {
+      public:
+        OPCodeA5()
+          : Instruction(-1, 0xA5, nullptr) {}
+        OPCodeA5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA5, Maker) {}
+        OPCodeA5(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA5, Maker) {}
+        OPCodeA5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA5, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    //0xA6
-    class OPCodeA6: public Instruction{
-    public:
-        OPCodeA6():Instruction(-1,0xA6,nullptr){}
-        OPCodeA6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA6,Maker){}
-        OPCodeA6(int addr, Builder *Maker):Instruction(addr,"???",0xA6,Maker){}
-        OPCodeA6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA6,Maker){
+    // 0xA6
+    class OPCodeA6 : public Instruction {
+      public:
+        OPCodeA6()
+          : Instruction(-1, 0xA6, nullptr) {}
+        OPCodeA6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA6, Maker) {}
+        OPCodeA6(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA6, Maker) {}
+        OPCodeA6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA6, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
                 case 0x03:
                 case 0x01:
                 case 0x04:
-                case 0x0E:
-                {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    break;
-                }
-
-            }
-        }
-    };
-    //0xA7
-    class OPCodeA7: public Instruction{
-    public:
-        OPCodeA7():Instruction(-1,0xA7,nullptr){}
-        OPCodeA7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA7,Maker){}
-        OPCodeA7(int addr, Builder *Maker):Instruction(addr,"???",0xA7,Maker){}
-        OPCodeA7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA7,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    //0xA8
-    class OPCodeA8: public Instruction{
-    public:
-        OPCodeA8():Instruction(-1,0xA8,nullptr){}
-        OPCodeA8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA8,Maker){}
-        OPCodeA8(int addr, Builder *Maker):Instruction(addr,"???",0xA8,Maker){}
-        OPCodeA8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA8,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-        }
-    };
-    //0xA9
-    class OPCodeA9: public Instruction{
-    public:
-        OPCodeA9():Instruction(-1,0xA9,nullptr){}
-        OPCodeA9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA9,Maker){}
-        OPCodeA9(int addr, Builder *Maker):Instruction(addr,"???",0xA9,Maker){}
-        OPCodeA9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA9,Maker){
-            addr++;
-
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-        }
-    };
-    //0xAA
-    class OPCodeAA: public Instruction{
-    public:
-        OPCodeAA():Instruction(-1,0xAA,nullptr){}
-        OPCodeAA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAA,Maker){}
-        OPCodeAA(int addr, Builder *Maker):Instruction(addr,"???",0xAA,Maker){}
-        OPCodeAA(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAA,Maker){
-            addr++;
-        }
-    };
-    //0xAB
-    class OPCodeAB: public Instruction{
-    public:
-        OPCodeAB():Instruction(-1,0xAB,nullptr){}
-        OPCodeAB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAB,Maker){}
-        OPCodeAB(int addr, Builder *Maker):Instruction(addr,"???",0xAB,Maker){}
-        OPCodeAB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAB,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-
-        }
-    };
-    //0xAC
-    class OPCodeAC: public Instruction{
-    public:
-        OPCodeAC():Instruction(-1,0xAC,nullptr){}
-        OPCodeAC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAC,Maker){}
-        OPCodeAC(int addr, Builder *Maker):Instruction(addr,"???",0xAC,Maker){}
-        OPCodeAC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAC,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-
-
-        }
-    };
-    //0xAD
-    class OPCodeAD: public Instruction{
-    public:
-        OPCodeAD():Instruction(-1,0xAD,nullptr){}
-        OPCodeAD(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAD,Maker){}
-        OPCodeAD(int addr, Builder *Maker):Instruction(addr,"???",0xAD,Maker){}
-        OPCodeAD(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAD,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-
-        }
-    };
-    //0xAE
-    class OPCodeAE: public Instruction{
-    public:
-        OPCodeAE():Instruction(-1,0xAE,nullptr){}
-        OPCodeAE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAE,Maker){}
-        OPCodeAE(int addr, Builder *Maker):Instruction(addr,"???",0xAE,Maker){}
-        OPCodeAE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAE,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-
-        }
-    };
-    //0xAF
-    class OPCodeAF: public Instruction{
-    public:
-        OPCodeAF():Instruction(-1,0xAF,nullptr){}
-        OPCodeAF(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAF,Maker){}
-        OPCodeAF(int addr, Builder *Maker):Instruction(addr,"???",0xAF,Maker){}
-        OPCodeAF(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAF,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+                case 0x0E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
             }
-
-
         }
     };
-    //0xB0
-    class OPCodeB0: public Instruction{
-    public:
-        OPCodeB0():Instruction(-1,0xB0,nullptr){}
-        OPCodeB0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB0,Maker){}
-        OPCodeB0(int addr, Builder *Maker):Instruction(addr,"???",0xB0,Maker){}
-        OPCodeB0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB0,Maker){
+    // 0xA7
+    class OPCodeA7 : public Instruction {
+      public:
+        OPCodeA7()
+          : Instruction(-1, 0xA7, nullptr) {}
+        OPCodeA7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA7, Maker) {}
+        OPCodeA7(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA7, Maker) {}
+        OPCodeA7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA7, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0xA8
+    class OPCodeA8 : public Instruction {
+      public:
+        OPCodeA8()
+          : Instruction(-1, 0xA8, nullptr) {}
+        OPCodeA8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA8, Maker) {}
+        OPCodeA8(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA8, Maker) {}
+        OPCodeA8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA8, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0xA9
+    class OPCodeA9 : public Instruction {
+      public:
+        OPCodeA9()
+          : Instruction(-1, 0xA9, nullptr) {}
+        OPCodeA9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA9, Maker) {}
+        OPCodeA9(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA9, Maker) {}
+        OPCodeA9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA9, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0xAA
+    class OPCodeAA : public Instruction {
+      public:
+        OPCodeAA()
+          : Instruction(-1, 0xAA, nullptr) {}
+        OPCodeAA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAA, Maker) {}
+        OPCodeAA(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAA, Maker) {}
+        OPCodeAA(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAA, Maker) {
+            addr++;
+        }
+    };
+    // 0xAB
+    class OPCodeAB : public Instruction {
+      public:
+        OPCodeAB()
+          : Instruction(-1, 0xAB, nullptr) {}
+        OPCodeAB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAB, Maker) {}
+        OPCodeAB(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAB, Maker) {}
+        OPCodeAB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAB, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0xAC
+    class OPCodeAC : public Instruction {
+      public:
+        OPCodeAC()
+          : Instruction(-1, 0xAC, nullptr) {}
+        OPCodeAC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAC, Maker) {}
+        OPCodeAC(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAC, Maker) {}
+        OPCodeAC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAC, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0xAD
+    class OPCodeAD : public Instruction {
+      public:
+        OPCodeAD()
+          : Instruction(-1, 0xAD, nullptr) {}
+        OPCodeAD(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAD, Maker) {}
+        OPCodeAD(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAD, Maker) {}
+        OPCodeAD(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAD, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0xAE
+    class OPCodeAE : public Instruction {
+      public:
+        OPCodeAE()
+          : Instruction(-1, 0xAE, nullptr) {}
+        OPCodeAE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAE, Maker) {}
+        OPCodeAE(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAE, Maker) {}
+        OPCodeAE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAE, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0xAF
+    class OPCodeAF : public Instruction {
+      public:
+        OPCodeAF()
+          : Instruction(-1, 0xAF, nullptr) {}
+        OPCodeAF(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAF, Maker) {}
+        OPCodeAF(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAF, Maker) {}
+        OPCodeAF(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAF, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x01: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
                     break;
                 }
             }
-
-
-
         }
     };
-    //0xB1
-    class OPCodeB1: public Instruction{
-    public:
-        OPCodeB1():Instruction(-1,0xB1,nullptr){}
-        OPCodeB1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB1,Maker){}
-        OPCodeB1(int addr, Builder *Maker):Instruction(addr,"???",0xB1,Maker){}
-        OPCodeB1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB1,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0xB2
-    class OPCodeB2: public Instruction{
-    public:
-        OPCodeB2():Instruction(-1,0xB2,nullptr){}
-        OPCodeB2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB2,Maker){}
-        OPCodeB2(int addr, Builder *Maker):Instruction(addr,"???",0xB2,Maker){}
-        OPCodeB2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB2,Maker){
+    // 0xB0
+    class OPCodeB0 : public Instruction {
+      public:
+        OPCodeB0()
+          : Instruction(-1, 0xB0, nullptr) {}
+        OPCodeB0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB0, Maker) {}
+        OPCodeB0(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB0, Maker) {}
+        OPCodeB0(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB0, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+            }
+        }
+    };
+    // 0xB1
+    class OPCodeB1 : public Instruction {
+      public:
+        OPCodeB1()
+          : Instruction(-1, 0xB1, nullptr) {}
+        OPCodeB1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB1, Maker) {}
+        OPCodeB1(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB1, Maker) {}
+        OPCodeB1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB1, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0xB2
+    class OPCodeB2 : public Instruction {
+      public:
+        OPCodeB2()
+          : Instruction(-1, 0xB2, nullptr) {}
+        OPCodeB2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB2, Maker) {}
+        OPCodeB2(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB2, Maker) {}
+        OPCodeB2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB2, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x00:
-                case 0x06:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x06: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x03:
-                case 0x04:{
-
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-            }
-
-
-
-        }
-    };
-    //0xB3
-    class OPCodeB3: public Instruction{
-    public:
-        OPCodeB3():Instruction(-1,0xB3,nullptr){}
-        OPCodeB3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB3,Maker){}
-        OPCodeB3(int addr, Builder *Maker):Instruction(addr,"???",0xB3,Maker){}
-        OPCodeB3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB3,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    break;
-                }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x03:
-                {
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x0A:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x04: {
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
             }
-
-
-
         }
     };
-    //0xB4
-    class OPCodeB4: public Instruction{
-    public:
-        OPCodeB4():Instruction(-1,0xB4,nullptr){}
-        OPCodeB4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB4,Maker){}
-        OPCodeB4(int addr, Builder *Maker):Instruction(addr,"???",0xB4,Maker){}
-        OPCodeB4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB4,Maker){
+    // 0xB3
+    class OPCodeB3 : public Instruction {
+      public:
+        OPCodeB3()
+          : Instruction(-1, 0xB3, nullptr) {}
+        OPCodeB3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB3, Maker) {}
+        OPCodeB3(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB3, Maker) {}
+        OPCodeB3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB3, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-
-
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+            }
         }
     };
-    //0xB5
-    class OPCodeB5: public Instruction{
-    public:
-        OPCodeB5():Instruction(-1,0xB5,nullptr){}
-        OPCodeB5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB5,Maker){}
-        OPCodeB5(int addr, Builder *Maker):Instruction(addr,"???",0xB5,Maker){}
-        OPCodeB5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB5,Maker){
+    // 0xB4
+    class OPCodeB4 : public Instruction {
+      public:
+        OPCodeB4()
+          : Instruction(-1, 0xB4, nullptr) {}
+        OPCodeB4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB4, Maker) {}
+        OPCodeB4(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB4, Maker) {}
+        OPCodeB4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB4, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-
-
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    std::shared_ptr<Instruction> CreateInstructionFromDAT(int &addr, QByteArray &dat_content, int function_type){
-        int OP = (dat_content[addr]&0xFF);
+    // 0xB5
+    class OPCodeB5 : public Instruction {
+      public:
+        OPCodeB5()
+          : Instruction(-1, 0xB5, nullptr) {}
+        OPCodeB5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB5, Maker) {}
+        OPCodeB5(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB5, Maker) {}
+        OPCodeB5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB5, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    std::shared_ptr<Instruction> CreateInstructionFromDAT(int& addr, QByteArray& dat_content, int function_type) {
+        int OP = (dat_content[addr] & 0xFF);
         int i = CS2UIFiles.indexOf(SceneName);
-        if ((i != -1)&&(OP == 0x13)) return std::make_shared<UI_OP13>(addr,dat_content,this); //UI files have a special 0x13 instruction
+        if ((i != -1) && (OP == 0x13))
+            return std::make_shared<UI_OP13>(addr, dat_content, this); // UI files have a special 0x13 instruction
 
-        if (function_type == 0){ //the function is read with OPCodes
+        if (function_type == 0) { // the function is read with OPCodes
 
-            switch(OP){
-                case 0x00: return std::make_shared<OPCode0>(addr,dat_content,this);
-                case 0x01: return std::make_shared<OPCode1>(addr,dat_content,this);
-                case 0x02: return std::make_shared<OPCode02>(addr,dat_content,this);
-                case 0x03: return std::make_shared<OPCode03>(addr,dat_content,this);
-                case 0x04: return std::make_shared<OPCode04>(addr,dat_content,this);
-                case 0x05: return std::make_shared<OPCode05>(addr,dat_content,this);
-                case 0x06: return std::make_shared<OPCode06>(addr,dat_content,this);
-                case 0x07: return std::make_shared<OPCode07>(addr,dat_content,this);
-                case 0x08: return std::make_shared<OPCode08>(addr,dat_content,this);
-                case 0x0A: return std::make_shared<OPCode0A>(addr,dat_content,this);
-                case 0x0C: return std::make_shared<OPCode0C>(addr,dat_content,this);
-                case 0x0D: return std::make_shared<OPCode0D>(addr,dat_content,this);
-                case 0x0E: return std::make_shared<OPCode0E>(addr,dat_content,this);
-                case 0x0F: return std::make_shared<OPCode0F>(addr,dat_content,this);
-                case 0x10: return std::make_shared<OPCode10>(addr,dat_content,this);
-                case 0x11: return std::make_shared<OPCode11>(addr,dat_content,this);
-                case 0x12: return std::make_shared<OPCode12>(addr,dat_content,this);
-                case 0x13: return std::make_shared<OPCode13>(addr,dat_content,this);
-                case 0x14: return std::make_shared<OPCode14>(addr,dat_content,this);
-                case 0x15: return std::make_shared<OPCode15>(addr,dat_content,this);
-                case 0x16: return std::make_shared<OPCode16>(addr,dat_content,this);
-                case 0x17: return std::make_shared<OPCode17>(addr,dat_content,this);
-                case 0x18: return std::make_shared<OPCode18>(addr,dat_content,this);
-                case 0x19: return std::make_shared<OPCode19>(addr,dat_content,this);
-                case 0x1A: return std::make_shared<OPCode1A>(addr,dat_content,this);
-                case 0x1B: return std::make_shared<OPCode1B>(addr,dat_content,this);
-                case 0x1C: return std::make_shared<OPCode1C>(addr,dat_content,this);
-                case 0x1D: return std::make_shared<OPCode1D>(addr,dat_content,this);
-                case 0x1E: return std::make_shared<OPCode1E>(addr,dat_content,this);
-                case 0x1F: return std::make_shared<OPCode1F>(addr,dat_content,this);
-                case 0x20: return std::make_shared<OPCode20>(addr,dat_content,this);
-                case 0x21: return std::make_shared<OPCode21>(addr,dat_content,this);
-                case 0x22: return std::make_shared<OPCode22>(addr,dat_content,this);
-                case 0x23: return std::make_shared<OPCode23>(addr,dat_content,this);
-                case 0x24: return std::make_shared<OPCode24>(addr,dat_content,this);
-                case 0x25: return std::make_shared<OPCode25>(addr,dat_content,this);
-                case 0x26: return std::make_shared<OPCode26>(addr,dat_content,this);
-                case 0x27: return std::make_shared<OPCode27>(addr,dat_content,this);
-                case 0x28: return std::make_shared<OPCode28>(addr,dat_content,this);
-                case 0x29: return std::make_shared<OPCode29>(addr,dat_content,this);
-                case 0x2A: return std::make_shared<OPCode2A>(addr,dat_content,this);
-                case 0x2B: return std::make_shared<OPCode2B>(addr,dat_content,this);
-                case 0x2C: return std::make_shared<OPCode2C>(addr,dat_content,this);
-                case 0x2D: return std::make_shared<OPCode2D>(addr,dat_content,this);
-                case 0x2E: return std::make_shared<OPCode2E>(addr,dat_content,this);
-                case 0x2F: return std::make_shared<OPCode2F>(addr,dat_content,this);
-                case 0x30: return std::make_shared<OPCode30>(addr,dat_content,this);
-                case 0x31: return std::make_shared<OPCode31>(addr,dat_content,this);
-                case 0x32: return std::make_shared<OPCode32>(addr,dat_content,this);
-                case 0x33: return std::make_shared<OPCode33>(addr,dat_content,this);
-                case 0x34: return std::make_shared<OPCode34>(addr,dat_content,this);
-                case 0x35: return std::make_shared<OPCode35>(addr,dat_content,this);
-                case 0x36: return std::make_shared<OPCode36>(addr,dat_content,this);
-                case 0x37: return std::make_shared<OPCode37>(addr,dat_content,this);
-                case 0x38: return std::make_shared<OPCode38>(addr,dat_content,this);
-                case 0x39: return std::make_shared<OPCode39>(addr,dat_content,this);
-                case 0x3A: return std::make_shared<OPCode3A>(addr,dat_content,this);
-                case 0x3B: return std::make_shared<OPCode3B>(addr,dat_content,this);
-                case 0x3C: return std::make_shared<OPCode3C>(addr,dat_content,this);
-                case 0x3D: return std::make_shared<OPCode3D>(addr,dat_content,this);
-                case 0x3E: return std::make_shared<OPCode3E>(addr,dat_content,this);
-                case 0x3F: return std::make_shared<OPCode3F>(addr,dat_content,this);
-                case 0x40: return std::make_shared<OPCode40>(addr,dat_content,this);
-                case 0x41: return std::make_shared<OPCode41>(addr,dat_content,this);
-                case 0x42: return std::make_shared<OPCode42>(addr,dat_content,this);
-                case 0x43: return std::make_shared<OPCode43>(addr,dat_content,this);
-                case 0x44: return std::make_shared<OPCode44>(addr,dat_content,this);
-                case 0x45: return std::make_shared<OPCode45>(addr,dat_content,this);
-                case 0x46: return std::make_shared<OPCode46>(addr,dat_content,this);
-                case 0x47: return std::make_shared<OPCode47>(addr,dat_content,this);
-                case 0x48: return std::make_shared<OPCode48>(addr,dat_content,this);
-                case 0x49: return std::make_shared<OPCode49>(addr,dat_content,this);
-                case 0x4A: return std::make_shared<OPCode4A>(addr,dat_content,this);
-                case 0x4B: return std::make_shared<OPCode4B>(addr,dat_content,this);
-                case 0x4C: return std::make_shared<OPCode4C>(addr,dat_content,this);
-                case 0x4D: return std::make_shared<OPCode4D>(addr,dat_content,this);
-                case 0x4E: return std::make_shared<OPCode4E>(addr,dat_content,this);
-                case 0x4F: return std::make_shared<OPCode4F>(addr,dat_content,this);
-                case 0x50: return std::make_shared<OPCode50>(addr,dat_content,this);
-                case 0x51: return std::make_shared<OPCode51>(addr,dat_content,this);
-                case 0x52: return std::make_shared<OPCode52>(addr,dat_content,this);
-                case 0x53: return std::make_shared<OPCode53>(addr,dat_content,this);
-                case 0x54: return std::make_shared<OPCode54>(addr,dat_content,this);
-                //case 0x55: return std::make_shared<OPCode55>(addr,dat_content,this);
-                case 0x56: return std::make_shared<OPCode56>(addr,dat_content,this);
-                case 0x57: return std::make_shared<OPCode57>(addr,dat_content,this);
-                case 0x58: return std::make_shared<OPCode58>(addr,dat_content,this);
-                case 0x59: return std::make_shared<OPCode59>(addr,dat_content,this);
-                //case 0x5A: return std::make_shared<OPCode5A>(addr,dat_content,this);
-                case 0x5B: return std::make_shared<OPCode5B>(addr,dat_content,this);
-                case 0x5C: return std::make_shared<OPCode5C>(addr,dat_content,this);
-                case 0x5D: return std::make_shared<OPCode5D>(addr,dat_content,this);
-                case 0x5E: return std::make_shared<OPCode5E>(addr,dat_content,this);
-                case 0x5F: return std::make_shared<OPCode5F>(addr,dat_content,this);
-                case 0x60: return std::make_shared<OPCode60>(addr,dat_content,this);
-                case 0x61: return std::make_shared<OPCode61>(addr,dat_content,this);
-                case 0x62: return std::make_shared<OPCode62>(addr,dat_content,this);
-                //case 0x63: return std::make_shared<OPCode63>(addr,dat_content,this);
-                case 0x64: return std::make_shared<OPCode64>(addr,dat_content,this);
-                case 0x65: return std::make_shared<OPCode65>(addr,dat_content,this);
-                case 0x66: return std::make_shared<OPCode66>(addr,dat_content,this);
-                case 0x67: return std::make_shared<OPCode67>(addr,dat_content,this);
-                case 0x68: return std::make_shared<OPCode68>(addr,dat_content,this);
-                case 0x69: return std::make_shared<OPCode69>(addr,dat_content,this);
-                case 0x6A: return std::make_shared<OPCode6A>(addr,dat_content,this);
-                case 0x6B: return std::make_shared<OPCode6B>(addr,dat_content,this);
-                case 0x6C: return std::make_shared<OPCode6C>(addr,dat_content,this);
-                case 0x6D: return std::make_shared<OPCode6D>(addr,dat_content,this);
-                case 0x6E: return std::make_shared<OPCode6E>(addr,dat_content,this);
-                case 0x6F: return std::make_shared<OPCode6F>(addr,dat_content,this);
-                case 0x70: return std::make_shared<OPCode70>(addr,dat_content,this);
-                case 0x71: return std::make_shared<OPCode71>(addr,dat_content,this);
-                case 0x72: return std::make_shared<OPCode72>(addr,dat_content,this);
-                case 0x73: return std::make_shared<OPCode73>(addr,dat_content,this);
-                case 0x74: return std::make_shared<OPCode74>(addr,dat_content,this);
-                case 0x75: return std::make_shared<OPCode75>(addr,dat_content,this);
-                case 0x76: return std::make_shared<OPCode76>(addr,dat_content,this);
-                case 0x78: return std::make_shared<OPCode78>(addr,dat_content,this);
-                case 0x79: return std::make_shared<OPCode79>(addr,dat_content,this);
-                case 0x7A: return std::make_shared<OPCode7A>(addr,dat_content,this);
-                case 0x7B: return std::make_shared<OPCode7B>(addr,dat_content,this);
-                case 0x7C: return std::make_shared<OPCode7C>(addr,dat_content,this);
-                //case 0x7D: return std::make_shared<OPCode7D>(addr,dat_content,this);
-                case 0x7E: return std::make_shared<OPCode7E>(addr,dat_content,this);
-                case 0x7F: return std::make_shared<OPCode7F>(addr,dat_content,this);
-                case 0x80: return std::make_shared<OPCode80>(addr,dat_content,this);
-                case 0x81: return std::make_shared<OPCode81>(addr,dat_content,this);
-                case 0x82: return std::make_shared<OPCode82>(addr,dat_content,this);
-                case 0x83: return std::make_shared<OPCode83>(addr,dat_content,this);
-                case 0x84: return std::make_shared<OPCode84>(addr,dat_content,this);
-                case 0x85: return std::make_shared<OPCode85>(addr,dat_content,this);
-                case 0x86: return std::make_shared<OPCode86>(addr,dat_content,this);
-                case 0x87: return std::make_shared<OPCode87>(addr,dat_content,this);
-                case 0x88: return std::make_shared<OPCode88>(addr,dat_content,this);
-                case 0x89: return std::make_shared<OPCode89>(addr,dat_content,this);
-                case 0x8A: return std::make_shared<OPCode8A>(addr,dat_content,this);
-                case 0x8B: return std::make_shared<OPCode8B>(addr,dat_content,this);
-                //case 0x8C: return std::make_shared<OPCode8C>(addr,dat_content,this);
-                case 0x8D: return std::make_shared<OPCode8D>(addr,dat_content,this);
-                case 0x8E: return std::make_shared<OPCode8E>(addr,dat_content,this);
-                case 0x8F: return std::make_shared<OPCode8F>(addr,dat_content,this);
-                case 0x90: return std::make_shared<OPCode90>(addr,dat_content,this);
-                case 0x91: return std::make_shared<OPCode91>(addr,dat_content,this);
-                case 0x92: return std::make_shared<OPCode92>(addr,dat_content,this);
-                case 0x93: return std::make_shared<OPCode93>(addr,dat_content,this);
-                case 0x94: return std::make_shared<OPCode94>(addr,dat_content,this);
-                case 0x95: return std::make_shared<OPCode95>(addr,dat_content,this);
-                case 0x96: return std::make_shared<OPCode96>(addr,dat_content,this);
-                case 0x97: return std::make_shared<OPCode97>(addr,dat_content,this);
-                case 0x98: return std::make_shared<OPCode98>(addr,dat_content,this);
-                //case 0x99: return std::make_shared<OPCode99>(addr,dat_content,this);
-                case 0x9A: return std::make_shared<OPCode9A>(addr,dat_content,this);
-                case 0x9B: return std::make_shared<OPCode9B>(addr,dat_content,this);
-                case 0x9C: return std::make_shared<OPCode9C>(addr,dat_content,this);
-                //case 0x9D: return std::make_shared<OPCode9D>(addr,dat_content,this);
-                case 0x9E: return std::make_shared<OPCode9E>(addr,dat_content,this);
-                case 0x9F: return std::make_shared<OPCode9F>(addr,dat_content,this);
-                case 0xA0: return std::make_shared<OPCodeA0>(addr,dat_content,this);
-                case 0xA1: return std::make_shared<OPCodeA1>(addr,dat_content,this);
-                case 0xA2: return std::make_shared<OPCodeA2>(addr,dat_content,this);
-                case 0xA3: return std::make_shared<OPCodeA3>(addr,dat_content,this);
-                case 0xA4: return std::make_shared<OPCodeA4>(addr,dat_content,this);
-                case 0xA5: return std::make_shared<OPCodeA5>(addr,dat_content,this);
-                case 0xA6: return std::make_shared<OPCodeA6>(addr,dat_content,this);
-                case 0xA7: return std::make_shared<OPCodeA7>(addr,dat_content,this);
-                case 0xA8: return std::make_shared<OPCodeA8>(addr,dat_content,this);
-                case 0xA9: return std::make_shared<OPCodeA9>(addr,dat_content,this);
-                case 0xAA: return std::make_shared<OPCodeAA>(addr,dat_content,this);
-                case 0xAB: return std::make_shared<OPCodeAB>(addr,dat_content,this);
-                case 0xAC: return std::make_shared<OPCodeAC>(addr,dat_content,this);
-                case 0xAD: return std::make_shared<OPCodeAD>(addr,dat_content,this);
-                case 0xAE: return std::make_shared<OPCodeAE>(addr,dat_content,this);
-                case 0xAF: return std::make_shared<OPCodeAF>(addr,dat_content,this);
-                case 0xB0: return std::make_shared<OPCodeB0>(addr,dat_content,this);
-                case 0xB1: return std::make_shared<OPCodeB1>(addr,dat_content,this);
-                case 0xB2: return std::make_shared<OPCodeB2>(addr,dat_content,this);
-                case 0xB3: return std::make_shared<OPCodeB3>(addr,dat_content,this);
-                case 0xB4: return std::make_shared<OPCodeB4>(addr,dat_content,this);
-                case 0xB5: return std::make_shared<OPCodeB5>(addr,dat_content,this);
+            switch (OP) {
+                case 0x00:
+                    return std::make_shared<OPCode0>(addr, dat_content, this);
+                case 0x01:
+                    return std::make_shared<OPCode1>(addr, dat_content, this);
+                case 0x02:
+                    return std::make_shared<OPCode02>(addr, dat_content, this);
+                case 0x03:
+                    return std::make_shared<OPCode03>(addr, dat_content, this);
+                case 0x04:
+                    return std::make_shared<OPCode04>(addr, dat_content, this);
+                case 0x05:
+                    return std::make_shared<OPCode05>(addr, dat_content, this);
+                case 0x06:
+                    return std::make_shared<OPCode06>(addr, dat_content, this);
+                case 0x07:
+                    return std::make_shared<OPCode07>(addr, dat_content, this);
+                case 0x08:
+                    return std::make_shared<OPCode08>(addr, dat_content, this);
+                case 0x0A:
+                    return std::make_shared<OPCode0A>(addr, dat_content, this);
+                case 0x0C:
+                    return std::make_shared<OPCode0C>(addr, dat_content, this);
+                case 0x0D:
+                    return std::make_shared<OPCode0D>(addr, dat_content, this);
+                case 0x0E:
+                    return std::make_shared<OPCode0E>(addr, dat_content, this);
+                case 0x0F:
+                    return std::make_shared<OPCode0F>(addr, dat_content, this);
+                case 0x10:
+                    return std::make_shared<OPCode10>(addr, dat_content, this);
+                case 0x11:
+                    return std::make_shared<OPCode11>(addr, dat_content, this);
+                case 0x12:
+                    return std::make_shared<OPCode12>(addr, dat_content, this);
+                case 0x13:
+                    return std::make_shared<OPCode13>(addr, dat_content, this);
+                case 0x14:
+                    return std::make_shared<OPCode14>(addr, dat_content, this);
+                case 0x15:
+                    return std::make_shared<OPCode15>(addr, dat_content, this);
+                case 0x16:
+                    return std::make_shared<OPCode16>(addr, dat_content, this);
+                case 0x17:
+                    return std::make_shared<OPCode17>(addr, dat_content, this);
+                case 0x18:
+                    return std::make_shared<OPCode18>(addr, dat_content, this);
+                case 0x19:
+                    return std::make_shared<OPCode19>(addr, dat_content, this);
+                case 0x1A:
+                    return std::make_shared<OPCode1A>(addr, dat_content, this);
+                case 0x1B:
+                    return std::make_shared<OPCode1B>(addr, dat_content, this);
+                case 0x1C:
+                    return std::make_shared<OPCode1C>(addr, dat_content, this);
+                case 0x1D:
+                    return std::make_shared<OPCode1D>(addr, dat_content, this);
+                case 0x1E:
+                    return std::make_shared<OPCode1E>(addr, dat_content, this);
+                case 0x1F:
+                    return std::make_shared<OPCode1F>(addr, dat_content, this);
+                case 0x20:
+                    return std::make_shared<OPCode20>(addr, dat_content, this);
+                case 0x21:
+                    return std::make_shared<OPCode21>(addr, dat_content, this);
+                case 0x22:
+                    return std::make_shared<OPCode22>(addr, dat_content, this);
+                case 0x23:
+                    return std::make_shared<OPCode23>(addr, dat_content, this);
+                case 0x24:
+                    return std::make_shared<OPCode24>(addr, dat_content, this);
+                case 0x25:
+                    return std::make_shared<OPCode25>(addr, dat_content, this);
+                case 0x26:
+                    return std::make_shared<OPCode26>(addr, dat_content, this);
+                case 0x27:
+                    return std::make_shared<OPCode27>(addr, dat_content, this);
+                case 0x28:
+                    return std::make_shared<OPCode28>(addr, dat_content, this);
+                case 0x29:
+                    return std::make_shared<OPCode29>(addr, dat_content, this);
+                case 0x2A:
+                    return std::make_shared<OPCode2A>(addr, dat_content, this);
+                case 0x2B:
+                    return std::make_shared<OPCode2B>(addr, dat_content, this);
+                case 0x2C:
+                    return std::make_shared<OPCode2C>(addr, dat_content, this);
+                case 0x2D:
+                    return std::make_shared<OPCode2D>(addr, dat_content, this);
+                case 0x2E:
+                    return std::make_shared<OPCode2E>(addr, dat_content, this);
+                case 0x2F:
+                    return std::make_shared<OPCode2F>(addr, dat_content, this);
+                case 0x30:
+                    return std::make_shared<OPCode30>(addr, dat_content, this);
+                case 0x31:
+                    return std::make_shared<OPCode31>(addr, dat_content, this);
+                case 0x32:
+                    return std::make_shared<OPCode32>(addr, dat_content, this);
+                case 0x33:
+                    return std::make_shared<OPCode33>(addr, dat_content, this);
+                case 0x34:
+                    return std::make_shared<OPCode34>(addr, dat_content, this);
+                case 0x35:
+                    return std::make_shared<OPCode35>(addr, dat_content, this);
+                case 0x36:
+                    return std::make_shared<OPCode36>(addr, dat_content, this);
+                case 0x37:
+                    return std::make_shared<OPCode37>(addr, dat_content, this);
+                case 0x38:
+                    return std::make_shared<OPCode38>(addr, dat_content, this);
+                case 0x39:
+                    return std::make_shared<OPCode39>(addr, dat_content, this);
+                case 0x3A:
+                    return std::make_shared<OPCode3A>(addr, dat_content, this);
+                case 0x3B:
+                    return std::make_shared<OPCode3B>(addr, dat_content, this);
+                case 0x3C:
+                    return std::make_shared<OPCode3C>(addr, dat_content, this);
+                case 0x3D:
+                    return std::make_shared<OPCode3D>(addr, dat_content, this);
+                case 0x3E:
+                    return std::make_shared<OPCode3E>(addr, dat_content, this);
+                case 0x3F:
+                    return std::make_shared<OPCode3F>(addr, dat_content, this);
+                case 0x40:
+                    return std::make_shared<OPCode40>(addr, dat_content, this);
+                case 0x41:
+                    return std::make_shared<OPCode41>(addr, dat_content, this);
+                case 0x42:
+                    return std::make_shared<OPCode42>(addr, dat_content, this);
+                case 0x43:
+                    return std::make_shared<OPCode43>(addr, dat_content, this);
+                case 0x44:
+                    return std::make_shared<OPCode44>(addr, dat_content, this);
+                case 0x45:
+                    return std::make_shared<OPCode45>(addr, dat_content, this);
+                case 0x46:
+                    return std::make_shared<OPCode46>(addr, dat_content, this);
+                case 0x47:
+                    return std::make_shared<OPCode47>(addr, dat_content, this);
+                case 0x48:
+                    return std::make_shared<OPCode48>(addr, dat_content, this);
+                case 0x49:
+                    return std::make_shared<OPCode49>(addr, dat_content, this);
+                case 0x4A:
+                    return std::make_shared<OPCode4A>(addr, dat_content, this);
+                case 0x4B:
+                    return std::make_shared<OPCode4B>(addr, dat_content, this);
+                case 0x4C:
+                    return std::make_shared<OPCode4C>(addr, dat_content, this);
+                case 0x4D:
+                    return std::make_shared<OPCode4D>(addr, dat_content, this);
+                case 0x4E:
+                    return std::make_shared<OPCode4E>(addr, dat_content, this);
+                case 0x4F:
+                    return std::make_shared<OPCode4F>(addr, dat_content, this);
+                case 0x50:
+                    return std::make_shared<OPCode50>(addr, dat_content, this);
+                case 0x51:
+                    return std::make_shared<OPCode51>(addr, dat_content, this);
+                case 0x52:
+                    return std::make_shared<OPCode52>(addr, dat_content, this);
+                case 0x53:
+                    return std::make_shared<OPCode53>(addr, dat_content, this);
+                case 0x54:
+                    return std::make_shared<OPCode54>(addr, dat_content, this);
+                // case 0x55: return std::make_shared<OPCode55>(addr,dat_content,this);
+                case 0x56:
+                    return std::make_shared<OPCode56>(addr, dat_content, this);
+                case 0x57:
+                    return std::make_shared<OPCode57>(addr, dat_content, this);
+                case 0x58:
+                    return std::make_shared<OPCode58>(addr, dat_content, this);
+                case 0x59:
+                    return std::make_shared<OPCode59>(addr, dat_content, this);
+                // case 0x5A: return std::make_shared<OPCode5A>(addr,dat_content,this);
+                case 0x5B:
+                    return std::make_shared<OPCode5B>(addr, dat_content, this);
+                case 0x5C:
+                    return std::make_shared<OPCode5C>(addr, dat_content, this);
+                case 0x5D:
+                    return std::make_shared<OPCode5D>(addr, dat_content, this);
+                case 0x5E:
+                    return std::make_shared<OPCode5E>(addr, dat_content, this);
+                case 0x5F:
+                    return std::make_shared<OPCode5F>(addr, dat_content, this);
+                case 0x60:
+                    return std::make_shared<OPCode60>(addr, dat_content, this);
+                case 0x61:
+                    return std::make_shared<OPCode61>(addr, dat_content, this);
+                case 0x62:
+                    return std::make_shared<OPCode62>(addr, dat_content, this);
+                // case 0x63: return std::make_shared<OPCode63>(addr,dat_content,this);
+                case 0x64:
+                    return std::make_shared<OPCode64>(addr, dat_content, this);
+                case 0x65:
+                    return std::make_shared<OPCode65>(addr, dat_content, this);
+                case 0x66:
+                    return std::make_shared<OPCode66>(addr, dat_content, this);
+                case 0x67:
+                    return std::make_shared<OPCode67>(addr, dat_content, this);
+                case 0x68:
+                    return std::make_shared<OPCode68>(addr, dat_content, this);
+                case 0x69:
+                    return std::make_shared<OPCode69>(addr, dat_content, this);
+                case 0x6A:
+                    return std::make_shared<OPCode6A>(addr, dat_content, this);
+                case 0x6B:
+                    return std::make_shared<OPCode6B>(addr, dat_content, this);
+                case 0x6C:
+                    return std::make_shared<OPCode6C>(addr, dat_content, this);
+                case 0x6D:
+                    return std::make_shared<OPCode6D>(addr, dat_content, this);
+                case 0x6E:
+                    return std::make_shared<OPCode6E>(addr, dat_content, this);
+                case 0x6F:
+                    return std::make_shared<OPCode6F>(addr, dat_content, this);
+                case 0x70:
+                    return std::make_shared<OPCode70>(addr, dat_content, this);
+                case 0x71:
+                    return std::make_shared<OPCode71>(addr, dat_content, this);
+                case 0x72:
+                    return std::make_shared<OPCode72>(addr, dat_content, this);
+                case 0x73:
+                    return std::make_shared<OPCode73>(addr, dat_content, this);
+                case 0x74:
+                    return std::make_shared<OPCode74>(addr, dat_content, this);
+                case 0x75:
+                    return std::make_shared<OPCode75>(addr, dat_content, this);
+                case 0x76:
+                    return std::make_shared<OPCode76>(addr, dat_content, this);
+                case 0x78:
+                    return std::make_shared<OPCode78>(addr, dat_content, this);
+                case 0x79:
+                    return std::make_shared<OPCode79>(addr, dat_content, this);
+                case 0x7A:
+                    return std::make_shared<OPCode7A>(addr, dat_content, this);
+                case 0x7B:
+                    return std::make_shared<OPCode7B>(addr, dat_content, this);
+                case 0x7C:
+                    return std::make_shared<OPCode7C>(addr, dat_content, this);
+                // case 0x7D: return std::make_shared<OPCode7D>(addr,dat_content,this);
+                case 0x7E:
+                    return std::make_shared<OPCode7E>(addr, dat_content, this);
+                case 0x7F:
+                    return std::make_shared<OPCode7F>(addr, dat_content, this);
+                case 0x80:
+                    return std::make_shared<OPCode80>(addr, dat_content, this);
+                case 0x81:
+                    return std::make_shared<OPCode81>(addr, dat_content, this);
+                case 0x82:
+                    return std::make_shared<OPCode82>(addr, dat_content, this);
+                case 0x83:
+                    return std::make_shared<OPCode83>(addr, dat_content, this);
+                case 0x84:
+                    return std::make_shared<OPCode84>(addr, dat_content, this);
+                case 0x85:
+                    return std::make_shared<OPCode85>(addr, dat_content, this);
+                case 0x86:
+                    return std::make_shared<OPCode86>(addr, dat_content, this);
+                case 0x87:
+                    return std::make_shared<OPCode87>(addr, dat_content, this);
+                case 0x88:
+                    return std::make_shared<OPCode88>(addr, dat_content, this);
+                case 0x89:
+                    return std::make_shared<OPCode89>(addr, dat_content, this);
+                case 0x8A:
+                    return std::make_shared<OPCode8A>(addr, dat_content, this);
+                case 0x8B:
+                    return std::make_shared<OPCode8B>(addr, dat_content, this);
+                // case 0x8C: return std::make_shared<OPCode8C>(addr,dat_content,this);
+                case 0x8D:
+                    return std::make_shared<OPCode8D>(addr, dat_content, this);
+                case 0x8E:
+                    return std::make_shared<OPCode8E>(addr, dat_content, this);
+                case 0x8F:
+                    return std::make_shared<OPCode8F>(addr, dat_content, this);
+                case 0x90:
+                    return std::make_shared<OPCode90>(addr, dat_content, this);
+                case 0x91:
+                    return std::make_shared<OPCode91>(addr, dat_content, this);
+                case 0x92:
+                    return std::make_shared<OPCode92>(addr, dat_content, this);
+                case 0x93:
+                    return std::make_shared<OPCode93>(addr, dat_content, this);
+                case 0x94:
+                    return std::make_shared<OPCode94>(addr, dat_content, this);
+                case 0x95:
+                    return std::make_shared<OPCode95>(addr, dat_content, this);
+                case 0x96:
+                    return std::make_shared<OPCode96>(addr, dat_content, this);
+                case 0x97:
+                    return std::make_shared<OPCode97>(addr, dat_content, this);
+                case 0x98:
+                    return std::make_shared<OPCode98>(addr, dat_content, this);
+                // case 0x99: return std::make_shared<OPCode99>(addr,dat_content,this);
+                case 0x9A:
+                    return std::make_shared<OPCode9A>(addr, dat_content, this);
+                case 0x9B:
+                    return std::make_shared<OPCode9B>(addr, dat_content, this);
+                case 0x9C:
+                    return std::make_shared<OPCode9C>(addr, dat_content, this);
+                // case 0x9D: return std::make_shared<OPCode9D>(addr,dat_content,this);
+                case 0x9E:
+                    return std::make_shared<OPCode9E>(addr, dat_content, this);
+                case 0x9F:
+                    return std::make_shared<OPCode9F>(addr, dat_content, this);
+                case 0xA0:
+                    return std::make_shared<OPCodeA0>(addr, dat_content, this);
+                case 0xA1:
+                    return std::make_shared<OPCodeA1>(addr, dat_content, this);
+                case 0xA2:
+                    return std::make_shared<OPCodeA2>(addr, dat_content, this);
+                case 0xA3:
+                    return std::make_shared<OPCodeA3>(addr, dat_content, this);
+                case 0xA4:
+                    return std::make_shared<OPCodeA4>(addr, dat_content, this);
+                case 0xA5:
+                    return std::make_shared<OPCodeA5>(addr, dat_content, this);
+                case 0xA6:
+                    return std::make_shared<OPCodeA6>(addr, dat_content, this);
+                case 0xA7:
+                    return std::make_shared<OPCodeA7>(addr, dat_content, this);
+                case 0xA8:
+                    return std::make_shared<OPCodeA8>(addr, dat_content, this);
+                case 0xA9:
+                    return std::make_shared<OPCodeA9>(addr, dat_content, this);
+                case 0xAA:
+                    return std::make_shared<OPCodeAA>(addr, dat_content, this);
+                case 0xAB:
+                    return std::make_shared<OPCodeAB>(addr, dat_content, this);
+                case 0xAC:
+                    return std::make_shared<OPCodeAC>(addr, dat_content, this);
+                case 0xAD:
+                    return std::make_shared<OPCodeAD>(addr, dat_content, this);
+                case 0xAE:
+                    return std::make_shared<OPCodeAE>(addr, dat_content, this);
+                case 0xAF:
+                    return std::make_shared<OPCodeAF>(addr, dat_content, this);
+                case 0xB0:
+                    return std::make_shared<OPCodeB0>(addr, dat_content, this);
+                case 0xB1:
+                    return std::make_shared<OPCodeB1>(addr, dat_content, this);
+                case 0xB2:
+                    return std::make_shared<OPCodeB2>(addr, dat_content, this);
+                case 0xB3:
+                    return std::make_shared<OPCodeB3>(addr, dat_content, this);
+                case 0xB4:
+                    return std::make_shared<OPCodeB4>(addr, dat_content, this);
+                case 0xB5:
+                    return std::make_shared<OPCodeB5>(addr, dat_content, this);
                 default:
-                std::stringstream stream;
-                stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
+                    std::stringstream stream;
+                    stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
 
-                error = true;
-                std::string result( stream.str() );
-                //qFatal(result.c_str());
+                    error = true;
+                    std::string result(stream.str());
+                    // qFatal(result.c_str());
 
-                return std::shared_ptr<Instruction>();
+                    return std::shared_ptr<Instruction>();
             }
-        }
-        else if (function_type==1){//the function is a "CreateMonsters" function
+        } else if (function_type == 1) { // the function is a "CreateMonsters" function
 
-            return std::make_shared<CreateMonsters>(addr,dat_content,this);
-        }
-        else if (function_type==2){//the function is a "effect" function
+            return std::make_shared<CreateMonsters>(addr, dat_content, this);
+        } else if (function_type == 2) { // the function is a "effect" function
 
-            return std::make_shared<EffectsInstr>(addr,dat_content,this);
-        }
-        else if (function_type==3){
+            return std::make_shared<EffectsInstr>(addr, dat_content, this);
+        } else if (function_type == 3) {
 
-            return std::make_shared<ActionTable>(addr,dat_content,this);
-        }
-        else if (function_type==4){
+            return std::make_shared<ActionTable>(addr, dat_content, this);
+        } else if (function_type == 4) {
 
-            return std::make_shared<AlgoTable>(addr,dat_content,this);
-        }
-        else if (function_type==5){
+            return std::make_shared<AlgoTable>(addr, dat_content, this);
+        } else if (function_type == 5) {
 
-            return std::make_shared<WeaponAttTable>(addr,dat_content,this);
-        }
-        else if (function_type==6){
+            return std::make_shared<WeaponAttTable>(addr, dat_content, this);
+        } else if (function_type == 6) {
 
-            return std::make_shared<BreakTable>(addr,dat_content,this);
-        }
-        else if (function_type==7){
+            return std::make_shared<BreakTable>(addr, dat_content, this);
+        } else if (function_type == 7) {
 
-            return std::make_shared<SummonTable>(addr,dat_content,this);
-        }
-        else if (function_type==8){
+            return std::make_shared<SummonTable>(addr, dat_content, this);
+        } else if (function_type == 8) {
 
-            return std::make_shared<ReactionTable>(addr,dat_content,this);
-        }
-        else if (function_type==9){
+            return std::make_shared<ReactionTable>(addr, dat_content, this);
+        } else if (function_type == 9) {
 
-            return std::make_shared<PartTable>(addr,dat_content,this);
-        }
-        else if (function_type==10){
+            return std::make_shared<PartTable>(addr, dat_content, this);
+        } else if (function_type == 10) {
 
-            return std::make_shared<AnimeClipTable>(addr,dat_content,this);
-        }
-        else if (function_type==11){
+            return std::make_shared<AnimeClipTable>(addr, dat_content, this);
+        } else if (function_type == 11) {
 
-            return std::make_shared<FieldMonsterData>(addr,dat_content,this);
-        }
-        else if (function_type==12){
+            return std::make_shared<FieldMonsterData>(addr, dat_content, this);
+        } else if (function_type == 12) {
 
-            return std::make_shared<FieldFollowData>(addr,dat_content,this);
-        }
-        else if (function_type==13){
+            return std::make_shared<FieldFollowData>(addr, dat_content, this);
+        } else if (function_type == 13) {
 
-            return std::make_shared<FC_autoX>(addr,dat_content,this);
-        }
-        else if (function_type==14){
+            return std::make_shared<FC_autoX>(addr, dat_content, this);
+        } else if (function_type == 14) {
 
-            return std::make_shared<BookData99>(addr,dat_content,this);
-        }
-        else if (function_type==15){
+            return std::make_shared<BookData99>(addr, dat_content, this);
+        } else if (function_type == 15) {
 
-            return std::make_shared<BookDataX>(addr,dat_content,this);
-        }
-        else if (function_type==16){
+            return std::make_shared<BookDataX>(addr, dat_content, this);
+        } else if (function_type == 16) {
 
-            return std::make_shared<AddCollision>(addr,dat_content,this);
-        }
-        else if (function_type==17){
+            return std::make_shared<AddCollision>(addr, dat_content, this);
+        } else if (function_type == 17) {
 
-            return std::make_shared<ConditionTable>(addr,dat_content,this);
+            return std::make_shared<ConditionTable>(addr, dat_content, this);
         }
 
         return std::shared_ptr<Instruction>();
     }
-    bool CreateHeaderFromDAT(QByteArray &dat_content){
+    bool CreateHeaderFromDAT(QByteArray& dat_content) {
 
-        //Header structure:
-        //The first 0x20 is something used to check if the file is a valid file: it will always be that value
-        //The second 0x20 is the offset for the file name (shouldn't change too)
-        //The next integer is the position of the first pointer
-        //The 4th: probably the length in bytes of the pointer section
-        //The fifth: probably the position of the "names positions" section (right after the pointer section)
-        //The sixth: the number of functions inside the file
-        //the seventh: the position one byte after the 0x00 separator at the end of the functions section
-        //the eighth: 0xABCDEF00 => seems to always be there (no idea why)
-        //Then the name of the file
-        //Then the pointer section
-        //Then the "names positions" section
-        //Then the functions section
-        //Done; here the "function" objects holds the number of functions, the addr, name positions
-        //everything else can be deduced to recreate the header
+        // Header structure:
+        // The first 0x20 is something used to check if the file is a valid file: it will always be that value
+        // The second 0x20 is the offset for the file name (shouldn't change too)
+        // The next integer is the position of the first pointer
+        // The 4th: probably the length in bytes of the pointer section
+        // The fifth: probably the position of the "names positions" section (right after the pointer section)
+        // The sixth: the number of functions inside the file
+        // the seventh: the position one byte after the 0x00 separator at the end of the functions section
+        // the eighth: 0xABCDEF00 => seems to always be there (no idea why)
+        // Then the name of the file
+        // Then the pointer section
+        // Then the "names positions" section
+        // Then the functions section
+        // Done; here the "function" objects holds the number of functions, the addr, name positions
+        // everything else can be deduced to recreate the header
         display_text("Reading header...");
         uint nb_functions = ReadIntegerFromByteArray(0x14, dat_content);
         uint position_filename = ReadIntegerFromByteArray(0x4, dat_content);
@@ -7007,231 +7900,419 @@ class CS2Builder : public Builder
         QString filename = ReadStringFromByteArray(position, dat_content);
         SceneName = filename;
         int start_offset_area = ReadIntegerFromByteArray(0x8, dat_content);
-        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++){
-            position = start_offset_area + 4*idx_fun;
-            next_position = start_offset_area + 4*(idx_fun+1);
+        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++) {
+            position = start_offset_area + 4 * idx_fun;
+            next_position = start_offset_area + 4 * (idx_fun + 1);
             int addr = ReadIntegerFromByteArray(position, dat_content);
-            position = start_offset_area + 4*nb_functions + 2 * idx_fun;
+            position = start_offset_area + 4 * nb_functions + 2 * idx_fun;
             short name_pos = ReadShortFromByteArray(position, dat_content);
             int name_pos_int = name_pos;
             QString function_name = ReadStringFromByteArray(name_pos_int, dat_content);
             int end_addr;
-            if (idx_fun == nb_functions-1) //we are at the last function, so it ends at the end of the file
+            if (idx_fun == nb_functions - 1) // we are at the last function, so it ends at the end of the file
                 end_addr = dat_content.size();
-            else
-            {
+            else {
                 end_addr = ReadIntegerFromByteArray(next_position, dat_content);
             }
-            FunctionsToParse.push_back(function(idx_fun,function_name,name_pos,addr,end_addr));
-
+            FunctionsToParse.push_back(function(idx_fun, function_name, name_pos, addr, end_addr));
         }
         display_text("Header parsed.");
         return true;
     }
-    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int &addr, int row, QXlsx::Document &xls_content){
+    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int& addr, int row, QXlsx::Document& xls_content) {
 
-        uint OP = xls_content.read(row+1, 2).toInt();
+        uint OP = xls_content.read(row + 1, 2).toInt();
         int i = CS2UIFiles.indexOf(SceneName);
-        if ((i != -1)&&(OP == 0x13)) return std::make_shared<UI_OP13>(addr,row, xls_content,this);
+        if ((i != -1) && (OP == 0x13)) return std::make_shared<UI_OP13>(addr, row, xls_content, this);
 
-        switch(OP){
-        case 0x00: return std::make_shared<OPCode0>(addr, row, xls_content,this);
-        case 0x01: return std::make_shared<OPCode1>(addr, row, xls_content,this);
-        case 0x02: return std::make_shared<OPCode02>(addr, row, xls_content,this);
-        case 0x03: return std::make_shared<OPCode03>(addr, row, xls_content,this);
-        case 0x04: return std::make_shared<OPCode04>(addr, row, xls_content,this);
-        case 0x05: return std::make_shared<OPCode05>(addr, row, xls_content,this);
-        case 0x06: return std::make_shared<OPCode06>(addr, row, xls_content,this);
-        case 0x07: return std::make_shared<OPCode07>(addr, row, xls_content,this);
-        case 0x08: return std::make_shared<OPCode08>(addr, row, xls_content,this);
-        case 0x0A: return std::make_shared<OPCode0A>(addr, row, xls_content,this);
-        case 0x0C: return std::make_shared<OPCode0C>(addr, row, xls_content,this);
-        case 0x0D: return std::make_shared<OPCode0D>(addr, row, xls_content,this);
-        case 0x0E: return std::make_shared<OPCode0E>(addr, row, xls_content,this);
-        case 0x0F: return std::make_shared<OPCode0F>(addr, row, xls_content,this);
-        case 0x10: return std::make_shared<OPCode10>(addr, row, xls_content,this);
-        case 0x11: return std::make_shared<OPCode11>(addr, row, xls_content,this);
-        case 0x12: return std::make_shared<OPCode12>(addr, row, xls_content,this);
-        case 0x13: return std::make_shared<OPCode13>(addr, row, xls_content,this);
-        case 0x14: return std::make_shared<OPCode14>(addr, row, xls_content,this);
-        case 0x15: return std::make_shared<OPCode15>(addr, row, xls_content,this);
-        case 0x16: return std::make_shared<OPCode16>(addr, row, xls_content,this);
-        case 0x17: return std::make_shared<OPCode17>(addr, row, xls_content,this);
-        case 0x18: return std::make_shared<OPCode18>(addr, row, xls_content,this);
-        case 0x19: return std::make_shared<OPCode19>(addr, row, xls_content,this);
-        case 0x1A: return std::make_shared<OPCode1A>(addr, row, xls_content,this);
-        case 0x1B: return std::make_shared<OPCode1B>(addr, row, xls_content,this);
-        case 0x1C: return std::make_shared<OPCode1C>(addr, row, xls_content,this);
-        case 0x1D: return std::make_shared<OPCode1D>(addr, row, xls_content,this);
-        case 0x1E: return std::make_shared<OPCode1E>(addr, row, xls_content,this);
-        case 0x1F: return std::make_shared<OPCode1F>(addr, row, xls_content,this);
-        case 0x20: return std::make_shared<OPCode20>(addr, row, xls_content,this);
-        case 0x21: return std::make_shared<OPCode21>(addr, row, xls_content,this);
-        case 0x22: return std::make_shared<OPCode22>(addr, row, xls_content,this);
-        case 0x23: return std::make_shared<OPCode23>(addr, row, xls_content,this);
-        case 0x24: return std::make_shared<OPCode24>(addr, row, xls_content,this);
-        case 0x25: return std::make_shared<OPCode25>(addr, row, xls_content,this);
-        case 0x26: return std::make_shared<OPCode26>(addr, row, xls_content,this);
-        case 0x27: return std::make_shared<OPCode27>(addr, row, xls_content,this);
-        case 0x28: return std::make_shared<OPCode28>(addr, row, xls_content,this);
-        case 0x29: return std::make_shared<OPCode29>(addr, row, xls_content,this);
-        case 0x2A: return std::make_shared<OPCode2A>(addr, row, xls_content,this);
-        case 0x2B: return std::make_shared<OPCode2B>(addr, row, xls_content,this);
-        case 0x2C: return std::make_shared<OPCode2C>(addr, row, xls_content,this);
-        case 0x2D: return std::make_shared<OPCode2D>(addr, row, xls_content,this);
-        case 0x2E: return std::make_shared<OPCode2E>(addr, row, xls_content,this);
-        case 0x2F: return std::make_shared<OPCode2F>(addr, row, xls_content,this);
-        case 0x30: return std::make_shared<OPCode30>(addr, row, xls_content,this);
-        case 0x31: return std::make_shared<OPCode31>(addr, row, xls_content,this);
-        case 0x32: return std::make_shared<OPCode32>(addr, row, xls_content,this);
-        case 0x33: return std::make_shared<OPCode33>(addr, row, xls_content,this);
-        case 0x34: return std::make_shared<OPCode34>(addr, row, xls_content,this);
-        case 0x35: return std::make_shared<OPCode35>(addr, row, xls_content,this);
-        case 0x36: return std::make_shared<OPCode36>(addr, row, xls_content,this);
-        case 0x37: return std::make_shared<OPCode37>(addr, row, xls_content,this);
-        case 0x38: return std::make_shared<OPCode38>(addr, row, xls_content,this);
-        case 0x39: return std::make_shared<OPCode39>(addr, row, xls_content,this);
-        case 0x3A: return std::make_shared<OPCode3A>(addr, row, xls_content,this);
-        case 0x3B: return std::make_shared<OPCode3B>(addr, row, xls_content,this);
-        case 0x3C: return std::make_shared<OPCode3C>(addr, row, xls_content,this);
-        case 0x3D: return std::make_shared<OPCode3D>(addr, row, xls_content,this);
-        case 0x3E: return std::make_shared<OPCode3E>(addr, row, xls_content,this);
-        case 0x3F: return std::make_shared<OPCode3F>(addr, row, xls_content,this);
-        case 0x40: return std::make_shared<OPCode40>(addr, row, xls_content,this);
-        case 0x41: return std::make_shared<OPCode41>(addr, row, xls_content,this);
-        case 0x42: return std::make_shared<OPCode42>(addr, row, xls_content,this);
-        case 0x43: return std::make_shared<OPCode43>(addr, row, xls_content,this);
-        case 0x44: return std::make_shared<OPCode44>(addr, row, xls_content,this);
-        case 0x45: return std::make_shared<OPCode45>(addr, row, xls_content,this);
-        case 0x46: return std::make_shared<OPCode46>(addr, row, xls_content,this);
-        case 0x47: return std::make_shared<OPCode47>(addr, row, xls_content,this);
-        case 0x48: return std::make_shared<OPCode48>(addr, row, xls_content,this);
-        case 0x49: return std::make_shared<OPCode49>(addr, row, xls_content,this);
-        case 0x4A: return std::make_shared<OPCode4A>(addr, row, xls_content,this);
-        case 0x4B: return std::make_shared<OPCode4B>(addr, row, xls_content,this);
-        case 0x4C: return std::make_shared<OPCode4C>(addr, row, xls_content,this);
-        case 0x4D: return std::make_shared<OPCode4D>(addr, row, xls_content,this);
-        case 0x4E: return std::make_shared<OPCode4E>(addr, row, xls_content,this);
-        case 0x4F: return std::make_shared<OPCode4F>(addr, row, xls_content,this);
-        case 0x50: return std::make_shared<OPCode50>(addr, row, xls_content,this);
-        case 0x51: return std::make_shared<OPCode51>(addr, row, xls_content,this);
-        case 0x52: return std::make_shared<OPCode52>(addr, row, xls_content,this);
-        case 0x53: return std::make_shared<OPCode53>(addr, row, xls_content,this);
-        case 0x54: return std::make_shared<OPCode54>(addr, row, xls_content,this);
-        //case 0x55: return std::make_shared<OPCode55>(addr, row, xls_content,this);
-        case 0x56: return std::make_shared<OPCode56>(addr, row, xls_content,this);
-        case 0x57: return std::make_shared<OPCode57>(addr, row, xls_content,this);
-        case 0x58: return std::make_shared<OPCode58>(addr, row, xls_content,this);
-        case 0x59: return std::make_shared<OPCode59>(addr, row, xls_content,this);
-        //case 0x5A: return std::make_shared<OPCode5A>(addr, row, xls_content,this);
-        case 0x5B: return std::make_shared<OPCode5B>(addr, row, xls_content,this);
-        case 0x5C: return std::make_shared<OPCode5C>(addr, row, xls_content,this);
-        case 0x5D: return std::make_shared<OPCode5D>(addr, row, xls_content,this);
-        case 0x5E: return std::make_shared<OPCode5E>(addr, row, xls_content,this);
-        case 0x5F: return std::make_shared<OPCode5F>(addr, row, xls_content,this);
-        case 0x60: return std::make_shared<OPCode60>(addr, row, xls_content,this);
-        case 0x61: return std::make_shared<OPCode61>(addr, row, xls_content,this);
-        case 0x62: return std::make_shared<OPCode62>(addr, row, xls_content,this);
-        //case 0x63: return std::make_shared<OPCode63>(addr, row, xls_content,this);
-        case 0x64: return std::make_shared<OPCode64>(addr, row, xls_content,this);
-        case 0x65: return std::make_shared<OPCode65>(addr, row, xls_content,this);
-        case 0x66: return std::make_shared<OPCode66>(addr, row, xls_content,this);
-        case 0x67: return std::make_shared<OPCode67>(addr, row, xls_content,this);
-        case 0x68: return std::make_shared<OPCode68>(addr, row, xls_content,this);
-        case 0x69: return std::make_shared<OPCode69>(addr, row, xls_content,this);
-        case 0x6A: return std::make_shared<OPCode6A>(addr, row, xls_content,this);
-        case 0x6B: return std::make_shared<OPCode6B>(addr, row, xls_content,this);
-        case 0x6C: return std::make_shared<OPCode6C>(addr, row, xls_content,this);
-        case 0x6D: return std::make_shared<OPCode6D>(addr, row, xls_content,this);
-        case 0x6E: return std::make_shared<OPCode6E>(addr, row, xls_content,this);
-        case 0x6F: return std::make_shared<OPCode6F>(addr, row, xls_content,this);
-        case 0x70: return std::make_shared<OPCode70>(addr, row, xls_content,this);
-        case 0x71: return std::make_shared<OPCode71>(addr, row, xls_content,this);
-        case 0x72: return std::make_shared<OPCode72>(addr, row, xls_content,this);
-        case 0x73: return std::make_shared<OPCode73>(addr, row, xls_content,this);
-        case 0x74: return std::make_shared<OPCode74>(addr, row, xls_content,this);
-        case 0x75: return std::make_shared<OPCode75>(addr, row, xls_content,this);
-        case 0x76: return std::make_shared<OPCode76>(addr, row, xls_content,this);
-        case 0x78: return std::make_shared<OPCode78>(addr, row, xls_content,this);
-        case 0x79: return std::make_shared<OPCode79>(addr, row, xls_content,this);
-        case 0x7A: return std::make_shared<OPCode7A>(addr, row, xls_content,this);
-        case 0x7B: return std::make_shared<OPCode7B>(addr, row, xls_content,this);
-        case 0x7C: return std::make_shared<OPCode7C>(addr, row, xls_content,this);
-        //case 0x7D: return std::make_shared<OPCode7D>(addr, row, xls_content,this);
-        case 0x7E: return std::make_shared<OPCode7E>(addr, row, xls_content,this);
-        case 0x7F: return std::make_shared<OPCode7F>(addr, row, xls_content,this);
-        case 0x80: return std::make_shared<OPCode80>(addr, row, xls_content,this);
-        case 0x81: return std::make_shared<OPCode81>(addr, row, xls_content,this);
-        case 0x82: return std::make_shared<OPCode82>(addr, row, xls_content,this);
-        case 0x83: return std::make_shared<OPCode83>(addr, row, xls_content,this);
-        case 0x84: return std::make_shared<OPCode84>(addr, row, xls_content,this);
-        case 0x85: return std::make_shared<OPCode85>(addr, row, xls_content,this);
-        case 0x86: return std::make_shared<OPCode86>(addr, row, xls_content,this);
-        case 0x87: return std::make_shared<OPCode87>(addr, row, xls_content,this);
-        case 0x88: return std::make_shared<OPCode88>(addr, row, xls_content,this);
-        case 0x89: return std::make_shared<OPCode89>(addr, row, xls_content,this);
-        case 0x8A: return std::make_shared<OPCode8A>(addr, row, xls_content,this);
-        case 0x8B: return std::make_shared<OPCode8B>(addr, row, xls_content,this);
-        //case 0x8C: return std::make_shared<OPCode8C>(addr, row, xls_content,this);
-        case 0x8D: return std::make_shared<OPCode8D>(addr, row, xls_content,this);
-        case 0x8E: return std::make_shared<OPCode8E>(addr, row, xls_content,this);
-        case 0x8F: return std::make_shared<OPCode8F>(addr, row, xls_content,this);
-        case 0x90: return std::make_shared<OPCode90>(addr, row, xls_content,this);
-        case 0x91: return std::make_shared<OPCode91>(addr, row, xls_content,this);
-        case 0x92: return std::make_shared<OPCode92>(addr, row, xls_content,this);
-        case 0x93: return std::make_shared<OPCode93>(addr, row, xls_content,this);
-        case 0x94: return std::make_shared<OPCode94>(addr, row, xls_content,this);
-        case 0x95: return std::make_shared<OPCode95>(addr, row, xls_content,this);
-        case 0x96: return std::make_shared<OPCode96>(addr, row, xls_content,this);
-        case 0x97: return std::make_shared<OPCode97>(addr, row, xls_content,this);
-        case 0x98: return std::make_shared<OPCode98>(addr, row, xls_content,this);
-        //case 0x99: return std::make_shared<OPCode99>(addr, row, xls_content,this);
-        case 0x9A: return std::make_shared<OPCode9A>(addr, row, xls_content,this);
-        case 0x9B: return std::make_shared<OPCode9B>(addr, row, xls_content,this);
-        case 0x9C: return std::make_shared<OPCode9C>(addr, row, xls_content,this);
-        //case 0x9D: return std::make_shared<OPCode9D>(addr, row, xls_content,this);
-        case 0x9E: return std::make_shared<OPCode9E>(addr, row, xls_content,this);
-        case 0x9F: return std::make_shared<OPCode9F>(addr, row, xls_content,this);
-        case 0xA0: return std::make_shared<OPCodeA0>(addr, row, xls_content,this);
-        case 0xA1: return std::make_shared<OPCodeA1>(addr, row, xls_content,this);
-        case 0xA2: return std::make_shared<OPCodeA2>(addr, row, xls_content,this);
-        case 0xA3: return std::make_shared<OPCodeA3>(addr, row, xls_content,this);
-        case 0xA4: return std::make_shared<OPCodeA4>(addr, row, xls_content,this);
-        case 0xA5: return std::make_shared<OPCodeA5>(addr, row, xls_content,this);
-        case 0xA6: return std::make_shared<OPCodeA6>(addr, row, xls_content,this);
-        case 0xA7: return std::make_shared<OPCodeA7>(addr, row, xls_content,this);
-        case 0xA8: return std::make_shared<OPCodeA8>(addr, row, xls_content,this);
-        case 0xA9: return std::make_shared<OPCodeA9>(addr, row, xls_content,this);
-        case 0xAA: return std::make_shared<OPCodeAA>(addr, row, xls_content,this);
-        case 0xAB: return std::make_shared<OPCodeAB>(addr, row, xls_content,this);
-        case 0xAC: return std::make_shared<OPCodeAC>(addr, row, xls_content,this);
-        case 0xAD: return std::make_shared<OPCodeAD>(addr, row, xls_content,this);
-        case 0xAE: return std::make_shared<OPCodeAE>(addr, row, xls_content,this);
-        case 0xAF: return std::make_shared<OPCodeAF>(addr, row, xls_content,this);
-        case 0xB0: return std::make_shared<OPCodeB0>(addr, row, xls_content,this);
-        case 0xB1: return std::make_shared<OPCodeB1>(addr, row, xls_content,this);
-        case 0xB2: return std::make_shared<OPCodeB2>(addr, row, xls_content,this);
-        case 0xB3: return std::make_shared<OPCodeB3>(addr, row, xls_content,this);
-        case 0xB4: return std::make_shared<OPCodeB4>(addr, row, xls_content,this);
-        case 0xB5: return std::make_shared<OPCodeB5>(addr, row, xls_content,this);
-        case 256: return std::make_shared<CreateMonsters>(addr, row, xls_content,this);
-        case 257: return std::make_shared<EffectsInstr>(addr, row, xls_content,this);
-        case 258: return std::make_shared<ActionTable>(addr, row, xls_content,this);
-        case 259: return std::make_shared<AlgoTable>(addr, row, xls_content,this);
-        case 260: return std::make_shared<WeaponAttTable>(addr, row, xls_content,this);
-        case 261: return std::make_shared<BreakTable>(addr, row, xls_content,this);
-        case 262: return std::make_shared<SummonTable>(addr, row, xls_content,this);
-        case 263: return std::make_shared<ReactionTable>(addr, row, xls_content,this);
-        case 264: return std::make_shared<PartTable>(addr, row, xls_content,this);
-        case 265: return std::make_shared<AnimeClipTable>(addr, row, xls_content,this);
-        case 266: return std::make_shared<FieldMonsterData>(addr, row, xls_content,this);
-        case 267: return std::make_shared<FieldFollowData>(addr, row, xls_content,this);
-        case 268: return std::make_shared<FC_autoX>(addr, row, xls_content,this);
-        case 269: return std::make_shared<BookData99>(addr, row, xls_content,this);
-        case 270: return std::make_shared<BookDataX>(addr, row, xls_content,this);
-        case 271: return std::make_shared<AddCollision>(addr, row, xls_content,this);
-        case 272: return std::make_shared<ConditionTable>(addr, row, xls_content,this);
-        case 273: return std::make_shared<AnimeClipData>(addr, row, xls_content,this);
+        switch (OP) {
+            case 0x00:
+                return std::make_shared<OPCode0>(addr, row, xls_content, this);
+            case 0x01:
+                return std::make_shared<OPCode1>(addr, row, xls_content, this);
+            case 0x02:
+                return std::make_shared<OPCode02>(addr, row, xls_content, this);
+            case 0x03:
+                return std::make_shared<OPCode03>(addr, row, xls_content, this);
+            case 0x04:
+                return std::make_shared<OPCode04>(addr, row, xls_content, this);
+            case 0x05:
+                return std::make_shared<OPCode05>(addr, row, xls_content, this);
+            case 0x06:
+                return std::make_shared<OPCode06>(addr, row, xls_content, this);
+            case 0x07:
+                return std::make_shared<OPCode07>(addr, row, xls_content, this);
+            case 0x08:
+                return std::make_shared<OPCode08>(addr, row, xls_content, this);
+            case 0x0A:
+                return std::make_shared<OPCode0A>(addr, row, xls_content, this);
+            case 0x0C:
+                return std::make_shared<OPCode0C>(addr, row, xls_content, this);
+            case 0x0D:
+                return std::make_shared<OPCode0D>(addr, row, xls_content, this);
+            case 0x0E:
+                return std::make_shared<OPCode0E>(addr, row, xls_content, this);
+            case 0x0F:
+                return std::make_shared<OPCode0F>(addr, row, xls_content, this);
+            case 0x10:
+                return std::make_shared<OPCode10>(addr, row, xls_content, this);
+            case 0x11:
+                return std::make_shared<OPCode11>(addr, row, xls_content, this);
+            case 0x12:
+                return std::make_shared<OPCode12>(addr, row, xls_content, this);
+            case 0x13:
+                return std::make_shared<OPCode13>(addr, row, xls_content, this);
+            case 0x14:
+                return std::make_shared<OPCode14>(addr, row, xls_content, this);
+            case 0x15:
+                return std::make_shared<OPCode15>(addr, row, xls_content, this);
+            case 0x16:
+                return std::make_shared<OPCode16>(addr, row, xls_content, this);
+            case 0x17:
+                return std::make_shared<OPCode17>(addr, row, xls_content, this);
+            case 0x18:
+                return std::make_shared<OPCode18>(addr, row, xls_content, this);
+            case 0x19:
+                return std::make_shared<OPCode19>(addr, row, xls_content, this);
+            case 0x1A:
+                return std::make_shared<OPCode1A>(addr, row, xls_content, this);
+            case 0x1B:
+                return std::make_shared<OPCode1B>(addr, row, xls_content, this);
+            case 0x1C:
+                return std::make_shared<OPCode1C>(addr, row, xls_content, this);
+            case 0x1D:
+                return std::make_shared<OPCode1D>(addr, row, xls_content, this);
+            case 0x1E:
+                return std::make_shared<OPCode1E>(addr, row, xls_content, this);
+            case 0x1F:
+                return std::make_shared<OPCode1F>(addr, row, xls_content, this);
+            case 0x20:
+                return std::make_shared<OPCode20>(addr, row, xls_content, this);
+            case 0x21:
+                return std::make_shared<OPCode21>(addr, row, xls_content, this);
+            case 0x22:
+                return std::make_shared<OPCode22>(addr, row, xls_content, this);
+            case 0x23:
+                return std::make_shared<OPCode23>(addr, row, xls_content, this);
+            case 0x24:
+                return std::make_shared<OPCode24>(addr, row, xls_content, this);
+            case 0x25:
+                return std::make_shared<OPCode25>(addr, row, xls_content, this);
+            case 0x26:
+                return std::make_shared<OPCode26>(addr, row, xls_content, this);
+            case 0x27:
+                return std::make_shared<OPCode27>(addr, row, xls_content, this);
+            case 0x28:
+                return std::make_shared<OPCode28>(addr, row, xls_content, this);
+            case 0x29:
+                return std::make_shared<OPCode29>(addr, row, xls_content, this);
+            case 0x2A:
+                return std::make_shared<OPCode2A>(addr, row, xls_content, this);
+            case 0x2B:
+                return std::make_shared<OPCode2B>(addr, row, xls_content, this);
+            case 0x2C:
+                return std::make_shared<OPCode2C>(addr, row, xls_content, this);
+            case 0x2D:
+                return std::make_shared<OPCode2D>(addr, row, xls_content, this);
+            case 0x2E:
+                return std::make_shared<OPCode2E>(addr, row, xls_content, this);
+            case 0x2F:
+                return std::make_shared<OPCode2F>(addr, row, xls_content, this);
+            case 0x30:
+                return std::make_shared<OPCode30>(addr, row, xls_content, this);
+            case 0x31:
+                return std::make_shared<OPCode31>(addr, row, xls_content, this);
+            case 0x32:
+                return std::make_shared<OPCode32>(addr, row, xls_content, this);
+            case 0x33:
+                return std::make_shared<OPCode33>(addr, row, xls_content, this);
+            case 0x34:
+                return std::make_shared<OPCode34>(addr, row, xls_content, this);
+            case 0x35:
+                return std::make_shared<OPCode35>(addr, row, xls_content, this);
+            case 0x36:
+                return std::make_shared<OPCode36>(addr, row, xls_content, this);
+            case 0x37:
+                return std::make_shared<OPCode37>(addr, row, xls_content, this);
+            case 0x38:
+                return std::make_shared<OPCode38>(addr, row, xls_content, this);
+            case 0x39:
+                return std::make_shared<OPCode39>(addr, row, xls_content, this);
+            case 0x3A:
+                return std::make_shared<OPCode3A>(addr, row, xls_content, this);
+            case 0x3B:
+                return std::make_shared<OPCode3B>(addr, row, xls_content, this);
+            case 0x3C:
+                return std::make_shared<OPCode3C>(addr, row, xls_content, this);
+            case 0x3D:
+                return std::make_shared<OPCode3D>(addr, row, xls_content, this);
+            case 0x3E:
+                return std::make_shared<OPCode3E>(addr, row, xls_content, this);
+            case 0x3F:
+                return std::make_shared<OPCode3F>(addr, row, xls_content, this);
+            case 0x40:
+                return std::make_shared<OPCode40>(addr, row, xls_content, this);
+            case 0x41:
+                return std::make_shared<OPCode41>(addr, row, xls_content, this);
+            case 0x42:
+                return std::make_shared<OPCode42>(addr, row, xls_content, this);
+            case 0x43:
+                return std::make_shared<OPCode43>(addr, row, xls_content, this);
+            case 0x44:
+                return std::make_shared<OPCode44>(addr, row, xls_content, this);
+            case 0x45:
+                return std::make_shared<OPCode45>(addr, row, xls_content, this);
+            case 0x46:
+                return std::make_shared<OPCode46>(addr, row, xls_content, this);
+            case 0x47:
+                return std::make_shared<OPCode47>(addr, row, xls_content, this);
+            case 0x48:
+                return std::make_shared<OPCode48>(addr, row, xls_content, this);
+            case 0x49:
+                return std::make_shared<OPCode49>(addr, row, xls_content, this);
+            case 0x4A:
+                return std::make_shared<OPCode4A>(addr, row, xls_content, this);
+            case 0x4B:
+                return std::make_shared<OPCode4B>(addr, row, xls_content, this);
+            case 0x4C:
+                return std::make_shared<OPCode4C>(addr, row, xls_content, this);
+            case 0x4D:
+                return std::make_shared<OPCode4D>(addr, row, xls_content, this);
+            case 0x4E:
+                return std::make_shared<OPCode4E>(addr, row, xls_content, this);
+            case 0x4F:
+                return std::make_shared<OPCode4F>(addr, row, xls_content, this);
+            case 0x50:
+                return std::make_shared<OPCode50>(addr, row, xls_content, this);
+            case 0x51:
+                return std::make_shared<OPCode51>(addr, row, xls_content, this);
+            case 0x52:
+                return std::make_shared<OPCode52>(addr, row, xls_content, this);
+            case 0x53:
+                return std::make_shared<OPCode53>(addr, row, xls_content, this);
+            case 0x54:
+                return std::make_shared<OPCode54>(addr, row, xls_content, this);
+            // case 0x55: return std::make_shared<OPCode55>(addr, row, xls_content,this);
+            case 0x56:
+                return std::make_shared<OPCode56>(addr, row, xls_content, this);
+            case 0x57:
+                return std::make_shared<OPCode57>(addr, row, xls_content, this);
+            case 0x58:
+                return std::make_shared<OPCode58>(addr, row, xls_content, this);
+            case 0x59:
+                return std::make_shared<OPCode59>(addr, row, xls_content, this);
+            // case 0x5A: return std::make_shared<OPCode5A>(addr, row, xls_content,this);
+            case 0x5B:
+                return std::make_shared<OPCode5B>(addr, row, xls_content, this);
+            case 0x5C:
+                return std::make_shared<OPCode5C>(addr, row, xls_content, this);
+            case 0x5D:
+                return std::make_shared<OPCode5D>(addr, row, xls_content, this);
+            case 0x5E:
+                return std::make_shared<OPCode5E>(addr, row, xls_content, this);
+            case 0x5F:
+                return std::make_shared<OPCode5F>(addr, row, xls_content, this);
+            case 0x60:
+                return std::make_shared<OPCode60>(addr, row, xls_content, this);
+            case 0x61:
+                return std::make_shared<OPCode61>(addr, row, xls_content, this);
+            case 0x62:
+                return std::make_shared<OPCode62>(addr, row, xls_content, this);
+            // case 0x63: return std::make_shared<OPCode63>(addr, row, xls_content,this);
+            case 0x64:
+                return std::make_shared<OPCode64>(addr, row, xls_content, this);
+            case 0x65:
+                return std::make_shared<OPCode65>(addr, row, xls_content, this);
+            case 0x66:
+                return std::make_shared<OPCode66>(addr, row, xls_content, this);
+            case 0x67:
+                return std::make_shared<OPCode67>(addr, row, xls_content, this);
+            case 0x68:
+                return std::make_shared<OPCode68>(addr, row, xls_content, this);
+            case 0x69:
+                return std::make_shared<OPCode69>(addr, row, xls_content, this);
+            case 0x6A:
+                return std::make_shared<OPCode6A>(addr, row, xls_content, this);
+            case 0x6B:
+                return std::make_shared<OPCode6B>(addr, row, xls_content, this);
+            case 0x6C:
+                return std::make_shared<OPCode6C>(addr, row, xls_content, this);
+            case 0x6D:
+                return std::make_shared<OPCode6D>(addr, row, xls_content, this);
+            case 0x6E:
+                return std::make_shared<OPCode6E>(addr, row, xls_content, this);
+            case 0x6F:
+                return std::make_shared<OPCode6F>(addr, row, xls_content, this);
+            case 0x70:
+                return std::make_shared<OPCode70>(addr, row, xls_content, this);
+            case 0x71:
+                return std::make_shared<OPCode71>(addr, row, xls_content, this);
+            case 0x72:
+                return std::make_shared<OPCode72>(addr, row, xls_content, this);
+            case 0x73:
+                return std::make_shared<OPCode73>(addr, row, xls_content, this);
+            case 0x74:
+                return std::make_shared<OPCode74>(addr, row, xls_content, this);
+            case 0x75:
+                return std::make_shared<OPCode75>(addr, row, xls_content, this);
+            case 0x76:
+                return std::make_shared<OPCode76>(addr, row, xls_content, this);
+            case 0x78:
+                return std::make_shared<OPCode78>(addr, row, xls_content, this);
+            case 0x79:
+                return std::make_shared<OPCode79>(addr, row, xls_content, this);
+            case 0x7A:
+                return std::make_shared<OPCode7A>(addr, row, xls_content, this);
+            case 0x7B:
+                return std::make_shared<OPCode7B>(addr, row, xls_content, this);
+            case 0x7C:
+                return std::make_shared<OPCode7C>(addr, row, xls_content, this);
+            // case 0x7D: return std::make_shared<OPCode7D>(addr, row, xls_content,this);
+            case 0x7E:
+                return std::make_shared<OPCode7E>(addr, row, xls_content, this);
+            case 0x7F:
+                return std::make_shared<OPCode7F>(addr, row, xls_content, this);
+            case 0x80:
+                return std::make_shared<OPCode80>(addr, row, xls_content, this);
+            case 0x81:
+                return std::make_shared<OPCode81>(addr, row, xls_content, this);
+            case 0x82:
+                return std::make_shared<OPCode82>(addr, row, xls_content, this);
+            case 0x83:
+                return std::make_shared<OPCode83>(addr, row, xls_content, this);
+            case 0x84:
+                return std::make_shared<OPCode84>(addr, row, xls_content, this);
+            case 0x85:
+                return std::make_shared<OPCode85>(addr, row, xls_content, this);
+            case 0x86:
+                return std::make_shared<OPCode86>(addr, row, xls_content, this);
+            case 0x87:
+                return std::make_shared<OPCode87>(addr, row, xls_content, this);
+            case 0x88:
+                return std::make_shared<OPCode88>(addr, row, xls_content, this);
+            case 0x89:
+                return std::make_shared<OPCode89>(addr, row, xls_content, this);
+            case 0x8A:
+                return std::make_shared<OPCode8A>(addr, row, xls_content, this);
+            case 0x8B:
+                return std::make_shared<OPCode8B>(addr, row, xls_content, this);
+            // case 0x8C: return std::make_shared<OPCode8C>(addr, row, xls_content,this);
+            case 0x8D:
+                return std::make_shared<OPCode8D>(addr, row, xls_content, this);
+            case 0x8E:
+                return std::make_shared<OPCode8E>(addr, row, xls_content, this);
+            case 0x8F:
+                return std::make_shared<OPCode8F>(addr, row, xls_content, this);
+            case 0x90:
+                return std::make_shared<OPCode90>(addr, row, xls_content, this);
+            case 0x91:
+                return std::make_shared<OPCode91>(addr, row, xls_content, this);
+            case 0x92:
+                return std::make_shared<OPCode92>(addr, row, xls_content, this);
+            case 0x93:
+                return std::make_shared<OPCode93>(addr, row, xls_content, this);
+            case 0x94:
+                return std::make_shared<OPCode94>(addr, row, xls_content, this);
+            case 0x95:
+                return std::make_shared<OPCode95>(addr, row, xls_content, this);
+            case 0x96:
+                return std::make_shared<OPCode96>(addr, row, xls_content, this);
+            case 0x97:
+                return std::make_shared<OPCode97>(addr, row, xls_content, this);
+            case 0x98:
+                return std::make_shared<OPCode98>(addr, row, xls_content, this);
+            // case 0x99: return std::make_shared<OPCode99>(addr, row, xls_content,this);
+            case 0x9A:
+                return std::make_shared<OPCode9A>(addr, row, xls_content, this);
+            case 0x9B:
+                return std::make_shared<OPCode9B>(addr, row, xls_content, this);
+            case 0x9C:
+                return std::make_shared<OPCode9C>(addr, row, xls_content, this);
+            // case 0x9D: return std::make_shared<OPCode9D>(addr, row, xls_content,this);
+            case 0x9E:
+                return std::make_shared<OPCode9E>(addr, row, xls_content, this);
+            case 0x9F:
+                return std::make_shared<OPCode9F>(addr, row, xls_content, this);
+            case 0xA0:
+                return std::make_shared<OPCodeA0>(addr, row, xls_content, this);
+            case 0xA1:
+                return std::make_shared<OPCodeA1>(addr, row, xls_content, this);
+            case 0xA2:
+                return std::make_shared<OPCodeA2>(addr, row, xls_content, this);
+            case 0xA3:
+                return std::make_shared<OPCodeA3>(addr, row, xls_content, this);
+            case 0xA4:
+                return std::make_shared<OPCodeA4>(addr, row, xls_content, this);
+            case 0xA5:
+                return std::make_shared<OPCodeA5>(addr, row, xls_content, this);
+            case 0xA6:
+                return std::make_shared<OPCodeA6>(addr, row, xls_content, this);
+            case 0xA7:
+                return std::make_shared<OPCodeA7>(addr, row, xls_content, this);
+            case 0xA8:
+                return std::make_shared<OPCodeA8>(addr, row, xls_content, this);
+            case 0xA9:
+                return std::make_shared<OPCodeA9>(addr, row, xls_content, this);
+            case 0xAA:
+                return std::make_shared<OPCodeAA>(addr, row, xls_content, this);
+            case 0xAB:
+                return std::make_shared<OPCodeAB>(addr, row, xls_content, this);
+            case 0xAC:
+                return std::make_shared<OPCodeAC>(addr, row, xls_content, this);
+            case 0xAD:
+                return std::make_shared<OPCodeAD>(addr, row, xls_content, this);
+            case 0xAE:
+                return std::make_shared<OPCodeAE>(addr, row, xls_content, this);
+            case 0xAF:
+                return std::make_shared<OPCodeAF>(addr, row, xls_content, this);
+            case 0xB0:
+                return std::make_shared<OPCodeB0>(addr, row, xls_content, this);
+            case 0xB1:
+                return std::make_shared<OPCodeB1>(addr, row, xls_content, this);
+            case 0xB2:
+                return std::make_shared<OPCodeB2>(addr, row, xls_content, this);
+            case 0xB3:
+                return std::make_shared<OPCodeB3>(addr, row, xls_content, this);
+            case 0xB4:
+                return std::make_shared<OPCodeB4>(addr, row, xls_content, this);
+            case 0xB5:
+                return std::make_shared<OPCodeB5>(addr, row, xls_content, this);
+            case 256:
+                return std::make_shared<CreateMonsters>(addr, row, xls_content, this);
+            case 257:
+                return std::make_shared<EffectsInstr>(addr, row, xls_content, this);
+            case 258:
+                return std::make_shared<ActionTable>(addr, row, xls_content, this);
+            case 259:
+                return std::make_shared<AlgoTable>(addr, row, xls_content, this);
+            case 260:
+                return std::make_shared<WeaponAttTable>(addr, row, xls_content, this);
+            case 261:
+                return std::make_shared<BreakTable>(addr, row, xls_content, this);
+            case 262:
+                return std::make_shared<SummonTable>(addr, row, xls_content, this);
+            case 263:
+                return std::make_shared<ReactionTable>(addr, row, xls_content, this);
+            case 264:
+                return std::make_shared<PartTable>(addr, row, xls_content, this);
+            case 265:
+                return std::make_shared<AnimeClipTable>(addr, row, xls_content, this);
+            case 266:
+                return std::make_shared<FieldMonsterData>(addr, row, xls_content, this);
+            case 267:
+                return std::make_shared<FieldFollowData>(addr, row, xls_content, this);
+            case 268:
+                return std::make_shared<FC_autoX>(addr, row, xls_content, this);
+            case 269:
+                return std::make_shared<BookData99>(addr, row, xls_content, this);
+            case 270:
+                return std::make_shared<BookDataX>(addr, row, xls_content, this);
+            case 271:
+                return std::make_shared<AddCollision>(addr, row, xls_content, this);
+            case 272:
+                return std::make_shared<ConditionTable>(addr, row, xls_content, this);
+            case 273:
+                return std::make_shared<AnimeClipData>(addr, row, xls_content, this);
             default:
                 std::stringstream stream;
                 stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << this->SceneName.toStdString();
@@ -7245,8 +8326,7 @@ class CS2Builder : public Builder
         }
     }
 
-
-    QByteArray CreateHeaderBytes(){
+    QByteArray CreateHeaderBytes() {
 
         QByteArray header;
 
@@ -7255,43 +8335,43 @@ class CS2Builder : public Builder
         int size_of_scene_name = scene_name_bytes.length();
         header.append(GetBytesFromInt(0x20));
         header.append(GetBytesFromInt(0x20));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name));
-        header.append(GetBytesFromInt(FunctionsParsed.size()*4));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name));
+        header.append(GetBytesFromInt(FunctionsParsed.size() * 4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4));
         header.append(GetBytesFromInt(FunctionsParsed.size()));
         int length_of_names_section = 0;
-        for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + length_of_names_section));
+        for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++)
+            length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
+        header.append(
+          GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + length_of_names_section));
         header.append(GetBytesFromInt(0xABCDEF00));
         header.append(scene_name_bytes);
-        if (FunctionsParsed.size()>0){
+        if (FunctionsParsed.size() > 0) {
             QByteArray position_names;
             QByteArray actual_names;
             int offset_names = 0;
-            for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) {
+            for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++) {
                 header.append(GetBytesFromInt(FunctionsParsed[idx_fun].actual_addr));
                 QByteArray name = FunctionsParsed[idx_fun].name.toUtf8();
                 name.append('\x0');
-                position_names.append(GetBytesFromShort(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + offset_names));
+                position_names.append(
+                  GetBytesFromShort(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + offset_names));
                 actual_names.append(name);
                 offset_names = offset_names + name.size();
-
             }
             header.append(position_names);
             header.append(actual_names);
             int multiple = 4;
             if (FunctionsParsed[0].name.startsWith("_")) multiple = 0x10;
-            int nb_byte_to_add = (((int) ceil((float)header.size()/multiple)))*multiple - header.size();
+            int nb_byte_to_add = (((int)ceil((float)header.size() / multiple))) * multiple - header.size();
             QByteArray remaining;
-            for (int i = 0; i < nb_byte_to_add;i++) {
+            for (int i = 0; i < nb_byte_to_add; i++) {
                 remaining.push_back('\x0');
             }
             header.append(remaining);
         }
         return header;
     }
-
 };
-
 
 #endif // CS2INSTRUCTIONSSET_H

--- a/headers/CS3InstructionsSet.h
+++ b/headers/CS3InstructionsSet.h
@@ -1,187 +1,173 @@
 #ifndef CS3INSTRUCTIONSSET_H
 #define CS3INSTRUCTIONSSET_H
-#include "headers/utilities.h"
 #include "headers/functions.h"
 #include "headers/translationfile.h"
+#include "headers/utilities.h"
 
 #include <QString>
 
-
-
-class CS3TranslationFile : public TranslationFile
-{
-    public:
-    CS3TranslationFile():TranslationFile(){}
-
+class CS3TranslationFile : public TranslationFile {
+  public:
+    CS3TranslationFile()
+      : TranslationFile() {}
 };
-class CS3Builder : public Builder
-{
-    public:
-    CS3Builder(){
-
-    }
-    int add_operandes(int &addr, QByteArray &content, Instruction * instr, int size){
+class CS3Builder : public Builder {
+  public:
+    CS3Builder() {}
+    int add_operandes(int& addr, QByteArray& content, Instruction* instr, int size) {
         int plVar15 = addr;
         int lVar5, lVar7;
         lVar7 = -1;
         do {
-          instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-          lVar5 = lVar7 + size;
-          lVar7 = lVar7 + 1;
-        } while (content[plVar15+lVar5] != '\0');
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            lVar5 = lVar7 + size;
+            lVar7 = lVar7 + 1;
+        } while (content[plVar15 + lVar5] != '\0');
         return lVar7;
-
-
     }
 
-    static void reading_dialog(int &addr, QByteArray &content, Instruction * instr){
+    static void reading_dialog(int& addr, QByteArray& content, Instruction* instr) {
 
         QByteArray current_op_value;
         int addr_ = addr;
 
         bool start_text = false;
         int cnt = 0;
-        do{
+        do {
             unsigned char current_byte = content[addr];
 
-            switch(current_byte){
+            switch (current_byte) {
                 case 0x00:
                     current_op_value.clear();
                     current_op_value[0] = 0;
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     addr++;
                     return;
                 case 0x01:
 
                     if (start_text)
                         current_op_value.push_back(current_byte);
-                    else{
+                    else {
 
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         current_op_value.clear();
                     }
                     addr++;
                     break;
                 case 0x02:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
                     break;
                 case 0x10:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x17:
                 case 0x19:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x11:
                 case 0x12:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x23:
                     current_op_value.push_back(0x23);
                     addr_ = addr;
                     addr++;
                     current_byte = content[addr];
-                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) ||
-                           (current_byte == 0x42)||(current_byte == 0x48)||(current_byte == 0x56)||(current_byte == 0x4b) ||
-                            (current_byte == 0x6b) || (current_byte == 0x46)) {
+                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) || (current_byte == 0x42) ||
+                        (current_byte == 0x48) || (current_byte == 0x56) || (current_byte == 0x4b) || (current_byte == 0x6b) ||
+                        (current_byte == 0x46)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
+
+                        if (current_byte != 0x5f) {
+                            if (current_byte == 0x5b) {
+                                do {
+                                    current_op_value.push_back(current_byte);
+                                    addr++;
+                                    current_byte = content[addr];
+                                } while (current_byte != 0x5D);
+                                current_op_value.push_back(current_byte);
+                                addr++;
+                                current_byte = content[addr];
+                            }
+                            break;
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
-
-                              if (current_byte != 0x5f) {
-                                  if (current_byte == 0x5b) {
-                                      do{
-                                          current_op_value.push_back(current_byte);
-                                          addr++;
-                                          current_byte = content[addr];
-                                      }
-                                      while(current_byte!=0x5D);
-                                      current_op_value.push_back(current_byte);
-                                      addr++;
-                                      current_byte = content[addr];
-                                  }
-                                  break;
-                              }
-                              else{
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  break;
-                              }
-
-                           }
-                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
-                                 (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
-                                 (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
-                                 current_op_value.push_back(current_byte);
-                                 addr++;
-                                 current_byte = content[addr];
-                                 break;
+                            current_op_value.push_back(current_byte);
+                            addr++;
+                            current_byte = content[addr];
+                            break;
                         }
+
+                    } else if ((((current_byte + 0xb7) & 0xdf) == 0) || (current_byte == 0x50) || (current_byte == 0x54) ||
+                               (current_byte == 0x57) || (current_byte == 0x53) || (current_byte == 0x73) || (current_byte == 0x43) ||
+                               (current_byte == 99) || (current_byte == 0x78) || (current_byte == 0x79) || (current_byte == 0x47) ||
+                               (current_byte == 0x44) || (current_byte == 0x55) || (current_byte == 0x52)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
                         break;
+                    }
+                    break;
                 default:
-                    if (current_byte < 0x20){
-                        if (current_op_value.size()>0) {
-                            instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_byte < 0x20) {
+                        if (current_op_value.size() > 0) {
+                            instr->AddOperande(operande(addr_, "dialog", current_op_value));
                         }
                         start_text = false;
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         addr++;
                         current_op_value.clear();
-                    }
-                    else {
+                    } else {
                         if (!(start_text)) start_text = true;
 
-                        if ((current_byte < 0xE0)&&(current_byte >= 0xC0)){
+                        if ((current_byte < 0xE0) && (current_byte >= 0xC0)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte >= 0xE0)&&(current_byte <= 0xF7)){
+                        } else if ((current_byte >= 0xE0) && (current_byte <= 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
@@ -190,12 +176,10 @@ class CS3Builder : public Builder
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte > 0xF7)){
+                        } else if ((current_byte > 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else{
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                         }
@@ -203,6179 +187,6765 @@ class CS3Builder : public Builder
                     break;
             }
 
-
             cnt++;
-        }
-        while(cnt<9999);
-
+        } while (cnt < 9999);
     }
-    static void fun_1403c90e0(int &addr, QByteArray &content, Instruction * instr, int param){
+    static void fun_1403c90e0(int& addr, QByteArray& content, Instruction* instr, int param) {
         QByteArray control_byte3_arr = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte3_arr));
+        instr->AddOperande(operande(addr, "byte", control_byte3_arr));
         unsigned char control_byte3 = (unsigned char)control_byte3_arr[0];
 
-        if (control_byte3 == '\x11'){
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+        if (control_byte3 == '\x11') {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-        }
-        else if (control_byte3 != '3'){
+        } else if (control_byte3 != '3') {
 
-            if (control_byte3 == '\"'){
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            if (control_byte3 == '\"') {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-            }
-            else if (control_byte3 != 0x44){
+            } else if (control_byte3 != 0x44) {
 
-                if (control_byte3 == 0xDD){
+                if (control_byte3 == 0xDD) {
 
-                    //there is a XOR,XOR EDI which causes a jump that ignores the strcpy
-                    if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                }
-                else if (control_byte3 == 0xFF){
-                    instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                }
-                else{
-                    if (control_byte3 != 0xEE){
+                    // there is a XOR,XOR EDI which causes a jump that ignores the strcpy
+                    if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                } else if (control_byte3 == 0xFF) {
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                } else {
+                    if (control_byte3 != 0xEE) {
 
-                    }
-                    else{
-                        instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    } else {
+                        instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     }
                 }
 
-
-            }
-            else{
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            } else {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
 
-        }
-        else{
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+        } else {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     }
-    static void sub05(int &addr, QByteArray &content, Instruction * instr){
+    static void sub05(int& addr, QByteArray& content, Instruction* instr) {
         QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte));
+        instr->AddOperande(operande(addr, "byte", control_byte));
 
-        while ((int)control_byte[0]!=1){
+        while ((int)control_byte[0] != 1) {
 
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x0:
-                    case 0x24:
-                        instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x24:
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-                    case 0x1c:{
-                        //the next byte is the OP code for a new instruction
+                case 0x1c: {
+                    // the next byte is the OP code for a new instruction
 
-                        std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content,0);
+                    std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content, 0);
 
-                        operande op = operande(addr,"instruction", instr2->getBytes());
-                        instr->AddOperande(op);
+                    operande op = operande(addr, "instruction", instr2->getBytes());
+                    instr->AddOperande(op);
 
-
-                        break;
-                    }
-                    case 0x1e:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x1f:
-                    case 0x20:
-                    case 0x23:
-
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x21:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x25:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    default:
-                        ;
+                    break;
                 }
+                case 0x1e:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x1f:
+                case 0x20:
+                case 0x23:
 
-                control_byte = ReadSubByteArray(content, addr, 1);
-
-                instr->AddOperande(operande(addr,"byte", control_byte));
-
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x21:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x25:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                default:;
             }
+
+            control_byte = ReadSubByteArray(content, addr, 1);
+
+            instr->AddOperande(operande(addr, "byte", control_byte));
+        }
     }
-    class CreateMonsters : public Instruction
-    {
-        public:
-        CreateMonsters():Instruction(-1,256,nullptr){}
-        CreateMonsters(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"CreateMonsters", 256,Maker){}
-        CreateMonsters(int addr, Builder *Maker):Instruction(addr,"CreateMonsters", 256, Maker){}
-        CreateMonsters(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"CreateMonsters", 256,Maker){
+    class CreateMonsters : public Instruction {
+      public:
+        CreateMonsters()
+          : Instruction(-1, 256, nullptr) {}
+        CreateMonsters(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int addr, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {
             int initial_addr = addr;
-            if (Maker->goal<addr+0x4C){
+            if (Maker->goal < addr + 0x4C) {
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            int check1 = ReadIntegerFromByteArray(addr,content);
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            int check1 = ReadIntegerFromByteArray(addr, content);
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            int check2 = ReadIntegerFromByteArray(addr,content);
-            if (check1 && check2 != 0){ //bad
+            int check2 = ReadIntegerFromByteArray(addr, content);
+            if (check1 && check2 != 0) { // bad
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2))); //RSI + 0x28
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RSI + 0x28
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4))); //0x2C
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x2C
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//0x30
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//0x32
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//0x34
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//0x36
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x30
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x32
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x34
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x36
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0x38
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x38
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0x3C
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0x40
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0x44
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0x48
-            //0x4C The first part is done
-            //from here, it's just a guess. There is a maximum of 8 enemies hardcoded in the function.
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x3C
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x40
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x44
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x48
+            // 0x4C The first part is done
+            // from here, it's just a guess. There is a maximum of 8 enemies hardcoded in the function.
 
             QByteArray array = ReadSubByteArray(content, addr, 4);
-            this->AddOperande(operande(addr,"int", array));
-            int first = ReadIntegerFromByteArray(0,array);
+            this->AddOperande(operande(addr, "int", array));
+            int first = ReadIntegerFromByteArray(0, array);
             int cnt = 0;
-            do{
+            do {
                 int counter = 0;
-                if (Maker->goal<initial_addr+0x4C + cnt * (0x90)){
+                if (Maker->goal < initial_addr + 0x4C + cnt * (0x90)) {
                     addr = initial_addr;
                     Maker->flag_monsters = false;
                     return;
                 }
-                do{
+                do {
                     counter++;
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10-monsters_name.size()-1);
-                    operande fill = operande(addr,"fill", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "fill", remaining);
                     fill.setBytesToFill(0x10);
                     this->AddOperande(fill);
 
-                }
-                while(counter < 0x8);
-                for (int idx_byte = 0; idx_byte < 8; idx_byte++) this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                if ((unsigned char) content[addr] == 0)this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 8))); //??
+                } while (counter < 0x8);
+                for (int idx_byte = 0; idx_byte < 8; idx_byte++)
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                if ((unsigned char)content[addr] == 0)
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 8))); //??
                 else {
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 12-monsters_name.size()-1);
-                    operande fill = operande(addr,"bytearray", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 12 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "bytearray", remaining);
                     fill.setBytesToFill(12);
                     this->AddOperande(fill);
-
-
                 }
 
-
                 QByteArray array = ReadSubByteArray(content, addr, 4);
-                this->AddOperande(operande(addr,"int", array));
-                first = ReadIntegerFromByteArray(0,array);
+                this->AddOperande(operande(addr, "int", array));
+                first = ReadIntegerFromByteArray(0, array);
                 cnt++;
-            }
-            while(first != -1);
+            } while (first != -1);
 
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x18))); //??
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x18))); //??
             Maker->flag_monsters = true;
         }
-
-
     };
-    class EffectsInstr : public Instruction
-    {
-        public:
-        EffectsInstr():Instruction(-1,257,nullptr){}
-        EffectsInstr(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"EffectsInstr", 257,Maker){}
-        EffectsInstr(int addr, Builder *Maker):Instruction(addr,"EffectsInstr", 257, Maker){}
-        EffectsInstr(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"EffectsInstr", 257,Maker){
+    class EffectsInstr : public Instruction {
+      public:
+        EffectsInstr()
+          : Instruction(-1, 257, nullptr) {}
+        EffectsInstr(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int addr, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {
             unsigned char current_byte = content[addr];
-            while (current_byte!=0x01){
+            while (current_byte != 0x01) {
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
+                this->AddOperande(operande(addr, "string", str));
 
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
 
-
-                operande fill = operande(addr,"fill", remaining);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 current_byte = content[addr];
             }
         }
-
-
     };
-    class ActionTable : public Instruction
-    {
-        public:
-        ActionTable():Instruction(-1,258,nullptr){}
-        ActionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ActionTable", 258,Maker){}
-        ActionTable(int addr, Builder *Maker):Instruction(addr,"ActionTable", 258, Maker){}
-        ActionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ActionTable", 258,Maker){
+    class ActionTable : public Instruction {
+      public:
+        ActionTable()
+          : Instruction(-1, 258, nullptr) {}
+        ActionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ActionTable", 258, Maker) {}
+        ActionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {}
+        ActionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {
             int cnt = 0;
             short shrt = 0;
-            do{
+            do {
 
                 shrt = ReadShortFromByteArray(addr, content);
                 if (shrt == -1) break;
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+                this->AddOperande(operande(addr, "short", short_bytes));
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1))); //57
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//58->5B
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//5C->5F
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//60->63
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//64
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//65
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//66
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//67
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//68
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//6A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//6C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//6E
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//70
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//74
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//78
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RSP+7C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-80
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-7C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-78
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-74
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-70
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-6C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-68
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-64
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-60
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-5C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-58
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-54
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //RBP-50
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 57
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 58->5B
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 5C->5F
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 60->63
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 64
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 65
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 66
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 67
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 68
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 6A
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 6C
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 6E
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 70
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 74
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 78
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RSP+7C
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-80
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-7C
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-78
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-74
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-70
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-6C
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-68
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-64
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-60
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-5C
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-58
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-54
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RBP-50
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 /*QByteArray current_byte = ReadSubByteArray(content, addr,1);
                 this->AddOperande(operande(addr,"byte", current_byte));*///Strange byte dealt in 14027dcf0
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
 
                 QByteArray str_ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str_));
-                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20-str_.size()-1);
-                operande fill_ = operande(addr,"fill", remaining_);
+                this->AddOperande(operande(addr, "string", str_));
+                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20 - str_.size() - 1);
+                operande fill_ = operande(addr, "fill", remaining_);
                 fill_.setBytesToFill(0x20);
                 this->AddOperande(fill_);
 
-                //The last string can be 0x20 long and the following 0x20 can terminate the string, I think
-                //it's their purpose here
+                // The last string can be 0x20 long and the following 0x20 can terminate the string, I think
+                // it's their purpose here
                 QByteArray str__ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str__));
-                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x40-str__.size()-1);
-                operande fill__ = operande(addr,"fill", remaining__);
+                this->AddOperande(operande(addr, "string", str__));
+                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x40 - str__.size() - 1);
+                operande fill__ = operande(addr, "fill", remaining__);
                 fill__.setBytesToFill(0x40);
                 this->AddOperande(fill__);
 
                 cnt++;
-          }
-            while(cnt < 0x40);
-            //also here, can't explain what is the purpose of those bytes
-            while (shrt==-1){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", short_bytes));
+            } while (cnt < 0x40);
+            // also here, can't explain what is the purpose of those bytes
+            while (shrt == -1) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+                this->AddOperande(operande(addr, "short", short_bytes));
                 QByteArray remaining___ = ReadSubByteArray(content, addr, 0xC1);
-                this->AddOperande(operande(addr,"bytearray", remaining___));
+                this->AddOperande(operande(addr, "bytearray", remaining___));
 
                 shrt = ReadShortFromByteArray(addr, content);
             }
-
-
-
         }
-
-
     };
-    class AlgoTable : public Instruction
-    {
-        public:
-        AlgoTable():Instruction(-1,259,nullptr){}
-        AlgoTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AlgoTable", 259,Maker){}
-        AlgoTable(int addr, Builder *Maker):Instruction(addr,"AlgoTable", 259, Maker){}
-        AlgoTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AlgoTable", 259,Maker){
+    class AlgoTable : public Instruction {
+      public:
+        AlgoTable()
+          : Instruction(-1, 259, nullptr) {}
+        AlgoTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AlgoTable", 259, Maker) {}
+        AlgoTable(int addr, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {}
+        AlgoTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {
             int cnt = 0;
 
-            //A complete guess for the moment; nothing looks like a pointer here though
-            //The operands actually all look like bytes to me except the first one which seems like
-            //a character ID so a short
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            // A complete guess for the moment; nothing looks like a pointer here though
+            // The operands actually all look like bytes to me except the first one which seems like
+            // a character ID so a short
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 short shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
 
                 if (shrt == 0) break;
 
-                this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
+                this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1E)));
 
                 cnt++;
-          }
-            while(cnt < 0x40);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-
+            } while (cnt < 0x40);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1E)));
         }
     };
-    class WeaponAttTable : public Instruction
-    {
-        public:
-        WeaponAttTable():Instruction(-1,260,nullptr){}
-        WeaponAttTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"WeaponAttTable", 260,Maker){}
-        WeaponAttTable(int addr, Builder *Maker):Instruction(addr,"WeaponAttTable", 260, Maker){}
-        WeaponAttTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"WeaponAttTable", 260,Maker){
+    class WeaponAttTable : public Instruction {
+      public:
+        WeaponAttTable()
+          : Instruction(-1, 260, nullptr) {}
+        WeaponAttTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int addr, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {
 
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class BreakTable : public Instruction
-    {
-        public:
-        BreakTable():Instruction(-1,261,nullptr){}
-        BreakTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BreakTable", 261,Maker){}
-        BreakTable(int addr, Builder *Maker):Instruction(addr,"BreakTable", 261, Maker){}
-        BreakTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BreakTable", 261,Maker){
+    class BreakTable : public Instruction {
+      public:
+        BreakTable()
+          : Instruction(-1, 261, nullptr) {}
+        BreakTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BreakTable", 261, Maker) {}
+        BreakTable(int addr, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {}
+        BreakTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {
             int cnt = 0;
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 short shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0) break;
-                QByteArray short_bytes2 = ReadSubByteArray(content, addr,2);
+                QByteArray short_bytes2 = ReadSubByteArray(content, addr, 2);
 
-                this->AddOperande(operande(addr,"short", short_bytes2)); //not sure if two single bytes
-                //or one short, guessing its one short
+                this->AddOperande(operande(addr, "short", short_bytes2)); // not sure if two single bytes
+                // or one short, guessing its one short
 
                 cnt++;
-            }
-            while(cnt < 0x40);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x2)));
+            } while (cnt < 0x40);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x2)));
         }
     };
-    class SummonTable : public Instruction //140142002
+    class SummonTable
+      : public Instruction // 140142002
     {
-        public:
-        SummonTable():Instruction(-1,262,nullptr){}
-        SummonTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"SummonTable", 262,Maker){}
-        SummonTable(int addr, Builder *Maker):Instruction(addr,"SummonTable", 262, Maker){}
-        SummonTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"SummonTable", 262,Maker){
+      public:
+        SummonTable()
+          : Instruction(-1, 262, nullptr) {}
+        SummonTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "SummonTable", 262, Maker) {}
+        SummonTable(int addr, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {}
+        SummonTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {
             int cnt = 0;
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 ushort shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0xFFFF) break;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
                 cnt++;
-            }
-            while(cnt < 0x40);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x24-2)));
+            } while (cnt < 0x40);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x24 - 2)));
         }
     };
-    class ReactionTable : public Instruction //140142002
+    class ReactionTable
+      : public Instruction // 140142002
     {
-        public:
-        ReactionTable():Instruction(-1,263,nullptr){}
-        ReactionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ReactionTable", 263,Maker){}
-        ReactionTable(int addr, Builder *Maker):Instruction(addr,"ReactionTable", 263, Maker){}
-        ReactionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ReactionTable", 263,Maker){
+      public:
+        ReactionTable()
+          : Instruction(-1, 263, nullptr) {}
+        ReactionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ReactionTable", 263, Maker) {}
+        ReactionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {}
+        ReactionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {
             int cnt = 0;
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 ushort shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0x0) break;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                 cnt++;
-            }
-            while(cnt < 0x8);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x3A)));
+            } while (cnt < 0x8);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x3A)));
         }
     };
-    class PartTable : public Instruction //14019797c
+    class PartTable
+      : public Instruction // 14019797c
     {
-        public:
-        PartTable():Instruction(-1,264,nullptr){}
-        PartTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"PartTable", 264,Maker){}
-        PartTable(int addr, Builder *Maker):Instruction(addr,"PartTable", 264, Maker){}
-        PartTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"PartTable", 264,Maker){
+      public:
+        PartTable()
+          : Instruction(-1, 264, nullptr) {}
+        PartTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "PartTable", 264, Maker) {}
+        PartTable(int addr, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {}
+        PartTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {
             int cnt = 0;
-            do{
-                QByteArray int_bytes = ReadSubByteArray(content, addr,4);
+            do {
+                QByteArray int_bytes = ReadSubByteArray(content, addr, 4);
                 uint integer = ReadIntegerFromByteArray(0, int_bytes);
-                this->AddOperande(operande(addr,"int", int_bytes));
+                this->AddOperande(operande(addr, "int", int_bytes));
                 if (integer == 0xFF) break;
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 cnt++;
-            }
-            while(cnt < 0x4);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x40)));
-
+            } while (cnt < 0x4);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x40)));
         }
     };
 
-
-    class AnimeClipTable : public Instruction // from CS3
+    class AnimeClipTable
+      : public Instruction // from CS3
     {
-        public:
-        AnimeClipTable():Instruction(-1,265,nullptr){}
-        AnimeClipTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipTable", 265,Maker){}
-        AnimeClipTable(int addr, Builder *Maker):Instruction(addr,"AnimeClipTable", 265, Maker){}
-        AnimeClipTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipTable", 265,Maker){
+      public:
+        AnimeClipTable()
+          : Instruction(-1, 265, nullptr) {}
+        AnimeClipTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {
 
             int first_integer;
             first_integer = ReadIntegerFromByteArray(addr, content);
             std::vector<function>::iterator itt_current_fun = find_function_by_ID(Maker->FunctionsToParse, Maker->idx_current_fun);
-            while(first_integer != 0){
-                itt_current_fun->AddInstruction(std::make_shared<AnimeClipData>(addr, content,Maker));
+            while (first_integer != 0) {
+                itt_current_fun->AddInstruction(std::make_shared<AnimeClipData>(addr, content, Maker));
                 first_integer = ReadIntegerFromByteArray(addr, content);
-
             }
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            //I think this is some sort of a table with ID at the beginning and then two names
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            // I think this is some sort of a table with ID at the beginning and then two names
         }
     };
-    class AnimeClipData : public Instruction
-    {
-        public:
-        AnimeClipData():Instruction(-1,273,nullptr){}
-        AnimeClipData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipData", 273,Maker){}
-        AnimeClipData(int addr, Builder *Maker):Instruction(addr,"AnimeClipData", 273, Maker){}
-        AnimeClipData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipData", 273,Maker){
+    class AnimeClipData : public Instruction {
+      public:
+        AnimeClipData()
+          : Instruction(-1, 273, nullptr) {}
+        AnimeClipData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipData", 273, Maker) {}
+        AnimeClipData(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipData", 273, Maker) {}
+        AnimeClipData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipData", 273, Maker) {
 
-
-                QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-                this->AddOperande(operande(addr,"int", first_integer_bytes));
-                QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
-                fill.setBytesToFill((0x20));
-                this->AddOperande(fill);
-                str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                fill = operande(addr,"fill", remaining);
-                fill.setBytesToFill((0x20));
-                this->AddOperande(fill);
-
-
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            QByteArray str = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", str));
+            QByteArray remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+            operande fill = operande(addr, "fill", remaining);
+            fill.setBytesToFill((0x20));
+            this->AddOperande(fill);
+            str = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", str));
+            remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+            fill = operande(addr, "fill", remaining);
+            fill.setBytesToFill((0x20));
+            this->AddOperande(fill);
         }
     };
 
-
-    class FieldMonsterData : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
+    class FieldMonsterData
+      : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
     {
-        public:
-        FieldMonsterData():Instruction(-1,266,nullptr){}
-        FieldMonsterData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 266,Maker){}
-        FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
-        FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
+      public:
+        FieldMonsterData()
+          : Instruction(-1, 266, nullptr) {}
+        FieldMonsterData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {
 
-
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FieldFollowData : public Instruction //
+    class FieldFollowData
+      : public Instruction //
     {
-        public:
-        FieldFollowData():Instruction(-1,267,nullptr){}
-        FieldFollowData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 267,Maker){}
-        FieldFollowData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 267, Maker){}
-        FieldFollowData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 267,Maker){
+      public:
+        FieldFollowData()
+          : Instruction(-1, 267, nullptr) {}
+        FieldFollowData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FC_autoX : public Instruction //
+    class FC_autoX
+      : public Instruction //
     {
-        public:
-        FC_autoX():Instruction(-1,268,nullptr){}
-        FC_autoX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FC_autoX", 268,Maker){}
-        FC_autoX(int addr, Builder *Maker):Instruction(addr,"FC_autoX", 268, Maker){}
-        FC_autoX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FC_autoX", 268,Maker){
+      public:
+        FC_autoX()
+          : Instruction(-1, 268, nullptr) {}
+        FC_autoX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FC_autoX", 268, Maker) {}
+        FC_autoX(int addr, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {}
+        FC_autoX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {
 
             QByteArray things = ReadStringSubByteArray(content, addr);
-            this->AddOperande(operande(addr,"string", things));
+            this->AddOperande(operande(addr, "string", things));
         }
     };
-    class BookData99 : public Instruction //
+    class BookData99
+      : public Instruction //
     {
-        public:
-        BookData99():Instruction(-1,269,nullptr){}
-        BookData99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookData99", 269,Maker){}
-        BookData99(int addr, Builder *Maker):Instruction(addr,"BookData99", 269, Maker){}
-        BookData99(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookData99", 269,Maker){
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+      public:
+        BookData99()
+          : Instruction(-1, 269, nullptr) {}
+        BookData99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookData99", 269, Maker) {}
+        BookData99(int addr, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {}
+        BookData99(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class BookDataX: public Instruction //0000000140464549
+    class BookDataX
+      : public Instruction // 0000000140464549
     {
-        public:
-        BookDataX():Instruction(-1,270,nullptr){}
-        BookDataX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookDataX", 270,Maker){}
-        BookDataX(int addr, Builder *Maker):Instruction(addr,"BookDataX", 270, Maker){}
-        BookDataX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookDataX", 270,Maker){
+      public:
+        BookDataX()
+          : Instruction(-1, 270, nullptr) {}
+        BookDataX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookDataX", 270, Maker) {}
+        BookDataX(int addr, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {}
+        BookDataX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             short control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));//3
-            if (control>0){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", control_short)); // 3
+            if (control > 0) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 QByteArray title = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", title));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-title.size()-1);
-                operande fill = operande(addr,"bytearray", remaining);
+                this->AddOperande(operande(addr, "string", title));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - title.size() - 1);
+                operande fill = operande(addr, "bytearray", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x12
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x14
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x16
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x18
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1E
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x20
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x22
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x24
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            }
-            else
-            {
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x12
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x14
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x16
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x18
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1A
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1C
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1E
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x20
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x22
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x24
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            } else {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
         }
     };
 
-
-    class OPCode0 : public Instruction
-    {
-        public:
-        OPCode0():Instruction(-1,0,nullptr){}
-        OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
-        OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
-            addr++;
-
-        }
-
-
-    };
-    class OPCode1 : public Instruction
-    {
-        public:
-        OPCode1():Instruction(-1,1,nullptr){}
-        OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
-        OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+    class OPCode0 : public Instruction {
+      public:
+        OPCode0()
+          : Instruction(-1, 0, nullptr) {}
+        OPCode0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Instruction 0", 0, Maker) {}
+        OPCode0(int addr, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {}
+        OPCode0(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {
             addr++;
         }
-
-
     };
-    class OPCode2 : public Instruction
-    {
-        public:
-        OPCode2():Instruction(-1,2,nullptr){}
-        OPCode2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Call", 2,Maker){}
-        OPCode2(int addr, Builder *Maker):Instruction(addr,"Call",2,Maker){}
-        OPCode2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"Call", 2,Maker){
-                addr++;
-
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                QByteArray function_name = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", function_name));
-                QByteArray control_byte2_arr = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte2_arr));
-
-                int control_byte2 = (int)control_byte2_arr[0];
-
-                if (control_byte2!=0){
-                    for (int i = 0; i < control_byte2; i++){
-                        fun_1403c90e0(addr, content, this, 0);
-                    }
-
-                }
-                switch((unsigned char)control_byte[0]){
-                    case 0xB:
-
-                        /*qDebug() << "Calling function " << ConvertBytesToString(function_name);
-                        //here we're calling a function that was defined at the beginning
-                        std::vector<function>::iterator it = find_function_by_name(Maker->FunctionsToParse,ConvertBytesToString(function_name));
-
-                        if (!std::count(Maker->FunctionsParsed.begin(), Maker->FunctionsParsed.end(), *it)){
-                            Maker->ReadIndividualFunction(*it,content);
-                            Maker->FunctionsParsed.push_back(*it);
-                        }*/
-                        //Maker->FunctionsToParse.erase(it);
-                        break;
-                }
-
-
-
-        }
-
-
-    };
-    class OPCode3 : public Instruction
-    {
-        public:
-        OPCode3():Instruction(-1,3,nullptr){}
-        OPCode3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 3,Maker){}
-        OPCode3(int addr, Builder *Maker):Instruction(addr,"???",3,Maker){}
-        OPCode3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 3,Maker){
+    class OPCode1 : public Instruction {
+      public:
+        OPCode1()
+          : Instruction(-1, 1, nullptr) {}
+        OPCode1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Return", 1, Maker) {}
+        OPCode1(int addr, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {}
+        OPCode1(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr, 4)));
-        }
-
-
-    };
-    class OPCode4 : public Instruction
-    {
-        public:
-        OPCode4():Instruction(-1,4,nullptr){}
-        OPCode4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 4,Maker){}
-        OPCode4(int addr, Builder *Maker):Instruction(addr,"???",4,Maker){}
-        OPCode4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 4,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
         }
     };
-    class OPCode5 : public Instruction
-    {
-        public:
-        OPCode5():Instruction(-1,5,nullptr){}
-        OPCode5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 5,Maker){}
-        OPCode5(int addr, Builder *Maker):Instruction(addr,"???",5,Maker){}
-        OPCode5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 5,Maker){
-                addr++;
-                sub05(addr, content, this);
-                this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr, 4))); // pointer
+    class OPCode2 : public Instruction {
+      public:
+        OPCode2()
+          : Instruction(-1, 2, nullptr) {}
+        OPCode2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Call", 2, Maker) {}
+        OPCode2(int addr, Builder* Maker)
+          : Instruction(addr, "Call", 2, Maker) {}
+        OPCode2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Call", 2, Maker) {
+            addr++;
 
-        }
-    };
-    class OPCode6 : public Instruction
-    {
-        public:
-        OPCode6():Instruction(-1,6,nullptr){}
-        OPCode6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 6,Maker){}
-        OPCode6(int addr, Builder *Maker):Instruction(addr,"???",6,Maker){}
-        OPCode6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 6,Maker){
-                addr++;
-                sub05(addr, content, this);
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            QByteArray function_name = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", function_name));
+            QByteArray control_byte2_arr = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte2_arr));
 
-                QByteArray ptr;
-                this->AddOperande(operande(addr,"byte", control_byte));
+            int control_byte2 = (int)control_byte2_arr[0];
 
-                for (int i = 0; i < (unsigned char) control_byte[0]; i++){
-                    QByteArray iVar3_arr = ReadSubByteArray(content, addr,4);
-                    this->AddOperande(operande(addr,"int", iVar3_arr));
-
-                    ptr = ReadSubByteArray(content, addr,4);
-                    this->AddOperande(operande(addr,"pointer",ptr));
-
+            if (control_byte2 != 0) {
+                for (int i = 0; i < control_byte2; i++) {
+                    fun_1403c90e0(addr, content, this, 0);
                 }
+            }
+            switch ((unsigned char)control_byte[0]) {
+                case 0xB:
 
-                this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
+                    /*qDebug() << "Calling function " << ConvertBytesToString(function_name);
+                    //here we're calling a function that was defined at the beginning
+                    std::vector<function>::iterator it =
+                    find_function_by_name(Maker->FunctionsToParse,ConvertBytesToString(function_name));
+
+                    if (!std::count(Maker->FunctionsParsed.begin(), Maker->FunctionsParsed.end(), *it)){
+                        Maker->ReadIndividualFunction(*it,content);
+                        Maker->FunctionsParsed.push_back(*it);
+                    }*/
+                    // Maker->FunctionsToParse.erase(it);
+                    break;
+            }
         }
     };
-    class OPCode7 : public Instruction
-    {
-        public:
-        OPCode7():Instruction(-1,0x7,nullptr){}
-        OPCode7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 7,Maker){}
-        OPCode7(int addr, Builder *Maker):Instruction(addr,"???",0x7,Maker){}
-        OPCode7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        fun_1403c90e0(addr, content, this, 0);
-
-                        break;
-                    case 1:
-                        fun_1403c90e0(addr, content, this, 0);
-                        break;
-                    case 2:
-                        fun_1403c90e0(addr, content, this, 0);
-                        break;
-                }
-        }
-
-
-    };
-    class OPCode8 : public Instruction
-    {
-        public:
-        OPCode8():Instruction(-1,8,nullptr){}
-        OPCode8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 8,Maker){}
-        OPCode8(int addr, Builder *Maker):Instruction(addr,"???",8,Maker){}
-        OPCode8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 8,Maker){
-                addr++;
-                sub05(addr, content, this);
-
+    class OPCode3 : public Instruction {
+      public:
+        OPCode3()
+          : Instruction(-1, 3, nullptr) {}
+        OPCode3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 3, Maker) {}
+        OPCode3(int addr, Builder* Maker)
+          : Instruction(addr, "???", 3, Maker) {}
+        OPCode3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 3, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCodeA : public Instruction
-    {
-        public:
-        OPCodeA():Instruction(-1,0xA,nullptr){}
-        OPCodeA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA,Maker){}
-        OPCodeA(int addr, Builder *Maker):Instruction(addr,"???",0xA,Maker){}
-        OPCodeA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                sub05(addr, content, this);
+    class OPCode4 : public Instruction {
+      public:
+        OPCode4()
+          : Instruction(-1, 4, nullptr) {}
+        OPCode4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 4, Maker) {}
+        OPCode4(int addr, Builder* Maker)
+          : Instruction(addr, "???", 4, Maker) {}
+        OPCode4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 4, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    class OPCodeC : public Instruction
-    {
-        public:
-        OPCodeC():Instruction(-1,0xC,nullptr){}
-        OPCodeC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC,Maker){}
-        OPCodeC(int addr, Builder *Maker):Instruction(addr,"???",0xC,Maker){}
-        OPCodeC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+    class OPCode5 : public Instruction {
+      public:
+        OPCode5()
+          : Instruction(-1, 5, nullptr) {}
+        OPCode5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 5, Maker) {}
+        OPCode5(int addr, Builder* Maker)
+          : Instruction(addr, "???", 5, Maker) {}
+        OPCode5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 5, Maker) {
+            addr++;
+            sub05(addr, content, this);
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4))); // pointer
         }
     };
-    class OPCode0D : public Instruction
-    {
-        public:
-        OPCode0D():Instruction(-1,0x0D,nullptr){}
-        OPCode0D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0D,Maker){}
-        OPCode0D(int addr, Builder *Maker):Instruction(addr,"???",0x0D,Maker){}
-        OPCode0D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0D,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+    class OPCode6 : public Instruction {
+      public:
+        OPCode6()
+          : Instruction(-1, 6, nullptr) {}
+        OPCode6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 6, Maker) {}
+        OPCode6(int addr, Builder* Maker)
+          : Instruction(addr, "???", 6, Maker) {}
+        OPCode6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 6, Maker) {
+            addr++;
+            sub05(addr, content, this);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
 
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        sub05(addr, content, this);
-                        break;
-                }
-        }
+            QByteArray ptr;
+            this->AddOperande(operande(addr, "byte", control_byte));
 
+            for (int i = 0; i < (unsigned char)control_byte[0]; i++) {
+                QByteArray iVar3_arr = ReadSubByteArray(content, addr, 4);
+                this->AddOperande(operande(addr, "int", iVar3_arr));
 
-    };
-    class OPCodeE : public Instruction
-    {
-        public:
-        OPCodeE():Instruction(-1,0xE,nullptr){}
-        OPCodeE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xE,Maker){}
-        OPCodeE(int addr, Builder *Maker):Instruction(addr,"???",0xE,Maker){}
-        OPCodeE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xE,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                ptr = ReadSubByteArray(content, addr, 4);
+                this->AddOperande(operande(addr, "pointer", ptr));
+            }
 
-
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode10 : public Instruction
-    {
-        public:
-        OPCode10():Instruction(-1,0x10,nullptr){}
-        OPCode10(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x10,Maker){}
-        OPCode10(int addr, Builder *Maker):Instruction(addr,"???",0x10,Maker){}
-        OPCode10(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x10,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode11 : public Instruction
-    {
-        public:
-        OPCode11():Instruction(-1,0x11,nullptr){}
-        OPCode11(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x11,Maker){}
-        OPCode11(int addr, Builder *Maker):Instruction(addr,"???",0x11,Maker){}
-        OPCode11(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x11,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode12 : public Instruction
-    {
-        public:
-        OPCode12():Instruction(-1,0x12,nullptr){}
-        OPCode12(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x12,Maker){}
-        OPCode12(int addr, Builder *Maker):Instruction(addr,"???",0x12,Maker){}
-        OPCode12(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x12,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode13 : public Instruction
-    {
-        public:
-        OPCode13():Instruction(-1,0x13,nullptr){}
-        OPCode13(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x13,Maker){}
-        OPCode13(int addr, Builder *Maker):Instruction(addr,"???",0x13,Maker){}
-        OPCode13(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x13,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode14 : public Instruction
-    {
-        public:
-        OPCode14():Instruction(-1,0x14,nullptr){}
-        OPCode14(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x14,Maker){}
-        OPCode14(int addr, Builder *Maker):Instruction(addr,"???",0x14,Maker){}
-        OPCode14(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x14,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode15 : public Instruction
-    {
-        public:
-        OPCode15():Instruction(-1,0x15,nullptr){}
-        OPCode15(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x15,Maker){}
-        OPCode15(int addr, Builder *Maker):Instruction(addr,"???",0x15,Maker){}
-        OPCode15(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x15,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode16 : public Instruction
-    {
-        public:
-        OPCode16():Instruction(-1,0x16,nullptr){}
-        OPCode16(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x16,Maker){}
-        OPCode16(int addr, Builder *Maker):Instruction(addr,"???",0x16,Maker){}
-        OPCode16(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x16,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode17 : public Instruction
-    {
-        public:
-        OPCode17():Instruction(-1,0x17,nullptr){}
-        OPCode17(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x17,Maker){}
-        OPCode17(int addr, Builder *Maker):Instruction(addr,"???",0x17,Maker){}
-        OPCode17(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x17,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode18 : public Instruction
-    {
-        public:
-        OPCode18():Instruction(-1,0x18,nullptr){}
-        OPCode18(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x18,Maker){}
-        OPCode18(int addr, Builder *Maker):Instruction(addr,"???",0x18,Maker){}
-        OPCode18(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x18,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                sub05(addr, content, this);
-
-        }
-    };
-    class OPCode1A : public Instruction
-    {
-        public:
-        OPCode1A():Instruction(-1,0x1A,nullptr){}
-        OPCode1A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1A,Maker){}
-        OPCode1A(int addr, Builder *Maker):Instruction(addr,"???",0x1A,Maker){}
-        OPCode1A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1A,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode1D : public Instruction
-    {
-        public:
-        OPCode1D():Instruction(-1,0x1D,nullptr){}
-        OPCode1D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1D,Maker){}
-        OPCode1D(int addr, Builder *Maker):Instruction(addr,"???",0x1D,Maker){}
-        OPCode1D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//6
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//10
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//E
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x12
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x16
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x1A
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x1E
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x22
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//i think this one is the id of the battle function it triggers
-                /*if (ID_fun != -1){
-                    std::vector<function>::iterator itt = find_function_by_ID(Maker->FunctionsParsed, ID_fun); //we'll read it right away
-
-                    if (itt == Maker->FunctionsParsed.end()){ //if we never read it, we'll do that.
-
-                        int addr_initial = addr;
-                        std::vector<function>::iterator it_fun_to_read = find_function_by_ID(Maker->FunctionsToParse, ID_fun);
-
-                        it_fun_to_read->called = true;
-                        Maker->ReadIndividualFunction(*it_fun_to_read,content);
-                        Maker->FunctionsParsed.push_back(*it_fun_to_read);
-                        addr = addr_initial;
-                    }
-                }
-                else if (fun_name!=""){
-                    std::vector<function>::iterator itt = find_function_by_name(Maker->FunctionsParsed, fun_name); //we'll read it right away
-                    if (itt == Maker->FunctionsParsed.end()){ //if we never read it, we'll do that.
-
-                        int addr_initial = addr;
-                        std::vector<function>::iterator it_fun_to_read = find_function_by_name(Maker->FunctionsToParse, fun_name);
-                        if (it_fun_to_read != Maker->FunctionsToParse.end()){
-                        qDebug() << hex << it_fun_to_read->actual_addr;
-                        it_fun_to_read->called = true;
-                        Maker->ReadIndividualFunction(*it_fun_to_read,content);
-                        Maker->FunctionsParsed.push_back(*it_fun_to_read);
-                        addr = addr_initial;
-                        }
-                    }
-
-                }*/
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode1E : public Instruction
-    {
-        public:
-        OPCode1E():Instruction(-1,0x1E,nullptr){}
-        OPCode1E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1E,Maker){}
-        OPCode1E(int addr, Builder *Maker):Instruction(addr,"???",0x1E,Maker){}
-        OPCode1E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-        }
-    };
-    class OPCode1F : public Instruction
-    {
-        public:
-        OPCode1F():Instruction(-1,0x1F,nullptr){}
-        OPCode1F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1F,Maker){}
-        OPCode1F(int addr, Builder *Maker):Instruction(addr,"???",0x1F,Maker){}
-        OPCode1F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1F,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-
-        }
-    };
-    class OPCode20 : public Instruction
-    {
-        public:
-        OPCode20():Instruction(-1,0x20,nullptr){}
-        OPCode20(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x20,Maker){}
-        OPCode20(int addr, Builder *Maker):Instruction(addr,"???",0x20,Maker){}
-        OPCode20(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x20,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-        }
-
-
-    };
-    class OPCode21 : public Instruction
-    {
-        public:
-        OPCode21():Instruction(-1,0x21,nullptr){}
-        OPCode21(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x21,Maker){}
-        OPCode21(int addr, Builder *Maker):Instruction(addr,"???",0x21,Maker){}
-        OPCode21(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x21,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-
-    };
-    class OPCode22 : public Instruction
-    {
-        public:
-        OPCode22():Instruction(-1,0x22,nullptr){}
-        OPCode22(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x22,Maker){}
-        OPCode22(int addr, Builder *Maker):Instruction(addr,"???",0x22,Maker){}
-        OPCode22(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x22,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                reading_dialog(addr, content, this);
-        }
-
-
-    };
-    class OPCode23 : public Instruction
-    {
-        public:
-        OPCode23():Instruction(-1,0x23,nullptr){}
-        OPCode23(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x23,Maker){}
-        OPCode23(int addr, Builder *Maker):Instruction(addr,"???",0x23,Maker){}
-        OPCode23(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x23,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                }
-        }
-
-
-    };
-    class OPCode24 : public Instruction
-    {
-        public:
-        OPCode24():Instruction(-1,0x24,nullptr){}
-        OPCode24(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x24,Maker){}
-        OPCode24(int addr, Builder *Maker):Instruction(addr,"???",0x24,Maker){}
-        OPCode24(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x24,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                reading_dialog(addr, content, this);
-
-        }
-
-
-    };
-    class OPCode25 : public Instruction
-    {
-        public:
-        OPCode25():Instruction(-1,0x25,nullptr){}
-        OPCode25(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x25,Maker){}
-        OPCode25(int addr, Builder *Maker):Instruction(addr,"???",0x25,Maker){}
-        OPCode25(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x25,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-
-    };
-    class OPCode26 : public Instruction
-    {
-        public:
-        OPCode26():Instruction(-1,0x26,nullptr){}
-        OPCode26(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x26,Maker){}
-        OPCode26(int addr, Builder *Maker):Instruction(addr,"???",0x26,Maker){}
-        OPCode26(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
-                addr++;
-        }
-
-
-    };
-    class OPCode27 : public Instruction
-    {
-        public:
-        OPCode27():Instruction(-1,0x27,nullptr){}
-        OPCode27(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x27,Maker){}
-        OPCode27(int addr, Builder *Maker):Instruction(addr,"???",0x27,Maker){}
-        OPCode27(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x27,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-        }
-
-
-    };
-    class OPCode28 : public Instruction
-    {
-        public:
-        OPCode28():Instruction(-1,0x28,nullptr){}
-        OPCode28(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x28,Maker){}
-        OPCode28(int addr, Builder *Maker):Instruction(addr,"???",0x28,Maker){}
-        OPCode28(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x28,Maker){
-                addr++;
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-
-    };
-    class OPCode29 : public Instruction
-    {
-        public:
-        OPCode29():Instruction(-1,0x29,nullptr){}
-        OPCode29(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x29,Maker){}
-        OPCode29(int addr, Builder *Maker):Instruction(addr,"???",0x29,Maker){}
-        OPCode29(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x29,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", control_byte2));
-                if((unsigned char)control_byte2[0]<4){
-                    switch ((unsigned char)control_byte[0])  {
-                        case 0:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                        case 1:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                        case 2:
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                        case 4:
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                        case 5:
-                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                        case 6:
-                        case 7:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                        case 8:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                            fun_1403c90e0(addr, content, this, 1);
-                            fun_1403c90e0(addr, content, this, 1);
-                        break;
-                        case 0xB:
-                            fun_1403c90e0(addr, content, this, 1);
-                        break;
-                        case 0xC:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                        case 0xD:
-                        case 0xE:
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    }
-                }
-
-        }
-
-
-    };
-    class OPCode2A : public Instruction
-    {
-        public:
-        OPCode2A():Instruction(-1,0x2A,nullptr){}
-        OPCode2A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2A,Maker){}
-        OPCode2A(int addr, Builder *Maker):Instruction(addr,"???",0x2A,Maker){}
-        OPCode2A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                    switch ((unsigned char)control_byte[0])  {
-                        case 0:
-                        case 1:
-                        case 2:
-                        case 3:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-
-        }
-
-
-    };
-
-    class OPCode2B : public Instruction
-    {
-        public:
-        OPCode2B():Instruction(-1,0x2B,nullptr){}
-        OPCode2B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2B,Maker){}
-        OPCode2B(int addr, Builder *Maker):Instruction(addr,"???",0x2B,Maker){}
-        OPCode2B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2B,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                if ((unsigned char)control_byte[0] == 0){
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                }
-                if ((unsigned char)control_byte[0] == 1){
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                }
-
-
-        }
-
-
-    };
-    class OPCode2C : public Instruction
-    {
-        public:
-        OPCode2C():Instruction(-1,0x2C,nullptr){}
-        OPCode2C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2C,Maker){}
-        OPCode2C(int addr, Builder *Maker):Instruction(addr,"???",0x2C,Maker){}
-        OPCode2C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                //le parsing du string est bizarre (parse 0xC) mais vérifié
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-        }
-
-
-    };
-    class OPCode2D : public Instruction
-    {
-        public:
-        OPCode2D():Instruction(-1,0x2D,nullptr){}
-        OPCode2D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2D,Maker){}
-        OPCode2D(int addr, Builder *Maker):Instruction(addr,"???",0x2D,Maker){}
-        OPCode2D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-
-    };
-    class OPCode2E : public Instruction
-    {
-        public:
-        OPCode2E():Instruction(-1,0x2E,nullptr){}
-        OPCode2E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2E,Maker){}
-        OPCode2E(int addr, Builder *Maker):Instruction(addr,"???",0x2E,Maker){}
-        OPCode2E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2E,Maker){
+    class OPCode7 : public Instruction {
+      public:
+        OPCode7()
+          : Instruction(-1, 0x7, nullptr) {}
+        OPCode7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 7, Maker) {}
+        OPCode7(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7, Maker) {}
+        OPCode7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-            switch ((unsigned char)control_byte[0])  {
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    fun_1403c90e0(addr, content, this, 0);
+
+                    break;
+                case 1:
+                    fun_1403c90e0(addr, content, this, 0);
+                    break;
+                case 2:
+                    fun_1403c90e0(addr, content, this, 0);
+                    break;
+            }
+        }
+    };
+    class OPCode8 : public Instruction {
+      public:
+        OPCode8()
+          : Instruction(-1, 8, nullptr) {}
+        OPCode8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 8, Maker) {}
+        OPCode8(int addr, Builder* Maker)
+          : Instruction(addr, "???", 8, Maker) {}
+        OPCode8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 8, Maker) {
+            addr++;
+            sub05(addr, content, this);
+        }
+    };
+    class OPCodeA : public Instruction {
+      public:
+        OPCodeA()
+          : Instruction(-1, 0xA, nullptr) {}
+        OPCodeA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA, Maker) {}
+        OPCodeA(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA, Maker) {}
+        OPCodeA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            sub05(addr, content, this);
+        }
+    };
+    class OPCodeC : public Instruction {
+      public:
+        OPCodeC()
+          : Instruction(-1, 0xC, nullptr) {}
+        OPCodeC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC, Maker) {}
+        OPCodeC(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC, Maker) {}
+        OPCodeC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode0D : public Instruction {
+      public:
+        OPCode0D()
+          : Instruction(-1, 0x0D, nullptr) {}
+        OPCode0D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0D, Maker) {}
+        OPCode0D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {}
+        OPCode0D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    sub05(addr, content, this);
+                    break;
+            }
+        }
+    };
+    class OPCodeE : public Instruction {
+      public:
+        OPCodeE()
+          : Instruction(-1, 0xE, nullptr) {}
+        OPCodeE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xE, Maker) {}
+        OPCodeE(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xE, Maker) {}
+        OPCodeE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xE, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode10 : public Instruction {
+      public:
+        OPCode10()
+          : Instruction(-1, 0x10, nullptr) {}
+        OPCode10(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x10, Maker) {}
+        OPCode10(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {}
+        OPCode10(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode11 : public Instruction {
+      public:
+        OPCode11()
+          : Instruction(-1, 0x11, nullptr) {}
+        OPCode11(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x11, Maker) {}
+        OPCode11(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {}
+        OPCode11(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode12 : public Instruction {
+      public:
+        OPCode12()
+          : Instruction(-1, 0x12, nullptr) {}
+        OPCode12(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x12, Maker) {}
+        OPCode12(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {}
+        OPCode12(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode13 : public Instruction {
+      public:
+        OPCode13()
+          : Instruction(-1, 0x13, nullptr) {}
+        OPCode13(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x13, Maker) {}
+        OPCode13(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {}
+        OPCode13(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode14 : public Instruction {
+      public:
+        OPCode14()
+          : Instruction(-1, 0x14, nullptr) {}
+        OPCode14(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x14, Maker) {}
+        OPCode14(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {}
+        OPCode14(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode15 : public Instruction {
+      public:
+        OPCode15()
+          : Instruction(-1, 0x15, nullptr) {}
+        OPCode15(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x15, Maker) {}
+        OPCode15(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {}
+        OPCode15(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode16 : public Instruction {
+      public:
+        OPCode16()
+          : Instruction(-1, 0x16, nullptr) {}
+        OPCode16(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x16, Maker) {}
+        OPCode16(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {}
+        OPCode16(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode17 : public Instruction {
+      public:
+        OPCode17()
+          : Instruction(-1, 0x17, nullptr) {}
+        OPCode17(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x17, Maker) {}
+        OPCode17(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {}
+        OPCode17(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode18 : public Instruction {
+      public:
+        OPCode18()
+          : Instruction(-1, 0x18, nullptr) {}
+        OPCode18(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x18, Maker) {}
+        OPCode18(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {}
+        OPCode18(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            sub05(addr, content, this);
+        }
+    };
+    class OPCode1A : public Instruction {
+      public:
+        OPCode1A()
+          : Instruction(-1, 0x1A, nullptr) {}
+        OPCode1A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1A, Maker) {}
+        OPCode1A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {}
+        OPCode1A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode1D : public Instruction {
+      public:
+        OPCode1D()
+          : Instruction(-1, 0x1D, nullptr) {}
+        OPCode1D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1D, Maker) {}
+        OPCode1D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {}
+        OPCode1D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 6
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // E
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x12
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x16
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x1A
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x1E
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x22
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(
+              operande(addr, "int", ReadSubByteArray(content, addr, 4))); // i think this one is the id of the battle function it triggers
+            /*if (ID_fun != -1){
+                std::vector<function>::iterator itt = find_function_by_ID(Maker->FunctionsParsed, ID_fun); //we'll read
+            it right away
+
+                if (itt == Maker->FunctionsParsed.end()){ //if we never read it, we'll do that.
+
+                    int addr_initial = addr;
+                    std::vector<function>::iterator it_fun_to_read = find_function_by_ID(Maker->FunctionsToParse,
+            ID_fun);
+
+                    it_fun_to_read->called = true;
+                    Maker->ReadIndividualFunction(*it_fun_to_read,content);
+                    Maker->FunctionsParsed.push_back(*it_fun_to_read);
+                    addr = addr_initial;
+                }
+            }
+            else if (fun_name!=""){
+                std::vector<function>::iterator itt = find_function_by_name(Maker->FunctionsParsed, fun_name); //we'll
+            read it right away if (itt == Maker->FunctionsParsed.end()){ //if we never read it, we'll do that.
+
+                    int addr_initial = addr;
+                    std::vector<function>::iterator it_fun_to_read = find_function_by_name(Maker->FunctionsToParse,
+            fun_name); if (it_fun_to_read != Maker->FunctionsToParse.end()){ qDebug() << hex <<
+            it_fun_to_read->actual_addr; it_fun_to_read->called = true;
+                    Maker->ReadIndividualFunction(*it_fun_to_read,content);
+                    Maker->FunctionsParsed.push_back(*it_fun_to_read);
+                    addr = addr_initial;
+                    }
+                }
+
+            }*/
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode1E : public Instruction {
+      public:
+        OPCode1E()
+          : Instruction(-1, 0x1E, nullptr) {}
+        OPCode1E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1E, Maker) {}
+        OPCode1E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {}
+        OPCode1E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    class OPCode1F : public Instruction {
+      public:
+        OPCode1F()
+          : Instruction(-1, 0x1F, nullptr) {}
+        OPCode1F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1F, Maker) {}
+        OPCode1F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {}
+        OPCode1F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    class OPCode20 : public Instruction {
+      public:
+        OPCode20()
+          : Instruction(-1, 0x20, nullptr) {}
+        OPCode20(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x20, Maker) {}
+        OPCode20(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {}
+        OPCode20(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+        }
+    };
+    class OPCode21 : public Instruction {
+      public:
+        OPCode21()
+          : Instruction(-1, 0x21, nullptr) {}
+        OPCode21(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x21, Maker) {}
+        OPCode21(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {}
+        OPCode21(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode22 : public Instruction {
+      public:
+        OPCode22()
+          : Instruction(-1, 0x22, nullptr) {}
+        OPCode22(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x22, Maker) {}
+        OPCode22(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {}
+        OPCode22(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            reading_dialog(addr, content, this);
+        }
+    };
+    class OPCode23 : public Instruction {
+      public:
+        OPCode23()
+          : Instruction(-1, 0x23, nullptr) {}
+        OPCode23(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x23, Maker) {}
+        OPCode23(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {}
+        OPCode23(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode24 : public Instruction {
+      public:
+        OPCode24()
+          : Instruction(-1, 0x24, nullptr) {}
+        OPCode24(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x24, Maker) {}
+        OPCode24(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {}
+        OPCode24(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            reading_dialog(addr, content, this);
+        }
+    };
+    class OPCode25 : public Instruction {
+      public:
+        OPCode25()
+          : Instruction(-1, 0x25, nullptr) {}
+        OPCode25(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x25, Maker) {}
+        OPCode25(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {}
+        OPCode25(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode26 : public Instruction {
+      public:
+        OPCode26()
+          : Instruction(-1, 0x26, nullptr) {}
+        OPCode26(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x26, Maker) {}
+        OPCode26(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {}
+        OPCode26(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {
+            addr++;
+        }
+    };
+    class OPCode27 : public Instruction {
+      public:
+        OPCode27()
+          : Instruction(-1, 0x27, nullptr) {}
+        OPCode27(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x27, Maker) {}
+        OPCode27(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {}
+        OPCode27(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode28 : public Instruction {
+      public:
+        OPCode28()
+          : Instruction(-1, 0x28, nullptr) {}
+        OPCode28(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x28, Maker) {}
+        OPCode28(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {}
+        OPCode28(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {
+            addr++;
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode29 : public Instruction {
+      public:
+        OPCode29()
+          : Instruction(-1, 0x29, nullptr) {}
+        OPCode29(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x29, Maker) {}
+        OPCode29(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {}
+        OPCode29(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte2));
+            if ((unsigned char)control_byte2[0] < 4) {
+                switch ((unsigned char)control_byte[0]) {
+                    case 0:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 1:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 2:
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    case 4:
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    case 5:
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    case 6:
+                    case 7:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    case 8:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        fun_1403c90e0(addr, content, this, 1);
+                        fun_1403c90e0(addr, content, this, 1);
+                        break;
+                    case 0xB:
+                        fun_1403c90e0(addr, content, this, 1);
+                        break;
+                    case 0xC:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    case 0xD:
+                    case 0xE:
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        break;
+                }
+            }
+        }
+    };
+    class OPCode2A : public Instruction {
+      public:
+        OPCode2A()
+          : Instruction(-1, 0x2A, nullptr) {}
+        OPCode2A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2A, Maker) {}
+        OPCode2A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {}
+        OPCode2A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                case 2:
+                case 3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+
+    class OPCode2B : public Instruction {
+      public:
+        OPCode2B()
+          : Instruction(-1, 0x2B, nullptr) {}
+        OPCode2B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2B, Maker) {}
+        OPCode2B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {}
+        OPCode2B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+            if ((unsigned char)control_byte[0] == 0) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            }
+            if ((unsigned char)control_byte[0] == 1) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            }
+        }
+    };
+    class OPCode2C : public Instruction {
+      public:
+        OPCode2C()
+          : Instruction(-1, 0x2C, nullptr) {}
+        OPCode2C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2C, Maker) {}
+        OPCode2C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {}
+        OPCode2C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            // le parsing du string est bizarre (parse 0xC) mais vérifié
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode2D : public Instruction {
+      public:
+        OPCode2D()
+          : Instruction(-1, 0x2D, nullptr) {}
+        OPCode2D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2D, Maker) {}
+        OPCode2D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {}
+        OPCode2D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode2E : public Instruction {
+      public:
+        OPCode2E()
+          : Instruction(-1, 0x2E, nullptr) {}
+        OPCode2E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2E, Maker) {}
+        OPCode2E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {}
+        OPCode2E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte2));
+
+            switch ((unsigned char)control_byte[0]) {
                 case 0x01:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//5->8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//9->C
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));//D
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 5->8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 9->C
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // D
 
                     break;
                 case 0x03:
                 case 0x02:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));//5
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // 5
                     break;
             }
         }
-
-
     };
-    class OPCode2F : public Instruction
-    {
-        public:
-        OPCode2F():Instruction(-1,0x2F,nullptr){}
-        OPCode2F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2F,Maker){}
-        OPCode2F(int addr, Builder *Maker):Instruction(addr,"???",0x2F,Maker){}
-        OPCode2F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2F,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                switch ((unsigned char)control_byte[0])  {
+    class OPCode2F : public Instruction {
+      public:
+        OPCode2F()
+          : Instruction(-1, 0x2F, nullptr) {}
+        OPCode2F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2F, Maker) {}
+        OPCode2F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {}
+        OPCode2F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 1:
                 case 0:
                 case 2:
                 case 4:
                 case 5:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 6:
                 case 7:
 
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 8:
 
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));//16
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr))); // 16
                     break;
                 case 9:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0xA:
                 case 0xB:
                 case 0xC:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0xE:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0xF:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                }
-
+            }
         }
-
-
     };
-    class OPCode30 : public Instruction
-    {
-        public:
-        OPCode30():Instruction(-1,0x30,nullptr){}
-        OPCode30(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x30,Maker){}
-        OPCode30(int addr, Builder *Maker):Instruction(addr,"???",0x30,Maker){}
-        OPCode30(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x30,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
+    class OPCode30 : public Instruction {
+      public:
+        OPCode30()
+          : Instruction(-1, 0x30, nullptr) {}
+        OPCode30(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x30, Maker) {}
+        OPCode30(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {}
+        OPCode30(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    class OPCode31 : public Instruction
-    {
-        public:
-        OPCode31():Instruction(-1,0x31,nullptr){}
-        OPCode31(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x31,Maker){}
-        OPCode31(int addr, Builder *Maker):Instruction(addr,"???",0x31,Maker){}
-        OPCode31(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x31,Maker){
-                addr++;
+    class OPCode31 : public Instruction {
+      public:
+        OPCode31()
+          : Instruction(-1, 0x31, nullptr) {}
+        OPCode31(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x31, Maker) {}
+        OPCode31(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {}
+        OPCode31(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {
+            addr++;
 
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
-
     };
-    class OPCode32 : public Instruction
-    {
-        public:
-        OPCode32():Instruction(-1,0x32,nullptr){}
-        OPCode32(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x32,Maker){}
-        OPCode32(int addr, Builder *Maker):Instruction(addr,"???",0x32,Maker){}
-        OPCode32(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x32,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
+    class OPCode32 : public Instruction {
+      public:
+        OPCode32()
+          : Instruction(-1, 0x32, nullptr) {}
+        OPCode32(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x32, Maker) {}
+        OPCode32(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {}
+        OPCode32(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-                switch ((unsigned char)control_byte[0])  {
+            switch ((unsigned char)control_byte[0]) {
                 case '\n':
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     return;
 
-
                 case '\v':
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     return;
 
                 case '\f':
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    fun_1403c90e0(addr,content,this, 1);
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);//0xFF
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0); // 0xFF
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0);
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     return;
-                }
-                if (((unsigned char)control_byte[0] - 0xD) < 2) {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                }
-                else if (1 < (control_byte[0] - 0xfU)){
-                    switch((unsigned char)control_byte[0]){
+            }
+            if (((unsigned char)control_byte[0] - 0xD) < 2) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            } else if (1 < (control_byte[0] - 0xfU)) {
+                switch ((unsigned char)control_byte[0]) {
                     case '\x11':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                         break;
                     case '\x12':
 
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                         break;
                     case '\x13':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                         break;
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
 
                     default:
-                        if ((unsigned char)(control_byte[0] - 0x14U) < 2){
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//3
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//F
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                        if ((unsigned char)(control_byte[0] - 0x14U) < 2) {
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 3
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // F
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                         }
                         break;
-
-                    }
-
                 }
-                else{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
 
-                }
-                switch((unsigned char)control_byte[0]){
-                    case '\x16':
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case '\x17':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case '\x18':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case '\x19':
+            } else {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            }
+            switch ((unsigned char)control_byte[0]) {
+                case '\x16':
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case '\x17':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case '\x18':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case '\x19':
 
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case '\x1A':
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case '\x1B':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case '\x1C':
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case '\x1A':
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case '\x1B':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case '\x1C':
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                        break;
-                    case '\x1D':
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    }
-
-              }
-
-
-
+                    break;
+                case '\x1D':
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
     };
-    class OPCode33 : public Instruction
-    {
-        public:
-        OPCode33():Instruction(-1,0x33,nullptr){}
-        OPCode33(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x33,Maker){}
-        OPCode33(int addr, Builder *Maker):Instruction(addr,"???",0x33,Maker){}
-        OPCode33(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x33,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x00:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x01:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x02:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x03:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x04:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x07:
-                    case 0x05:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x06:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x08:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x09:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x0A:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x0C:
-                    case 0x0B:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x0D:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x0E:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x0F:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCode33 : public Instruction {
+      public:
+        OPCode33()
+          : Instruction(-1, 0x33, nullptr) {}
+        OPCode33(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x33, Maker) {}
+        OPCode33(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {}
+        OPCode33(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x01:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x02:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x03:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x04:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x07:
+                case 0x05:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x06:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x08:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x09:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x0A:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x0C:
+                case 0x0B:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x0D:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x0E:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x0F:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                        break;
-                    case 0x10:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x13:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x14:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x10:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x13:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x14:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                        break;
-                    case 0x15:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x16:
+                    break;
+                case 0x15:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x16:
 
-                        break;
-                    case 0x17:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x18:
+                    break;
+                case 0x17:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x18:
 
-                        break;
-                    case 0x1E:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x19:
-                    case 0x1A:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x1B:
+                    break;
+                case 0x1E:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x19:
+                case 0x1A:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x1B:
 
-                        break;
-                    case 0x20:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x21:
-                    case 0x22:
-                    case 0x23:
-                    case 0x24:
-                        break;
-                    case 0x26:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x27:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
+                    break;
+                case 0x20:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x21:
+                case 0x22:
+                case 0x23:
+                case 0x24:
+                    break;
+                case 0x26:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x27:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-                    case 0x2C:{
+                case 0x2C: {
 
-                        break;}
-                    case 0x2D:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x2E:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x2F:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x1f:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x30:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x31:
-                        break;
-                    case 0x32:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x34:
-                        break;
-                    case 0x35:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x36:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x37:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x38:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x39:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x3A:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x3B:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x3D:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x4B:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x67:
-                    case 0x68:
-                        break;
-                    case 0x48:
-                    case 0x6C:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x46:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    case 0x47:
-                        break;
-                    case 0x4A:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
+                    break;
+                }
+                case 0x2D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x2E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x2F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x1f:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x30:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x31:
+                    break;
+                case 0x32:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x34:
+                    break;
+                case 0x35:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x36:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x37:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x38:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x39:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x3A:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x3B:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x3D:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x4B:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x67:
+                case 0x68:
+                    break;
+                case 0x48:
+                case 0x6C:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x46:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                case 0x47:
+                    break;
+                case 0x4A:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-                    case 0x3c:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x6B:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x33:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x76:
-                    case 0x29:
-                        break;
-                    case 0x77:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x25:
+                case 0x3c:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x6B:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x33:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x76:
+                case 0x29:
+                    break;
+                case 0x77:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x25:
 
-                        break;
-                    case 0xB5:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0xBA:
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0xBB:
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
+                    break;
+                case 0xB5:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xBA:
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0xBB:
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
 
-                        break;
-                    case 0xBC:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xBC:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                        break;
-                    case 0xBD:
+                    break;
+                case 0xBD:
 
-                        break;
-                    case 0x62:
-                        {this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        QByteArray byte = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", byte));
-                        /*switch ((unsigned char)byte[0]){
-                            case 0:{
-                                QByteArray byte2 = ReadSubByteArray(content, addr, 1);
-                                this->AddOperande(operande(addr,"byte", byte2));
-                                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-
-                                break;
-                            }
-                            default:
-                             qFatal("Byte not analyzed yet");
-
-                        }*/
+                    break;
+                case 0x62: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    QByteArray byte = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", byte));
+                    /*switch ((unsigned char)byte[0]){
+                        case 0:{
+                            QByteArray byte2 = ReadSubByteArray(content, addr, 1);
+                            this->AddOperande(operande(addr,"byte", byte2));
+                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
 
 
-                        break;
-                    }
-                    case 0x52:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                        break;}
-                    case 0x5A:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-                        break;}
-                    case 0x5B:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-                        break;}
-                    case 0x5C:{
-                        QByteArray byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", byte2));
-                        /*this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));*/
-
-                        break;}
-                    case 0x61:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));//rbx+2
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));//rbx+3
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));//rbx+7
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));//rbx+B
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));//rbx+F
-                        break;}
-                    case 0x63:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x6E:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                    }
-                    case 0x6F:{
-                        break;}
-                    case 0x70:{
-                        break;}
-                    case 0x73:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x74:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x78:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x7B:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x7D:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0x7E:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                        break;}
-                    case 0x7F:{
-
-                        break;}
-                    case 0x87:{
-                        break;
-                    }
-                    case 0x83:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x85:{
-
-                        break;}
-                    case 0x86:{
-
-                        break;}
-                    case 0x88:{
-
-                        break;}
-                    case 0x89:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x8A:{
-
-                        break;}
-                    case 0x8E:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x8F:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x90:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    }
-                    case 0x91:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0x92:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    }
-                    case 0x94:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0x98:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0x9E:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    }
-                    case 0xA6:{
-                        break;
-                    }
-                    case 0xA7:{
-                        break;
-                    }
-                    case 0xA8:{
-                        break;
-                    }
-                    case 0xA9:{
-                        break;
-                    }
-                    case 0xAA:{
-                        break;
-                    }
-                    case 0xAB:{
-                        break;
-                    }
-                    case 0xAE:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0xAF:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0xB0:{
-                        break;}
-                    case 0xB1:{
-                        break;}
-                    case 0xB2:{
-                        break;}
-                    case 0xB4:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        break;}
-                    case 0xB6:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;}
-                    case 0xB7:{
-                        QByteArray byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", byte2));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0xB8:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0xBE:{
-
-                        break;}
-                    case 0xBF:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0xC0:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0xC1:{
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;}
-                    case 0xC2:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0xC3:{
-
-                        break;}
+                            break;
+                        }
                         default:
-                    qFatal("Byte not analyzed yet");
-                }
-        }
+                         qFatal("Byte not analyzed yet");
 
+                    }*/
 
-    };
-    class OPCode34 : public Instruction
-    {
-        public:
-        OPCode34():Instruction(-1,0x34,nullptr){}
-        OPCode34(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x34,Maker){}
-        OPCode34(int addr, Builder *Maker):Instruction(addr,"???",0x34,Maker){}
-        OPCode34(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x34,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode35 : public Instruction
-    {
-        public:
-        OPCode35():Instruction(-1,0x35,nullptr){}
-        OPCode35(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x35,Maker){}
-        OPCode35(int addr, Builder *Maker):Instruction(addr,"???",0x35,Maker){}
-        OPCode35(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x35,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode36 : public Instruction
-    {
-        public:
-        OPCode36():Instruction(-1,0x36,nullptr){}
-        OPCode36(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x36,Maker){}
-        OPCode36(int addr, Builder *Maker):Instruction(addr,"???",0x36,Maker){}
-        OPCode36(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x36,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 3:
-                    case 0x14:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x5:
-                    case 0x16:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x7:
-                    case 0x17:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x8:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x9:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0xA:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//4
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//8->c
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//c->E
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//E->10
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//10->12
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//12->14
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//14->16
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0xB:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xC:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xD:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xE:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xF:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    case 0x11:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x12:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x13:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;}
-                    case 0x15:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x1f:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;}
-                    case 0x19:
-                    case 0x18:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;}
-                    case 0x1A:{
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//2->6
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//6->10
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//10->14 (d)
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//(e)
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//(f)
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//(0x10)
-                        break;}
-                    case 0x1B:{
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;}
-                    case 0x28:
-                    case 0x29:{
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;}
-                    case 0x2A:
-                    case 0x2B:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;}
-                    case 0x2C:
-                    case 0x2D:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;}
-                    case 0x2E:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;}
-                }
-        }
-    };
-    class OPCode37 : public Instruction
-    {
-        public:
-        OPCode37():Instruction(-1,0x37,nullptr){}
-        OPCode37(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x37,Maker){}
-        OPCode37(int addr, Builder *Maker):Instruction(addr,"???",0x37,Maker){}
-        OPCode37(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x37,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class OPCode38 : public Instruction
-    {
-        public:
-        OPCode38():Instruction(-1,0x38,nullptr){}
-        OPCode38(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x38,Maker){}
-        OPCode38(int addr, Builder *Maker):Instruction(addr,"???",0x38,Maker){}
-        OPCode38(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x38,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-
-    class OPCode39 : public Instruction
-    {
-        public:
-        OPCode39():Instruction(-1,0x39,nullptr){}
-        OPCode39(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x39,Maker){}
-        OPCode39(int addr, Builder *Maker):Instruction(addr,"???",0x39,Maker){}
-        OPCode39(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x39,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-    };
-
-    class OPCode3A : public Instruction
-    {
-        public:
-        OPCode3A():Instruction(-1,0x3A,nullptr){}
-        OPCode3A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3A,Maker){}
-        OPCode3A(int addr, Builder *Maker):Instruction(addr,"???",0x3A,Maker){}
-        OPCode3A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x0:
-                    case 0x4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x7:
-
-                        break;
-                    case 0x8:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x9:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-
-
-        }
-    };
-    class OPCode3B : public Instruction
-    {
-        public:
-        OPCode3B():Instruction(-1,0x3B,nullptr){}
-        OPCode3B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3B,Maker){}
-        OPCode3B(int addr, Builder *Maker):Instruction(addr,"???",0x3B,Maker){}
-        OPCode3B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3B,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0xFB:
-                    case 0xFD:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0xFE:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0xFF:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0:
-                    case 0x32:
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        fun_1403c90e0(addr, content, this, 1);
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0->4
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4->8
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//8->A
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//A->C
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C->10
-                        /*this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//10->12
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//12->14*/
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//10->14
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//14->18
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//18->1C
-
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));//x
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//1C+x
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//1E+x
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//20+x
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//22+x
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//24+x
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//26+x
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//28+x
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//2A+x
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//2C+x
-
-                        break;
-                    case 1:
-                    case 0x33:
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        break;
-                    case 2:
-                    case 0x34:
-                        fun_1403c90e0(addr, content, this, 1);
-
-                        break;
-                    case 3:
-                    case 0x35:
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 4:
-                    case 0x36:
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 5:
-                    case 0x37://very weird one; caution
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-                    case 6:
-                    case 7:
-                    case 8:
-                    case 9:
-                    case 10:
-                    case 0xb:
-                    case 0xc:
-                    case 0xd:
-                    case 0xe:
-                    case 0xf:
-                    case 0x10:
-                    case 0x11:
-                    case 0x12:
-                    case 0x13:
-                    case 0x14:
-                    case 0x15:
-                    case 0x16:
-                    case 0x17:
-                    case 0x18:
-                    case 0x19:
-                    case 0x1a:
-                    case 0x1b:
-                    case 0x1c:
-                    case 0x1d:
-                    case 0x1e:
-                    case 0x1f:
-                    case 0x20:
-                    case 0x21:
-                    case 0x22:
-                    case 0x23:
-                    case 0x24:
-                    case 0x25:
-                    case 0x26:
-                    case 0x27:
-                    case 0x28:
-                    case 0x29:
-                    case 0x2a:
-                    case 0x2b:
-                    case 0x2c:
-                    case 0x2d:
-                    case 0x2e:
-                    case 0x2f:
-                    case 0x30:
-                    case 0x31:
-                    case 0x38:
-                    case 0x3f:
-                    case 0x40:
-                    case 0x41:
-                    case 0x42:
-                    case 0x43:
-                    case 0x44:
-                    case 0x45:
-                    case 0x46:
-                    case 0x47:
-                    case 0x48:
-                    case 0x49:
-                    case 0x4a:
-                    case 0x4b:
-                    case 0x4c:
-                    case 0x4d:
-                    case 0x4e:
-                    case 0x4f:
-                    case 0x50:
-                    case 0x51:
-                    case 0x52:
-                    case 0x53:
-                    case 0x54:
-                    case 0x55:
-                    case 0x56:
-                    case 0x57:
-                    case 0x58:
-                    case 0x59:
-                    case 0x5a:
-                    case 0x5b:
-                    case 0x5c:
-                    case 0x5d:
-                    case 0x5e:
-                    case 0x5f:
-                    case 0x60:
-                    case 0x61:
-                    case 0x62:
-                    case 99:
-                    case 0x66:
-                    case 0x67:
-                    case 0x68:
-                    case 0x69:
-                    case 0x6a:
-                    case 0x6b:
-                    case 0x6c:
-                    case 0x6d:
-                    case 0x6e:
-                    case 0x6f:
-                    case 0x70:
-                    case 0x71:
-                    case 0x72:
-                    case 0x73:
-                    case 0x74:
-                    case 0x75:
-                    case 0x76:
-                    case 0x77:
-                    case 0x78:
-                    case 0x79:
-                    case 0x7a:
-                    case 0x7b:
-                    case 0x7c:
-                    case 0x7d:
-                    case 0x7e:
-                    case 0x7f:
-                    case 0x80:
-                    case 0x81:
-                    case 0x82:
-                    case 0x83:
-                    case 0x84:
-                    case 0x85:
-                    case 0x86:
-                    case 0x87:
-                    case 0x88:
-                    case 0x89:
-                    case 0x8a:
-                    case 0x8b:
-                    case 0x8c:
-                    case 0x8d:
-                    case 0x8e:
-                    case 0x8f:
-                    case 0x90:
-                    case 0x91:
-                    case 0x92:
-                    case 0x93:
-                    case 0x94:
-                    case 0x95:
-                    case 0x3D:
-                      break;
-                    case 0x39:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x3A:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        break;
-                    case 0x3B:
-                    case 0x3C:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x3E:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 100:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x65:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//0->4
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//4->8
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//8->C
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//C->10
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//10->14
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//14->18
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//18->1C
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//1C->20
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//20->24
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//24->28
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//28->2C
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//2C->30
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//30->34
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//34->38
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//38->3C
-                        break;
-                    case 0x96:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    default:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                }
-
-
-        }
-    };
-    class OPCode3C : public Instruction
-    {
-        public:
-        OPCode3C():Instruction(-1,0x3C,nullptr){}
-        OPCode3C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3C,Maker){}
-        OPCode3C(int addr, Builder *Maker):Instruction(addr,"???",0x3C,Maker){}
-        OPCode3C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3C,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x1:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
                     break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-
                 }
+                case 0x52: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-
-        }
-    };
-    class OPCode3D : public Instruction
-    {
-        public:
-        OPCode3D():Instruction(-1,0x3D,nullptr){}
-        OPCode3D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3D,Maker){}
-        OPCode3D(int addr, Builder *Maker):Instruction(addr,"???",0x3D,Maker){}
-        OPCode3D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3D,Maker){
-                addr++;
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-        }
-    };
-    class OPCode3E : public Instruction
-    {
-        public:
-        OPCode3E():Instruction(-1,0x3E,nullptr){}
-        OPCode3E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3E,Maker){}
-        OPCode3E(int addr, Builder *Maker):Instruction(addr,"???",0x3E,Maker){}
-        OPCode3E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode3F : public Instruction
-    {
-        public:
-        OPCode3F():Instruction(-1,0x3F,nullptr){}
-        OPCode3F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3F,Maker){}
-        OPCode3F(int addr, Builder *Maker):Instruction(addr,"???",0x3F,Maker){}
-        OPCode3F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3F,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode40 : public Instruction
-    {
-        public:
-        OPCode40():Instruction(-1,0x40,nullptr){}
-        OPCode40(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x40,Maker){}
-        OPCode40(int addr, Builder *Maker):Instruction(addr,"???",0x40,Maker){}
-        OPCode40(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x40,Maker){
-                addr++;
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//1
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                short control = ReadShortFromByteArray(0, control_short);
-                this->AddOperande(operande(addr,"short", control_short));//3
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//5
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//9
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//D
-
-                if ((ushort)(control + 0x1feU) < 3){
-
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//11 -> 15
-                }
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                if (control == -0x1fb) {//I'm not sure at all of this behavior, but at the same time I'm not even sure it happens anywhere (lazy)
-                  while (content[addr] != '\0'){
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                  }
-                }
-
-        }
-    };
-    class OPCode41 : public Instruction
-    {
-        public:
-        OPCode41():Instruction(-1,0x41,nullptr){}
-        OPCode41(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x41", 0x41,Maker){}
-        OPCode41(int addr, Builder *Maker):Instruction(addr,"0x41",0x41,Maker){}
-        OPCode41(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x41", 0x41,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-        }
-    };
-    class OPCode42 : public Instruction
-    {
-        public:
-        OPCode42():Instruction(-1,0x42,nullptr){}
-        OPCode42(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x42,Maker){}
-        OPCode42(int addr, Builder *Maker):Instruction(addr,"???",0x42,Maker){}
-        OPCode42(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x42,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));//1
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//2
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//4
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//8
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//10
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//14
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//18 Not sure of the types here
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//1A
-
-
-        }
-    };
-    class OPCode43 : public Instruction
-    {
-        public:
-        OPCode43():Instruction(-1,0x43,nullptr){}
-        OPCode43(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x43,Maker){}
-        OPCode43(int addr, Builder *Maker):Instruction(addr,"???",0x43,Maker){}
-        OPCode43(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x43,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0xFF:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xFE:
-                    case 0x05:
-                    case 0x69:
-                    case 0x06:
-                    case 0x6A:
-                    case 0x0A:
-                    case 0x0B:
-                    case 0x0C:
-
-                        break;
-                    default:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-
-                }
-
-        }
-    };
-    class OPCode44 : public Instruction
-    {
-        public:
-        OPCode44():Instruction(-1,0x44,nullptr){}
-        OPCode44(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x44", 0x44,Maker){}
-        OPCode44(int addr, Builder *Maker):Instruction(addr,"0x44",0x44,Maker){}
-        OPCode44(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x44", 0x44,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class OPCode45 : public Instruction
-    {
-        public:
-        OPCode45():Instruction(-1,0x45,nullptr){}
-        OPCode45(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x45", 0x45,Maker){}
-        OPCode45(int addr, Builder *Maker):Instruction(addr,"0x45",0x45,Maker){}
-        OPCode45(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x45", 0x45,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode46 : public Instruction
-    {
-        public:
-        OPCode46():Instruction(-1,0x46,nullptr){}
-        OPCode46(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x46", 0x46,Maker){}
-        OPCode46(int addr, Builder *Maker):Instruction(addr,"0x46",0x46,Maker){}
-        OPCode46(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x46", 0x46,Maker){
-
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch ((unsigned char)control_byte[0])  {
-                    case 3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                }
-        }
-    };
-
-    class OPCode47 : public Instruction
-    {
-        public:
-        OPCode47():Instruction(-1,0x47,nullptr){}
-        OPCode47(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x47,Maker){}
-        OPCode47(int addr, Builder *Maker):Instruction(addr,"???",0x47,Maker){}
-        OPCode47(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x47,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode48 : public Instruction
-    {
-        public:
-        OPCode48():Instruction(-1,0x48,nullptr){}
-        OPCode48(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x48,Maker){}
-        OPCode48(int addr, Builder *Maker):Instruction(addr,"???",0x48,Maker){}
-        OPCode48(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x48,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode49 : public Instruction
-    {
-        public:
-        OPCode49():Instruction(-1,0x49,nullptr){}
-        OPCode49(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x49", 0x49,Maker){}
-        OPCode49(int addr, Builder *Maker):Instruction(addr,"0x49",0x49,Maker){}
-        OPCode49(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x49", 0x49,Maker){
-
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                    case 1:
-                    case 4:
-                    case 5:
-                    case 6:
-                    case 0x11:
-                    case '\t':
-                    case '\n':
-                    case '\v':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case '\b':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case '\f':
-                    case 0x17:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case '\r': // pas sûr
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x18)));
-                        break;
-                    case '\x0e':
-                    case '\x0f':
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-
-                }
-        }
-    };
-    class OPCode4A : public Instruction
-    {
-        public:
-        OPCode4A():Instruction(-1,0x4A,nullptr){}
-        OPCode4A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4A", 0x4A,Maker){}
-        OPCode4A(int addr, Builder *Maker):Instruction(addr,"0x4A",0x4A,Maker){}
-        OPCode4A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4A", 0x4A,Maker){
-
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-        }
-    };
-    class OPCode4B : public Instruction
-    {
-        public:
-        OPCode4B():Instruction(-1,0x4B,nullptr){}
-        OPCode4B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4B", 0x4B,Maker){}
-        OPCode4B(int addr, Builder *Maker):Instruction(addr,"0x4B",0x4B,Maker){}
-        OPCode4B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4B", 0x4B,Maker){
-
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                this->AddOperande(operande(addr,"short", control_short));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                /*switch (control_shrt)  {
-                    case 0xfff8:
-
-                        break;
-                    case 0xfff9:
-
-                        break;
-
-                }*/
-        }
-    };
-    class OPCode4C : public Instruction
-    {
-        public:
-        OPCode4C():Instruction(-1,0x4C,nullptr){}
-        OPCode4C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4C", 0x4C,Maker){}
-        OPCode4C(int addr, Builder *Maker):Instruction(addr,"0x4C",0x4C,Maker){}
-        OPCode4C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4C", 0x4C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode4D : public Instruction
-    {
-        public:
-        OPCode4D():Instruction(-1,0x4D,nullptr){}
-        OPCode4D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4D", 0x4D,Maker){}
-        OPCode4D(int addr, Builder *Maker):Instruction(addr,"0x4D",0x4D,Maker){}
-        OPCode4D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4D", 0x4D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode4E : public Instruction
-    {
-        public:
-        OPCode4E():Instruction(-1,0x4E,nullptr){}
-        OPCode4E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4E", 0x4E,Maker){}
-        OPCode4E(int addr, Builder *Maker):Instruction(addr,"0x4E",0x4E,Maker){}
-        OPCode4E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4E", 0x4E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode4F : public Instruction
-    {
-        public:
-        OPCode4F():Instruction(-1,0x4F,nullptr){}
-        OPCode4F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4F", 0x4F,Maker){}
-        OPCode4F(int addr, Builder *Maker):Instruction(addr,"0x4F",0x4F,Maker){}
-        OPCode4F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4F", 0x4F,Maker){
-
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-
-                    case 3:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-
-                }
-        }
-    };
-    class OPCode50 : public Instruction
-    {
-        public:
-        OPCode50():Instruction(-1,0x50,nullptr){}
-        OPCode50(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x50", 0x50,Maker){}
-        OPCode50(int addr, Builder *Maker):Instruction(addr,"0x50",0x50,Maker){}
-        OPCode50(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x50", 0x50,Maker){
-                addr++;
-                fun_1403c90e0(addr, content, this, 1);
-
-        }
-    };
-    class OPCode51 : public Instruction
-    {
-        public:
-        OPCode51():Instruction(-1,0x51,nullptr){}
-        OPCode51(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x51", 0x51,Maker){}
-        OPCode51(int addr, Builder *Maker):Instruction(addr,"0x51",0x51,Maker){}
-        OPCode51(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x51", 0x51,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCode52 : public Instruction
-    {
-        public:
-        OPCode52():Instruction(-1,0x52,nullptr){}
-        OPCode52(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x52", 0x52,Maker){}
-        OPCode52(int addr, Builder *Maker):Instruction(addr,"0x52",0x52,Maker){}
-        OPCode52(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x52", 0x52,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode53 : public Instruction
-    {
-        public:
-        OPCode53():Instruction(-1,0x53,nullptr){}
-        OPCode53(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x53", 0x53,Maker){}
-        OPCode53(int addr, Builder *Maker):Instruction(addr,"0x53",0x53,Maker){}
-        OPCode53(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x53", 0x53,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-
-        }
-    };
-    class OPCode54 : public Instruction
-    {
-        public:
-        OPCode54():Instruction(-1,0x54,nullptr){}
-        OPCode54(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x54,Maker){}
-        OPCode54(int addr, Builder *Maker):Instruction(addr,"???",0x54,Maker){}
-        OPCode54(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x54,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                QByteArray control_byte2;
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x1:
-                    case 0x3:
-                    case 0x8:
-                    case 0x0:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x20-4)));
-                        break;
-                    case 10:
-                    case 0xE:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0xB:
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x18:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
                     break;
-                    case 0xD:
+                }
+                case 0x5A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x14:
+                    break;
+                }
+                case 0x5B: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x15:
+                    break;
+                }
+                case 0x5C: {
+                    QByteArray byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", byte2));
+                    /*this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));*/
 
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x61: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // rbx+2
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // rbx+3
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // rbx+7
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // rbx+B
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // rbx+F
+                    break;
+                }
+                case 0x63: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x6E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                        break;
-                    case 0x17:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x30:
+                    break;
+                }
+                case 0x6F: {
+                    break;
+                }
+                case 0x70: {
+                    break;
+                }
+                case 0x73: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x74: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x78: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x7B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x7D: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x7E: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x7F: {
+
+                    break;
+                }
+                case 0x87: {
+                    break;
+                }
+                case 0x83: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x85: {
+
+                    break;
+                }
+                case 0x86: {
+
+                    break;
+                }
+                case 0x88: {
+
+                    break;
+                }
+                case 0x89: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x8A: {
+
+                    break;
+                }
+                case 0x8E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x8F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x90: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x91: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x92: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x94: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x98: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x9E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0xA6: {
+                    break;
+                }
+                case 0xA7: {
+                    break;
+                }
+                case 0xA8: {
+                    break;
+                }
+                case 0xA9: {
+                    break;
+                }
+                case 0xAA: {
+                    break;
+                }
+                case 0xAB: {
+                    break;
+                }
+                case 0xAE: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xAF: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xB0: {
+                    break;
+                }
+                case 0xB1: {
+                    break;
+                }
+                case 0xB2: {
+                    break;
+                }
+                case 0xB4: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
                     fun_1403c90e0(addr, content, this, 1);
                     break;
-                    case 0x24:
-                    case 0x22:
+                }
+                case 0xB6: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xB7: {
+                    QByteArray byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", byte2));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0xB8: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0xBE: {
 
-                    case 0x28:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x19:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x1C:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x21:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
+                    break;
+                }
+                case 0xBF: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xC0: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xC1: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xC2: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xC3: {
 
-                    case 0x23:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x26:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                default:
+                    qFatal("Byte not analyzed yet");
+            }
+        }
+    };
+    class OPCode34 : public Instruction {
+      public:
+        OPCode34()
+          : Instruction(-1, 0x34, nullptr) {}
+        OPCode34(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x34, Maker) {}
+        OPCode34(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {}
+        OPCode34(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode35 : public Instruction {
+      public:
+        OPCode35()
+          : Instruction(-1, 0x35, nullptr) {}
+        OPCode35(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x35, Maker) {}
+        OPCode35(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {}
+        OPCode35(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode36 : public Instruction {
+      public:
+        OPCode36()
+          : Instruction(-1, 0x36, nullptr) {}
+        OPCode36(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x36, Maker) {}
+        OPCode36(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {}
+        OPCode36(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 3:
+                case 0x14:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x5:
+                case 0x16:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                        break;
+                    break;
+                case 0x6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    case 0x29:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x2B:
-                        control_byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", control_byte2));
-                        if ((int)control_byte2[0]==0){
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));}
-                        break;
-                    case 0x2C:
+                    break;
+                case 0x7:
+                case 0x17:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x31:
-                        control_byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", control_byte2));
-                        if ((int)control_byte2[0]==0){
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        }
-                        else if ((int)control_byte2[0]==1){
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        }
-                        break;
+                    break;
+                case 0x8:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0x9:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0xA:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8->c
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // c->E
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // E->10
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 10->12
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 12->14
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 14->16
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xB:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xC:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xD:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xE:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xF:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                case 0x11:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x12:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x13: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x15:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x1f: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x19:
+                case 0x18: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1A: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 2->6
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 6->10
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10->14 (d)
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  //(e)
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  //(f)
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  //(0x10)
+                    break;
+                }
+                case 0x1B: {
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x28:
+                case 0x29: {
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2A:
+                case 0x2B: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x2C:
+                case 0x2D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x2E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+            }
+        }
+    };
+    class OPCode37 : public Instruction {
+      public:
+        OPCode37()
+          : Instruction(-1, 0x37, nullptr) {}
+        OPCode37(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x37, Maker) {}
+        OPCode37(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {}
+        OPCode37(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode38 : public Instruction {
+      public:
+        OPCode38()
+          : Instruction(-1, 0x38, nullptr) {}
+        OPCode38(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x38, Maker) {}
+        OPCode38(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {}
+        OPCode38(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+
+    class OPCode39 : public Instruction {
+      public:
+        OPCode39()
+          : Instruction(-1, 0x39, nullptr) {}
+        OPCode39(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x39, Maker) {}
+        OPCode39(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {}
+        OPCode39(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+
+    class OPCode3A : public Instruction {
+      public:
+        OPCode3A()
+          : Instruction(-1, 0x3A, nullptr) {}
+        OPCode3A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3A, Maker) {}
+        OPCode3A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {}
+        OPCode3A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x4:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0x7:
+
+                    break;
+                case 0x8:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x9:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode3B : public Instruction {
+      public:
+        OPCode3B()
+          : Instruction(-1, 0x3B, nullptr) {}
+        OPCode3B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3B, Maker) {}
+        OPCode3B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {}
+        OPCode3B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0xFB:
+                case 0xFD:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xFE:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0xFF:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0:
+                case 0x32:
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    fun_1403c90e0(addr, content, this, 1);
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0->4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4->8
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 8->A
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // A->C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C->10
+                    /*this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//10->12
+                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//12->14*/
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10->14
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 14->18
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 18->1C
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr))); // x
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 1C+x
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 1E+x
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 20+x
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 22+x
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 24+x
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 26+x
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 28+x
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 2A+x
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 2C+x
+
+                    break;
+                case 1:
+                case 0x33:
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    break;
+                case 2:
+                case 0x34:
+                    fun_1403c90e0(addr, content, this, 1);
+
+                    break;
+                case 3:
+                case 0x35:
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 4:
+                case 0x36:
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 5:
+                case 0x37: // very weird one; caution
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 0xb:
+                case 0xc:
+                case 0xd:
+                case 0xe:
+                case 0xf:
+                case 0x10:
+                case 0x11:
+                case 0x12:
+                case 0x13:
+                case 0x14:
+                case 0x15:
+                case 0x16:
+                case 0x17:
+                case 0x18:
+                case 0x19:
+                case 0x1a:
+                case 0x1b:
+                case 0x1c:
+                case 0x1d:
+                case 0x1e:
+                case 0x1f:
+                case 0x20:
+                case 0x21:
+                case 0x22:
+                case 0x23:
+                case 0x24:
+                case 0x25:
+                case 0x26:
+                case 0x27:
+                case 0x28:
+                case 0x29:
+                case 0x2a:
+                case 0x2b:
+                case 0x2c:
+                case 0x2d:
+                case 0x2e:
+                case 0x2f:
+                case 0x30:
+                case 0x31:
+                case 0x38:
+                case 0x3f:
+                case 0x40:
+                case 0x41:
+                case 0x42:
+                case 0x43:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x47:
+                case 0x48:
+                case 0x49:
+                case 0x4a:
+                case 0x4b:
+                case 0x4c:
+                case 0x4d:
+                case 0x4e:
+                case 0x4f:
+                case 0x50:
+                case 0x51:
+                case 0x52:
+                case 0x53:
+                case 0x54:
+                case 0x55:
+                case 0x56:
+                case 0x57:
+                case 0x58:
+                case 0x59:
+                case 0x5a:
+                case 0x5b:
+                case 0x5c:
+                case 0x5d:
+                case 0x5e:
+                case 0x5f:
+                case 0x60:
+                case 0x61:
+                case 0x62:
+                case 99:
+                case 0x66:
+                case 0x67:
+                case 0x68:
+                case 0x69:
+                case 0x6a:
+                case 0x6b:
+                case 0x6c:
+                case 0x6d:
+                case 0x6e:
+                case 0x6f:
+                case 0x70:
+                case 0x71:
+                case 0x72:
+                case 0x73:
+                case 0x74:
+                case 0x75:
+                case 0x76:
+                case 0x77:
+                case 0x78:
+                case 0x79:
+                case 0x7a:
+                case 0x7b:
+                case 0x7c:
+                case 0x7d:
+                case 0x7e:
+                case 0x7f:
+                case 0x80:
+                case 0x81:
+                case 0x82:
+                case 0x83:
+                case 0x84:
+                case 0x85:
+                case 0x86:
+                case 0x87:
+                case 0x88:
+                case 0x89:
+                case 0x8a:
+                case 0x8b:
+                case 0x8c:
+                case 0x8d:
+                case 0x8e:
+                case 0x8f:
+                case 0x90:
+                case 0x91:
+                case 0x92:
+                case 0x93:
+                case 0x94:
+                case 0x95:
+                case 0x3D:
+                    break;
+                case 0x39:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x3A:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    break;
+                case 0x3B:
+                case 0x3C:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x3E:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 100:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x65:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 0->4
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 4->8
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 8->C
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // C->10
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 10->14
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 14->18
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 18->1C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 1C->20
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 20->24
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 24->28
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 28->2C
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 2C->30
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 30->34
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 34->38
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 38->3C
+                    break;
+                case 0x96:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                default:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode3C : public Instruction {
+      public:
+        OPCode3C()
+          : Instruction(-1, 0x3C, nullptr) {}
+        OPCode3C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3C, Maker) {}
+        OPCode3C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {}
+        OPCode3C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x1:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+            }
+        }
+    };
+    class OPCode3D : public Instruction {
+      public:
+        OPCode3D()
+          : Instruction(-1, 0x3D, nullptr) {}
+        OPCode3D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3D, Maker) {}
+        OPCode3D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {}
+        OPCode3D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode3E : public Instruction {
+      public:
+        OPCode3E()
+          : Instruction(-1, 0x3E, nullptr) {}
+        OPCode3E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3E, Maker) {}
+        OPCode3E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {}
+        OPCode3E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode3F : public Instruction {
+      public:
+        OPCode3F()
+          : Instruction(-1, 0x3F, nullptr) {}
+        OPCode3F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3F, Maker) {}
+        OPCode3F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {}
+        OPCode3F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode40 : public Instruction {
+      public:
+        OPCode40()
+          : Instruction(-1, 0x40, nullptr) {}
+        OPCode40(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x40, Maker) {}
+        OPCode40(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {}
+        OPCode40(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 1
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            short control = ReadShortFromByteArray(0, control_short);
+            this->AddOperande(operande(addr, "short", control_short));                      // 3
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 5
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 9
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // D
+
+            if ((ushort)(control + 0x1feU) < 3) {
+
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 11 -> 15
+            }
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            if (control == -0x1fb) { // I'm not sure at all of this behavior, but at the same time I'm not even sure it
+                                     // happens anywhere (lazy)
+                while (content[addr] != '\0') {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                }
+            }
+        }
+    };
+    class OPCode41 : public Instruction {
+      public:
+        OPCode41()
+          : Instruction(-1, 0x41, nullptr) {}
+        OPCode41(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x41", 0x41, Maker) {}
+        OPCode41(int addr, Builder* Maker)
+          : Instruction(addr, "0x41", 0x41, Maker) {}
+        OPCode41(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x41", 0x41, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode42 : public Instruction {
+      public:
+        OPCode42()
+          : Instruction(-1, 0x42, nullptr) {}
+        OPCode42(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x42, Maker) {}
+        OPCode42(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {}
+        OPCode42(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));                        // 1
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 2
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 14
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 18 Not sure of the types here
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 1A
+        }
+    };
+    class OPCode43 : public Instruction {
+      public:
+        OPCode43()
+          : Instruction(-1, 0x43, nullptr) {}
+        OPCode43(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x43, Maker) {}
+        OPCode43(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {}
+        OPCode43(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0xFF:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xFE:
+                case 0x05:
+                case 0x69:
+                case 0x06:
+                case 0x6A:
+                case 0x0A:
+                case 0x0B:
+                case 0x0C:
+
+                    break;
+                default:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode44 : public Instruction {
+      public:
+        OPCode44()
+          : Instruction(-1, 0x44, nullptr) {}
+        OPCode44(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x44", 0x44, Maker) {}
+        OPCode44(int addr, Builder* Maker)
+          : Instruction(addr, "0x44", 0x44, Maker) {}
+        OPCode44(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x44", 0x44, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode45 : public Instruction {
+      public:
+        OPCode45()
+          : Instruction(-1, 0x45, nullptr) {}
+        OPCode45(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x45", 0x45, Maker) {}
+        OPCode45(int addr, Builder* Maker)
+          : Instruction(addr, "0x45", 0x45, Maker) {}
+        OPCode45(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x45", 0x45, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode46 : public Instruction {
+      public:
+        OPCode46()
+          : Instruction(-1, 0x46, nullptr) {}
+        OPCode46(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x46", 0x46, Maker) {}
+        OPCode46(int addr, Builder* Maker)
+          : Instruction(addr, "0x46", 0x46, Maker) {}
+        OPCode46(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x46", 0x46, Maker) {
+
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+
+    class OPCode47 : public Instruction {
+      public:
+        OPCode47()
+          : Instruction(-1, 0x47, nullptr) {}
+        OPCode47(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x47, Maker) {}
+        OPCode47(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {}
+        OPCode47(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode48 : public Instruction {
+      public:
+        OPCode48()
+          : Instruction(-1, 0x48, nullptr) {}
+        OPCode48(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x48, Maker) {}
+        OPCode48(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {}
+        OPCode48(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode49 : public Instruction {
+      public:
+        OPCode49()
+          : Instruction(-1, 0x49, nullptr) {}
+        OPCode49(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x49", 0x49, Maker) {}
+        OPCode49(int addr, Builder* Maker)
+          : Instruction(addr, "0x49", 0x49, Maker) {}
+        OPCode49(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x49", 0x49, Maker) {
+
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                case 4:
+                case 5:
+                case 6:
+                case 0x11:
+                case '\t':
+                case '\n':
+                case '\v':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case '\b':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case '\f':
+                case 0x17:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case '\r': // pas sûr
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x18)));
+                    break;
+                case '\x0e':
+                case '\x0f':
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode4A : public Instruction {
+      public:
+        OPCode4A()
+          : Instruction(-1, 0x4A, nullptr) {}
+        OPCode4A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4A", 0x4A, Maker) {}
+        OPCode4A(int addr, Builder* Maker)
+          : Instruction(addr, "0x4A", 0x4A, Maker) {}
+        OPCode4A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4A", 0x4A, Maker) {
+
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode4B : public Instruction {
+      public:
+        OPCode4B()
+          : Instruction(-1, 0x4B, nullptr) {}
+        OPCode4B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4B", 0x4B, Maker) {}
+        OPCode4B(int addr, Builder* Maker)
+          : Instruction(addr, "0x4B", 0x4B, Maker) {}
+        OPCode4B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4B", 0x4B, Maker) {
+
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            this->AddOperande(operande(addr, "short", control_short));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            /*switch (control_shrt)  {
+                case 0xfff8:
+
+                    break;
+                case 0xfff9:
+
+                    break;
+
+            }*/
+        }
+    };
+    class OPCode4C : public Instruction {
+      public:
+        OPCode4C()
+          : Instruction(-1, 0x4C, nullptr) {}
+        OPCode4C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4C", 0x4C, Maker) {}
+        OPCode4C(int addr, Builder* Maker)
+          : Instruction(addr, "0x4C", 0x4C, Maker) {}
+        OPCode4C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4C", 0x4C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode4D : public Instruction {
+      public:
+        OPCode4D()
+          : Instruction(-1, 0x4D, nullptr) {}
+        OPCode4D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4D", 0x4D, Maker) {}
+        OPCode4D(int addr, Builder* Maker)
+          : Instruction(addr, "0x4D", 0x4D, Maker) {}
+        OPCode4D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4D", 0x4D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode4E : public Instruction {
+      public:
+        OPCode4E()
+          : Instruction(-1, 0x4E, nullptr) {}
+        OPCode4E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4E", 0x4E, Maker) {}
+        OPCode4E(int addr, Builder* Maker)
+          : Instruction(addr, "0x4E", 0x4E, Maker) {}
+        OPCode4E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4E", 0x4E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode4F : public Instruction {
+      public:
+        OPCode4F()
+          : Instruction(-1, 0x4F, nullptr) {}
+        OPCode4F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4F", 0x4F, Maker) {}
+        OPCode4F(int addr, Builder* Maker)
+          : Instruction(addr, "0x4F", 0x4F, Maker) {}
+        OPCode4F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4F", 0x4F, Maker) {
+
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+
+                case 3:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 4:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+            }
+        }
+    };
+    class OPCode50 : public Instruction {
+      public:
+        OPCode50()
+          : Instruction(-1, 0x50, nullptr) {}
+        OPCode50(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x50", 0x50, Maker) {}
+        OPCode50(int addr, Builder* Maker)
+          : Instruction(addr, "0x50", 0x50, Maker) {}
+        OPCode50(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x50", 0x50, Maker) {
+            addr++;
+            fun_1403c90e0(addr, content, this, 1);
+        }
+    };
+    class OPCode51 : public Instruction {
+      public:
+        OPCode51()
+          : Instruction(-1, 0x51, nullptr) {}
+        OPCode51(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x51", 0x51, Maker) {}
+        OPCode51(int addr, Builder* Maker)
+          : Instruction(addr, "0x51", 0x51, Maker) {}
+        OPCode51(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x51", 0x51, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode52 : public Instruction {
+      public:
+        OPCode52()
+          : Instruction(-1, 0x52, nullptr) {}
+        OPCode52(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x52", 0x52, Maker) {}
+        OPCode52(int addr, Builder* Maker)
+          : Instruction(addr, "0x52", 0x52, Maker) {}
+        OPCode52(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x52", 0x52, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode53 : public Instruction {
+      public:
+        OPCode53()
+          : Instruction(-1, 0x53, nullptr) {}
+        OPCode53(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x53", 0x53, Maker) {}
+        OPCode53(int addr, Builder* Maker)
+          : Instruction(addr, "0x53", 0x53, Maker) {}
+        OPCode53(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x53", 0x53, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode54 : public Instruction {
+      public:
+        OPCode54()
+          : Instruction(-1, 0x54, nullptr) {}
+        OPCode54(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x54, Maker) {}
+        OPCode54(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x54, Maker) {}
+        OPCode54(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x54, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            QByteArray control_byte2;
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x1:
+                case 0x3:
+                case 0x8:
+                case 0x0:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x20 - 4)));
+                    break;
+                case 10:
+                case 0xE:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xB:
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x18:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xD:
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x14:
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x15:
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                case 0x17:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x30:
+                    fun_1403c90e0(addr, content, this, 1);
+                    break;
+                case 0x24:
+                case 0x22:
+
+                case 0x28:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x19:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x1C:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x21:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+
+                case 0x23:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x26:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+
+                case 0x29:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x2B:
+                    control_byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", control_byte2));
+                    if ((int)control_byte2[0] == 0) {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    }
+                    break;
+                case 0x2C:
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x31:
+                    control_byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", control_byte2));
+                    if ((int)control_byte2[0] == 0) {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    } else if ((int)control_byte2[0] == 1) {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    }
+                    break;
                 case 0x34:
 
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x35:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0x37:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x38:
 
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x39:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x3A:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //0
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //2
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//C
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//10
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1))); //0x14
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 2
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 0x14
 
                     break;
                 case 0x3B:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //0
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //2
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//8
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 2
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
                     break;
 
                 case 0x3C:
 
-                    this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0xA)));
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0xA)));
                     break;
                 case 0x3E:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x40:
                 case 0x4B:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x42:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x44:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x45:
                 case 0x46:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x47:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x48:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x49:
                 case 0x4A:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x4C:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x4D:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x4F:
                     control_byte2 = ReadSubByteArray(content, addr, 1);
-                    this->AddOperande(operande(addr,"byte", control_byte2)); //1
-                    switch((int)control_byte2[0]){
+                    this->AddOperande(operande(addr, "byte", control_byte2)); // 1
+                    switch ((int)control_byte2[0]) {
                         case 0:
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                             break;
                         case 1:
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                             break;
                         case 2:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                             break;
                         case 3:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                             break;
                         case 4:
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                             break;
                         case '\n':
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //3
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1))); //4
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //8
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //10
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 3
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 4
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 10
                             break;
                     }
                     break;
                 case 0x50:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x51:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    //this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    //this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    // this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    // this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
                     break;
                 case 0x52:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 case 0x53:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
-
-                }
-
-
+            }
         }
     };
-    class OPCode55 : public Instruction
-    {
-        public:
-        OPCode55():Instruction(-1,0x55,nullptr){}
-        OPCode55(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x55", 0x55,Maker){}
-        OPCode55(int addr, Builder *Maker):Instruction(addr,"0x55",0x55,Maker){}
-        OPCode55(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x55", 0x55,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+    class OPCode55 : public Instruction {
+      public:
+        OPCode55()
+          : Instruction(-1, 0x55, nullptr) {}
+        OPCode55(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x55", 0x55, Maker) {}
+        OPCode55(int addr, Builder* Maker)
+          : Instruction(addr, "0x55", 0x55, Maker) {}
+        OPCode55(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x55", 0x55, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    class OPCode56 : public Instruction
-    {
-        public:
-        OPCode56():Instruction(-1,0x56,nullptr){}
-        OPCode56(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x56", 0x56,Maker){}
-        OPCode56(int addr, Builder *Maker):Instruction(addr,"0x56",0x56,Maker){}
-        OPCode56(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x56", 0x56,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//10
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//14
+    class OPCode56 : public Instruction {
+      public:
+        OPCode56()
+          : Instruction(-1, 0x56, nullptr) {}
+        OPCode56(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x56", 0x56, Maker) {}
+        OPCode56(int addr, Builder* Maker)
+          : Instruction(addr, "0x56", 0x56, Maker) {}
+        OPCode56(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x56", 0x56, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 14
         }
     };
-    class OPCode57 : public Instruction
-    {
-        public:
-        OPCode57():Instruction(-1,0x57,nullptr){}
-        OPCode57(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x57", 0x57,Maker){}
-        OPCode57(int addr, Builder *Maker):Instruction(addr,"0x57",0x57,Maker){}
-        OPCode57(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x57", 0x57,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+    class OPCode57 : public Instruction {
+      public:
+        OPCode57()
+          : Instruction(-1, 0x57, nullptr) {}
+        OPCode57(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x57", 0x57, Maker) {}
+        OPCode57(int addr, Builder* Maker)
+          : Instruction(addr, "0x57", 0x57, Maker) {}
+        OPCode57(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x57", 0x57, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCode58 : public Instruction
-    {
-        public:
-        OPCode58():Instruction(-1,0x58,nullptr){}
-        OPCode58(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x58", 0x58,Maker){}
-        OPCode58(int addr, Builder *Maker):Instruction(addr,"0x58",0x58,Maker){}
-        OPCode58(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x58", 0x58,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
+    class OPCode58 : public Instruction {
+      public:
+        OPCode58()
+          : Instruction(-1, 0x58, nullptr) {}
+        OPCode58(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x58", 0x58, Maker) {}
+        OPCode58(int addr, Builder* Maker)
+          : Instruction(addr, "0x58", 0x58, Maker) {}
+        OPCode58(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x58", 0x58, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
     };
-    class OPCode5A : public Instruction
-    {
-        public:
-        OPCode5A():Instruction(-1,0x5A,nullptr){}
-        OPCode5A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x5A", 0x5A,Maker){}
-        OPCode5A(int addr, Builder *Maker):Instruction(addr,"0x5A",0x5A,Maker){}
-        OPCode5A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x5A", 0x5A,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCode5A : public Instruction {
+      public:
+        OPCode5A()
+          : Instruction(-1, 0x5A, nullptr) {}
+        OPCode5A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x5A", 0x5A, Maker) {}
+        OPCode5A(int addr, Builder* Maker)
+          : Instruction(addr, "0x5A", 0x5A, Maker) {}
+        OPCode5A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x5A", 0x5A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode5B : public Instruction
-    {
-        public:
-        OPCode5B():Instruction(-1,0x5B,nullptr){}
-        OPCode5B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x5B", 0x5B,Maker){}
-        OPCode5B(int addr, Builder *Maker):Instruction(addr,"0x5B",0x5B,Maker){}
-        OPCode5B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x5B", 0x5B,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                sub05(addr, content, this);
+    class OPCode5B : public Instruction {
+      public:
+        OPCode5B()
+          : Instruction(-1, 0x5B, nullptr) {}
+        OPCode5B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x5B", 0x5B, Maker) {}
+        OPCode5B(int addr, Builder* Maker)
+          : Instruction(addr, "0x5B", 0x5B, Maker) {}
+        OPCode5B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x5B", 0x5B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            sub05(addr, content, this);
         }
     };
-    class OPCode5C : public Instruction
-    {
-        public:
-        OPCode5C():Instruction(-1,0x5C,nullptr){}
-        OPCode5C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5C,Maker){}
-        OPCode5C(int addr, Builder *Maker):Instruction(addr,"???",0x5C,Maker){}
-        OPCode5C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+    class OPCode5C : public Instruction {
+      public:
+        OPCode5C()
+          : Instruction(-1, 0x5C, nullptr) {}
+        OPCode5C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5C, Maker) {}
+        OPCode5C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5C, Maker) {}
+        OPCode5C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    class OPCode5D : public Instruction
-    {
-        public:
-        OPCode5D():Instruction(-1,0x5D,nullptr){}
-        OPCode5D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5D,Maker){}
-        OPCode5D(int addr, Builder *Maker):Instruction(addr,"???",0x5D,Maker){}
-        OPCode5D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+    class OPCode5D : public Instruction {
+      public:
+        OPCode5D()
+          : Instruction(-1, 0x5D, nullptr) {}
+        OPCode5D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5D, Maker) {}
+        OPCode5D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {}
+        OPCode5D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCode5E : public Instruction
-    {
-        public:
-        OPCode5E():Instruction(-1,0x5E,nullptr){}
-        OPCode5E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5E,Maker){}
-        OPCode5E(int addr, Builder *Maker):Instruction(addr,"???",0x5E,Maker){}
-        OPCode5E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5E,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 1:
-                        break;
-                }
-
+    class OPCode5E : public Instruction {
+      public:
+        OPCode5E()
+          : Instruction(-1, 0x5E, nullptr) {}
+        OPCode5E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5E, Maker) {}
+        OPCode5E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {}
+        OPCode5E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 1:
+                    break;
+            }
         }
     };
-    class OPCode60 : public Instruction
-    {
-        public:
-        OPCode60():Instruction(-1,0x60,nullptr){}
-        OPCode60(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x60,Maker){}
-        OPCode60(int addr, Builder *Maker):Instruction(addr,"???",0x60,Maker){}
-        OPCode60(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x60,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+    class OPCode60 : public Instruction {
+      public:
+        OPCode60()
+          : Instruction(-1, 0x60, nullptr) {}
+        OPCode60(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x60, Maker) {}
+        OPCode60(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {}
+        OPCode60(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    class OPCode61 : public Instruction
-    {
-        public:
-        OPCode61():Instruction(-1,0x61,nullptr){}
-        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x61,Maker){}
-        OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){}
-        OPCode61(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//10
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//14
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//18
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//1C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCode61 : public Instruction {
+      public:
+        OPCode61()
+          : Instruction(-1, 0x61, nullptr) {}
+        OPCode61(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x61, Maker) {}
+        OPCode61(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {}
+        OPCode61(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 14
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 18
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 1C
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode62 : public Instruction
-    {
-        public:
-        OPCode62():Instruction(-1,0x62,nullptr){}
-        OPCode62(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x62,Maker){}
-        OPCode62(int addr, Builder *Maker):Instruction(addr,"???",0x62,Maker){}
-        OPCode62(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x62,Maker){
-                addr++;
+    class OPCode62 : public Instruction {
+      public:
+        OPCode62()
+          : Instruction(-1, 0x62, nullptr) {}
+        OPCode62(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x62, Maker) {}
+        OPCode62(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x62, Maker) {}
+        OPCode62(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x62, Maker) {
+            addr++;
         }
     };
-    class OPCode63 : public Instruction
-    {
-        public:
-        OPCode63():Instruction(-1,0x63,nullptr){}
-        OPCode63(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x63,Maker){}
-        OPCode63(int addr, Builder *Maker):Instruction(addr,"???",0x63,Maker){}
-        OPCode63(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x63,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                this->AddOperande(operande(addr,"short", control_short));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
+    class OPCode63 : public Instruction {
+      public:
+        OPCode63()
+          : Instruction(-1, 0x63, nullptr) {}
+        OPCode63(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x63, Maker) {}
+        OPCode63(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x63, Maker) {}
+        OPCode63(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x63, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            this->AddOperande(operande(addr, "short", control_short));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
     };
-    class OPCode64 : public Instruction
-    {
-        public:
-        OPCode64():Instruction(-1,0x64,nullptr){}
-        OPCode64(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x64,Maker){}
-        OPCode64(int addr, Builder *Maker):Instruction(addr,"???",0x64,Maker){}
-        OPCode64(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x64,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                }
+    class OPCode64 : public Instruction {
+      public:
+        OPCode64()
+          : Instruction(-1, 0x64, nullptr) {}
+        OPCode64(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x64, Maker) {}
+        OPCode64(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {}
+        OPCode64(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
     };
-    class OPCode65 : public Instruction
-    {
-        public:
-        OPCode65():Instruction(-1,0x65,nullptr){}
-        OPCode65(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x65,Maker){}
-        OPCode65(int addr, Builder *Maker):Instruction(addr,"???",0x65,Maker){}
-        OPCode65(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x65,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-
-                }
+    class OPCode65 : public Instruction {
+      public:
+        OPCode65()
+          : Instruction(-1, 0x65, nullptr) {}
+        OPCode65(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x65, Maker) {}
+        OPCode65(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {}
+        OPCode65(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
     };
-    class OPCode66 : public Instruction
-    {
-        public:
-        OPCode66():Instruction(-1,0x66,nullptr){}
-        OPCode66(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x66,Maker){}
-        OPCode66(int addr, Builder *Maker):Instruction(addr,"???",0x66,Maker){}
-        OPCode66(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x66,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-                    case 4:
-                    case 8:
-                    case 6:
-                    case 9:
-                    case 10:
-                    case 0xC:
-                    case 0xE:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-
-                }
+    class OPCode66 : public Instruction {
+      public:
+        OPCode66()
+          : Instruction(-1, 0x66, nullptr) {}
+        OPCode66(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x66, Maker) {}
+        OPCode66(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {}
+        OPCode66(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                case 4:
+                case 8:
+                case 6:
+                case 9:
+                case 10:
+                case 0xC:
+                case 0xE:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
     };
-    class OPCode67 : public Instruction
-    {
-        public:
-        OPCode67():Instruction(-1,0x67,nullptr){}
-        OPCode67(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x67,Maker){}
-        OPCode67(int addr, Builder *Maker):Instruction(addr,"???",0x67,Maker){}
-        OPCode67(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x67,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
+    class OPCode67 : public Instruction {
+      public:
+        OPCode67()
+          : Instruction(-1, 0x67, nullptr) {}
+        OPCode67(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x67, Maker) {}
+        OPCode67(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {}
+        OPCode67(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
     };
-    class OPCode68 : public Instruction
-    {
-        public:
-        OPCode68():Instruction(-1,0x68,nullptr){}
-        OPCode68(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x68,Maker){}
-        OPCode68(int addr, Builder *Maker):Instruction(addr,"???",0x68,Maker){}
-        OPCode68(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x68,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                switch((unsigned char)control_byte[0]){
+    class OPCode68 : public Instruction {
+      public:
+        OPCode68()
+          : Instruction(-1, 0x68, nullptr) {}
+        OPCode68(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x68, Maker) {}
+        OPCode68(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {}
+        OPCode68(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
                 case 1:
                 case '\v':
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 2:
                 case 3:
                 case 4:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case '\a':
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case '\b':
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case '\x18':
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case '\x1E':
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
-                }
+            }
         }
     };
-    class OPCode69 : public Instruction
-    {
-        public:
-        OPCode69():Instruction(-1,0x69,nullptr){}
-        OPCode69(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x69,Maker){}
-        OPCode69(int addr, Builder *Maker):Instruction(addr,"???",0x69,Maker){}
-        OPCode69(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x69,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 1:
-                    case 4:
-                    case 7:
-                    case 8:
-                    case 9:
-                    case 0xB:
-                    case 0x13:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 2:
-                    case 3:
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 10:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0xC:
-                    case 0xD:
-                    case 0x12:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                }
-        }
-    };
-    class OPCode6A : public Instruction
-    {
-        public:
-        OPCode6A():Instruction(-1,0x6A,nullptr){}
-        OPCode6A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6A,Maker){}
-        OPCode6A(int addr, Builder *Maker):Instruction(addr,"???",0x6A,Maker){}
-        OPCode6A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6A,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1))); //not sure?
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    case 4:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 5:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-
-                }
-        }
-    };
-    class OPCode6B : public Instruction
-    {
-        public:
-        OPCode6B():Instruction(-1,0x6B,nullptr){}
-        OPCode6B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x6B", 0x6B,Maker){}
-        OPCode6B(int addr, Builder *Maker):Instruction(addr,"0x6B",0x6B,Maker){}
-        OPCode6B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x6B", 0x6B,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCode6C : public Instruction
-    {
-        public:
-        OPCode6C():Instruction(-1,0x6C,nullptr){}
-        OPCode6C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6C,Maker){}
-        OPCode6C(int addr, Builder *Maker):Instruction(addr,"???",0x6C,Maker){}
-        OPCode6C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode6E : public Instruction
-    {
-        public:
-        OPCode6E():Instruction(-1,0x6E,nullptr){}
-        OPCode6E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6E,Maker){}
-        OPCode6E(int addr, Builder *Maker):Instruction(addr,"???",0x6E,Maker){}
-        OPCode6E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-        }
-    };
-    class OPCode6F : public Instruction
-    {
-        public:
-        OPCode6F():Instruction(-1,0x6F,nullptr){}
-        OPCode6F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x6F", 0x6F,Maker){}
-        OPCode6F(int addr, Builder *Maker):Instruction(addr,"0x6F",0x6F,Maker){}
-        OPCode6F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x6F", 0x6F,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCode70 : public Instruction
-    {
-        public:
-        OPCode70():Instruction(-1,0x70,nullptr){}
-        OPCode70(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x70,Maker){}
-        OPCode70(int addr, Builder *Maker):Instruction(addr,"???",0x70,Maker){}
-        OPCode70(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x70,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 1:
-                    case 7:
-                    case 0xB:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 4:
-                    case 9:
-                    case 0xC:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 3:
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 8:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 10:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                }
-        }
-    };
-    class OPCode72 : public Instruction // not sure at all
-    {
-        public:
-        OPCode72():Instruction(-1,0x72,nullptr){}
-        OPCode72(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x72,Maker){}
-        OPCode72(int addr, Builder *Maker):Instruction(addr,"???",0x72,Maker){}
-        OPCode72(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x72,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", control_short));
-                ushort control_shrt = ReadShortFromByteArray(0, control_short);
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                if ((unsigned char) (control_byte[0] - 1U) < 2) {
-                  this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                  this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                }
-                else {
-                  if ((unsigned char)(control_byte[0] - 3U) < 2) {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                  }
-                }
-                if (control_shrt != 0xFFFF){
-                    if (control_shrt<0x100){
-                        switch((unsigned char) control_byte[0]){
-                        case '\x06':
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                            break;
-
-                        }
-                    }
-                }
-        }
-    };
-    class OPCode73 : public Instruction
-    {
-        public:
-        OPCode73():Instruction(-1,0x73,nullptr){}
-        OPCode73(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x73,Maker){}
-        OPCode73(int addr, Builder *Maker):Instruction(addr,"???",0x73,Maker){}
-        OPCode73(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x73,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 1:
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-
-                    default:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                }
-        }
-    };
-    class OPCode74 : public Instruction
-    {
-        public:
-        OPCode74():Instruction(-1,0x74,nullptr){}
-        OPCode74(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x74,Maker){}
-        OPCode74(int addr, Builder *Maker):Instruction(addr,"???",0x74,Maker){}
-        OPCode74(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x74,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 0x14:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 3:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                }
-        }
-    };
-    class OPCode75 : public Instruction
-    {
-        public:
-        OPCode75():Instruction(-1,0x75,nullptr){}
-        OPCode75(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x75,Maker){}
-        OPCode75(int addr, Builder *Maker):Instruction(addr,"???",0x75,Maker){}
-        OPCode75(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x75,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", control_byte2));
-                if((unsigned char)control_byte2[0]<4){
-                    switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                    case 4:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 7:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
-               }
-        }
-    };
-    class OPCode76 : public Instruction
-    {
-        public:
-        OPCode76():Instruction(-1,0x76,nullptr){}
-        OPCode76(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x76,Maker){}
-        OPCode76(int addr, Builder *Maker):Instruction(addr,"???",0x76,Maker){}
-        OPCode76(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x76,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class OPCode77 : public Instruction
-    {
-        public:
-        OPCode77():Instruction(-1,0x77,nullptr){}
-        OPCode77(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x77,Maker){}
-        OPCode77(int addr, Builder *Maker):Instruction(addr,"???",0x77,Maker){}
-        OPCode77(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x77,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode78 : public Instruction
-    {
-        public:
-        OPCode78():Instruction(-1,0x78,nullptr){}
-        OPCode78(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x78,Maker){}
-        OPCode78(int addr, Builder *Maker):Instruction(addr,"???",0x78,Maker){}
-        OPCode78(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x78,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-        }
-    };
-    class OPCode79 : public Instruction
-    {
-        public:
-        OPCode79():Instruction(-1,0x79,nullptr){}
-        OPCode79(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x79,Maker){}
-        OPCode79(int addr, Builder *Maker):Instruction(addr,"???",0x79,Maker){}
-        OPCode79(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x79,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch((unsigned char)control_byte[0]){
-                    case 0x5:
-                        this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 6))); //??
-                        break;
-                    case 0x7:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-
-        }
-    };
-    class OPCode7A : public Instruction
-    {
-        public:
-        OPCode7A():Instruction(-1,0x7A,nullptr){}
-        OPCode7A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7A,Maker){}
-        OPCode7A(int addr, Builder *Maker):Instruction(addr,"???",0x7A,Maker){}
-        OPCode7A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 0:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 1:
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                }
-        }
-    };
-    class OPCode7B : public Instruction
-    {
-        public:
-        OPCode7B():Instruction(-1,0x7B,nullptr){}
-        OPCode7B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7B,Maker){}
-        OPCode7B(int addr, Builder *Maker):Instruction(addr,"???",0x7B,Maker){}
-        OPCode7B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7B,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 1:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
-        }
-    };
-    class OPCode7C : public Instruction
-    {
-        public:
-        OPCode7C():Instruction(-1,0x7C,nullptr){}
-        OPCode7C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7C,Maker){}
-        OPCode7C(int addr, Builder *Maker):Instruction(addr,"???",0x7C,Maker){}
-        OPCode7C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7C,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 0:
-
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//3
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//5
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//7
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//9
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//B
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//D
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//f
-                        break;
-                }
-        }
-    };
-    class OPCode7D : public Instruction
-    {
-        public:
-        OPCode7D():Instruction(-1,0x7D,nullptr){}
-        OPCode7D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7D,Maker){}
-        OPCode7D(int addr, Builder *Maker):Instruction(addr,"???",0x7D,Maker){}
-        OPCode7D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode7E : public Instruction
-    {
-        public:
-        OPCode7E():Instruction(-1,0x7E,nullptr){}
-        OPCode7E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7E,Maker){}
-        OPCode7E(int addr, Builder *Maker):Instruction(addr,"???",0x7E,Maker){}
-        OPCode7E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7E,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-
-                        break;
-                    case 2:
-                    case 6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                    case 4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                    case 5:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-
-                }
-        }
-    };
-    class OPCode80 : public Instruction
-    {
-        public:
-        OPCode80():Instruction(-1,0x80,nullptr){}
-        OPCode80(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x80,Maker){}
-        OPCode80(int addr, Builder *Maker):Instruction(addr,"???",0x80,Maker){}
-        OPCode80(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x80,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class OPCode82 : public Instruction
-    {
-        public:
-        OPCode82():Instruction(-1,0x82,nullptr){}
-        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x82,Maker){}
-        OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){}
-        OPCode82(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode83 : public Instruction
-    {
-        public:
-        OPCode83():Instruction(-1,0x83,nullptr){}
-        OPCode83(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x83,Maker){}
-        OPCode83(int addr, Builder *Maker):Instruction(addr,"???",0x83,Maker){}
-        OPCode83(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x83,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode84 : public Instruction
-    {
-        public:
-        OPCode84():Instruction(-1,0x84,nullptr){}
-        OPCode84(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x84,Maker){}
-        OPCode84(int addr, Builder *Maker):Instruction(addr,"???",0x84,Maker){}
-        OPCode84(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 3:{ //not sure
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", control_byte2));
-                    break;}
-                    default:{
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    }
-                }
-        }
-    };
-    class OPCode86 : public Instruction
-    {
-        public:
-        OPCode86():Instruction(-1,0x86,nullptr){}
-        OPCode86(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x86", 0x86,Maker){}
-        OPCode86(int addr, Builder *Maker):Instruction(addr,"0x86",0x86,Maker){}
-        OPCode86(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x86", 0x86,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//2
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//4
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//6
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//8
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//c
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-        }
-    };
-    class OPCode87 : public Instruction
-    {
-        public:
-        OPCode87():Instruction(-1,0x87,nullptr){}
-        OPCode87(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x87", 0x87,Maker){}
-        OPCode87(int addr, Builder *Maker):Instruction(addr,"0x87",0x87,Maker){}
-        OPCode87(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x87", 0x87, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-        }
-    };
-    class OPCode88 : public Instruction
-    {
-        public:
-        OPCode88():Instruction(-1,0x88,nullptr){}
-        OPCode88(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x88", 0x88,Maker){}
-        OPCode88(int addr, Builder *Maker):Instruction(addr,"0x88",0x88,Maker){}
-        OPCode88(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x88", 0x88, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-        }
-    };
-    class OPCode89 : public Instruction
-    {
-        public:
-        OPCode89():Instruction(-1,0x89,nullptr){}
-        OPCode89(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x89", 0x89,Maker){}
-        OPCode89(int addr, Builder *Maker):Instruction(addr,"0x89",0x89,Maker){}
-        OPCode89(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x89", 0x89, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-        }
-    };
-    class OPCode8A : public Instruction
-    {
-        public:
-        OPCode8A():Instruction(-1,0x8A,nullptr){}
-        OPCode8A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8A", 0x8A,Maker){}
-        OPCode8A(int addr, Builder *Maker):Instruction(addr,"0x8A",0x8A,Maker){}
-        OPCode8A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8A", 0x8A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode69 : public Instruction {
+      public:
+        OPCode69()
+          : Instruction(-1, 0x69, nullptr) {}
+        OPCode69(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x69, Maker) {}
+        OPCode69(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {}
+        OPCode69(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                case 1: //NOT SURE!
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 1:
+                case 4:
+                case 7:
+                case 8:
+                case 9:
+                case 0xB:
+                case 0x13:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
-                case 2: //NOT SURE!
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                    break;
+                case 2:
                 case 3:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                case 0xFE:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                case 0xFF:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                default:
-                    if (((unsigned char)control_byte[0] - 0x32U) < 2){
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    }
-                    break;
-                }
-        }
-    };
-    class OPCode8B : public Instruction
-    {
-        public:
-        OPCode8B():Instruction(-1,0x8B,nullptr){}
-        OPCode8B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8B", 0x8B,Maker){}
-        OPCode8B(int addr, Builder *Maker):Instruction(addr,"0x8B",0x8B,Maker){}
-        OPCode8B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8B", 0x8B,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-        }
-    };
-    class OPCode8C : public Instruction
-    {
-        public:
-        OPCode8C():Instruction(-1,0x8C,nullptr){}
-        OPCode8C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8C", 0x8C,Maker){}
-        OPCode8C(int addr, Builder *Maker):Instruction(addr,"0x8C",0x8C,Maker){}
-        OPCode8C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8C", 0x8C,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                case 0:
                 case 5:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 10:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xC:
+                case 0xD:
+                case 0x12:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+    class OPCode6A : public Instruction {
+      public:
+        OPCode6A()
+          : Instruction(-1, 0x6A, nullptr) {}
+        OPCode6A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6A, Maker) {}
+        OPCode6A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {}
+        OPCode6A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // not sure?
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
-                case 3:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 2:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
                     break;
                 case 4:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 5:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+            }
+        }
+    };
+    class OPCode6B : public Instruction {
+      public:
+        OPCode6B()
+          : Instruction(-1, 0x6B, nullptr) {}
+        OPCode6B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x6B", 0x6B, Maker) {}
+        OPCode6B(int addr, Builder* Maker)
+          : Instruction(addr, "0x6B", 0x6B, Maker) {}
+        OPCode6B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x6B", 0x6B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode6C : public Instruction {
+      public:
+        OPCode6C()
+          : Instruction(-1, 0x6C, nullptr) {}
+        OPCode6C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6C, Maker) {}
+        OPCode6C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {}
+        OPCode6C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode6E : public Instruction {
+      public:
+        OPCode6E()
+          : Instruction(-1, 0x6E, nullptr) {}
+        OPCode6E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6E, Maker) {}
+        OPCode6E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {}
+        OPCode6E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode6F : public Instruction {
+      public:
+        OPCode6F()
+          : Instruction(-1, 0x6F, nullptr) {}
+        OPCode6F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x6F", 0x6F, Maker) {}
+        OPCode6F(int addr, Builder* Maker)
+          : Instruction(addr, "0x6F", 0x6F, Maker) {}
+        OPCode6F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x6F", 0x6F, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode70 : public Instruction {
+      public:
+        OPCode70()
+          : Instruction(-1, 0x70, nullptr) {}
+        OPCode70(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x70, Maker) {}
+        OPCode70(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {}
+        OPCode70(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 1:
+                case 7:
+                case 0xB:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 4:
+                case 9:
+                case 0xC:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 3:
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 8:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 10:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+    class OPCode72
+      : public Instruction // not sure at all
+    {
+      public:
+        OPCode72()
+          : Instruction(-1, 0x72, nullptr) {}
+        OPCode72(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x72, Maker) {}
+        OPCode72(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {}
+        OPCode72(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            this->AddOperande(operande(addr, "short", control_short));
+            ushort control_shrt = ReadShortFromByteArray(0, control_short);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            if ((unsigned char)(control_byte[0] - 1U) < 2) {
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            } else {
+                if ((unsigned char)(control_byte[0] - 3U) < 2) {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                }
+            }
+            if (control_shrt != 0xFFFF) {
+                if (control_shrt < 0x100) {
+                    switch ((unsigned char)control_byte[0]) {
+                        case '\x06':
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            break;
+                    }
+                }
+            }
+        }
+    };
+    class OPCode73 : public Instruction {
+      public:
+        OPCode73()
+          : Instruction(-1, 0x73, nullptr) {}
+        OPCode73(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x73, Maker) {}
+        OPCode73(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {}
+        OPCode73(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 1:
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+
+                default:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+            }
+        }
+    };
+    class OPCode74 : public Instruction {
+      public:
+        OPCode74()
+          : Instruction(-1, 0x74, nullptr) {}
+        OPCode74(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x74, Maker) {}
+        OPCode74(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {}
+        OPCode74(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 0x14:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+            }
+        }
+    };
+    class OPCode75 : public Instruction {
+      public:
+        OPCode75()
+          : Instruction(-1, 0x75, nullptr) {}
+        OPCode75(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x75, Maker) {}
+        OPCode75(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x75, Maker) {}
+        OPCode75(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x75, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte2));
+            if ((unsigned char)control_byte2[0] < 4) {
+                switch ((unsigned char)control_byte[0]) {
+                    case 0:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 1:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 2:
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                        break;
+                    case 4:
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                        break;
+                    case 5:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 6:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    case 7:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                }
+            }
+        }
+    };
+    class OPCode76 : public Instruction {
+      public:
+        OPCode76()
+          : Instruction(-1, 0x76, nullptr) {}
+        OPCode76(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x76, Maker) {}
+        OPCode76(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x76, Maker) {}
+        OPCode76(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x76, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode77 : public Instruction {
+      public:
+        OPCode77()
+          : Instruction(-1, 0x77, nullptr) {}
+        OPCode77(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x77, Maker) {}
+        OPCode77(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x77, Maker) {}
+        OPCode77(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x77, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode78 : public Instruction {
+      public:
+        OPCode78()
+          : Instruction(-1, 0x78, nullptr) {}
+        OPCode78(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x78, Maker) {}
+        OPCode78(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {}
+        OPCode78(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    class OPCode79 : public Instruction {
+      public:
+        OPCode79()
+          : Instruction(-1, 0x79, nullptr) {}
+        OPCode79(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x79, Maker) {}
+        OPCode79(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {}
+        OPCode79(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x5:
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 6))); //??
+                    break;
+                case 0x7:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode7A : public Instruction {
+      public:
+        OPCode7A()
+          : Instruction(-1, 0x7A, nullptr) {}
+        OPCode7A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7A, Maker) {}
+        OPCode7A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {}
+        OPCode7A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 0:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 1:
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+            }
+        }
+    };
+    class OPCode7B : public Instruction {
+      public:
+        OPCode7B()
+          : Instruction(-1, 0x7B, nullptr) {}
+        OPCode7B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7B, Maker) {}
+        OPCode7B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {}
+        OPCode7B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 1:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode7C : public Instruction {
+      public:
+        OPCode7C()
+          : Instruction(-1, 0x7C, nullptr) {}
+        OPCode7C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7C, Maker) {}
+        OPCode7C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7C, Maker) {}
+        OPCode7C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 0:
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 3
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 5
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 7
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 9
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // B
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // D
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // f
+                    break;
+            }
+        }
+    };
+    class OPCode7D : public Instruction {
+      public:
+        OPCode7D()
+          : Instruction(-1, 0x7D, nullptr) {}
+        OPCode7D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7D, Maker) {}
+        OPCode7D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7D, Maker) {}
+        OPCode7D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode7E : public Instruction {
+      public:
+        OPCode7E()
+          : Instruction(-1, 0x7E, nullptr) {}
+        OPCode7E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7E, Maker) {}
+        OPCode7E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {}
+        OPCode7E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+
+                    break;
+                case 2:
+                case 6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 4:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 5:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+    class OPCode80 : public Instruction {
+      public:
+        OPCode80()
+          : Instruction(-1, 0x80, nullptr) {}
+        OPCode80(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x80, Maker) {}
+        OPCode80(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {}
+        OPCode80(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode82 : public Instruction {
+      public:
+        OPCode82()
+          : Instruction(-1, 0x82, nullptr) {}
+        OPCode82(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x82, Maker) {}
+        OPCode82(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {}
+        OPCode82(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode83 : public Instruction {
+      public:
+        OPCode83()
+          : Instruction(-1, 0x83, nullptr) {}
+        OPCode83(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x83, Maker) {}
+        OPCode83(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {}
+        OPCode83(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode84 : public Instruction {
+      public:
+        OPCode84()
+          : Instruction(-1, 0x84, nullptr) {}
+        OPCode84(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x84, Maker) {}
+        OPCode84(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {}
+        OPCode84(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 3: { // not sure
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", control_byte2));
                     break;
                 }
-        }
-    };
-    class OPCode8D : public Instruction
-    {
-        public:
-        OPCode8D():Instruction(-1,0x8D,nullptr){}
-        OPCode8D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8D", 0x8D,Maker){}
-        OPCode8D(int addr, Builder *Maker):Instruction(addr,"0x8D",0x8D,Maker){}
-        OPCode8D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8D", 0x8D, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCode8E : public Instruction
-    {
-        public:
-        OPCode8E():Instruction(-1,0x8E,nullptr){}
-        OPCode8E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8E", 0x8E,Maker){}
-        OPCode8E(int addr, Builder *Maker):Instruction(addr,"0x8E",0x8E,Maker){}
-        OPCode8E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8E", 0x8E, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-        }
-    };
-    class OPCode8F : public Instruction
-    {
-        public:
-        OPCode8F():Instruction(-1,0x8F,nullptr){}
-        OPCode8F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8F", 0x8F,Maker){}
-        OPCode8F(int addr, Builder *Maker):Instruction(addr,"0x8F",0x8F,Maker){}
-        OPCode8F(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0x8F", 0x8F, Maker){
-                addr++;
-        }
-    };
-    class OPCode98 : public Instruction
-    {
-        public:
-        OPCode98():Instruction(-1,0x98,nullptr){}
-        OPCode98(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x98", 0x98,Maker){}
-        OPCode98(int addr, Builder *Maker):Instruction(addr,"0x98",0x98,Maker){}
-        OPCode98(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x98", 0x98,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                this->AddOperande(operande(addr,"short", control_short));
-                short control_shrt = ReadShortFromByteArray(0, control_short);
-                switch(control_shrt){
-                 case 1:
-                 case 2:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                 case 3:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    break;
-                 case 0x3E8:
-                 case 0x3E9:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    break;
+                default: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                 }
-
-
-
+            }
         }
     };
-    class OPCode90 : public Instruction
-    {
-        public:
-        OPCode90():Instruction(-1,0x90,nullptr){}
-        OPCode90(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x90", 0x90,Maker){}
-        OPCode90(int addr, Builder *Maker):Instruction(addr,"0x90",0x90,Maker){}
-        OPCode90(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x90", 0x90,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+    class OPCode86 : public Instruction {
+      public:
+        OPCode86()
+          : Instruction(-1, 0x86, nullptr) {}
+        OPCode86(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x86", 0x86, Maker) {}
+        OPCode86(int addr, Builder* Maker)
+          : Instruction(addr, "0x86", 0x86, Maker) {}
+        OPCode86(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x86", 0x86, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 2
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 4
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 6
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 8
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // A
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // c
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    class OPCode91 : public Instruction
-    {
-        public:
-        OPCode91():Instruction(-1,0x91,nullptr){}
-        OPCode91(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x91", 0x91,Maker){}
-        OPCode91(int addr, Builder *Maker):Instruction(addr,"0x91",0x91,Maker){}
-        OPCode91(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x91", 0x91, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode87 : public Instruction {
+      public:
+        OPCode87()
+          : Instruction(-1, 0x87, nullptr) {}
+        OPCode87(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x87", 0x87, Maker) {}
+        OPCode87(int addr, Builder* Maker)
+          : Instruction(addr, "0x87", 0x87, Maker) {}
+        OPCode87(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x87", 0x87, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode88 : public Instruction {
+      public:
+        OPCode88()
+          : Instruction(-1, 0x88, nullptr) {}
+        OPCode88(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x88", 0x88, Maker) {}
+        OPCode88(int addr, Builder* Maker)
+          : Instruction(addr, "0x88", 0x88, Maker) {}
+        OPCode88(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x88", 0x88, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode89 : public Instruction {
+      public:
+        OPCode89()
+          : Instruction(-1, 0x89, nullptr) {}
+        OPCode89(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x89", 0x89, Maker) {}
+        OPCode89(int addr, Builder* Maker)
+          : Instruction(addr, "0x89", 0x89, Maker) {}
+        OPCode89(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x89", 0x89, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode8A : public Instruction {
+      public:
+        OPCode8A()
+          : Instruction(-1, 0x8A, nullptr) {}
+        OPCode8A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8A", 0x8A, Maker) {}
+        OPCode8A(int addr, Builder* Maker)
+          : Instruction(addr, "0x8A", 0x8A, Maker) {}
+        OPCode8A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8A", 0x8A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 1: // NOT SURE!
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 2: // NOT SURE!
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0xFE:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0xFF:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                default:
+                    if (((unsigned char)control_byte[0] - 0x32U) < 2) {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    }
+                    break;
+            }
+        }
+    };
+    class OPCode8B : public Instruction {
+      public:
+        OPCode8B()
+          : Instruction(-1, 0x8B, nullptr) {}
+        OPCode8B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8B", 0x8B, Maker) {}
+        OPCode8B(int addr, Builder* Maker)
+          : Instruction(addr, "0x8B", 0x8B, Maker) {}
+        OPCode8B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8B", 0x8B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode8C : public Instruction {
+      public:
+        OPCode8C()
+          : Instruction(-1, 0x8C, nullptr) {}
+        OPCode8C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8C", 0x8C, Maker) {}
+        OPCode8C(int addr, Builder* Maker)
+          : Instruction(addr, "0x8C", 0x8C, Maker) {}
+        OPCode8C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8C", 0x8C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 3:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 4:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+    class OPCode8D : public Instruction {
+      public:
+        OPCode8D()
+          : Instruction(-1, 0x8D, nullptr) {}
+        OPCode8D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8D", 0x8D, Maker) {}
+        OPCode8D(int addr, Builder* Maker)
+          : Instruction(addr, "0x8D", 0x8D, Maker) {}
+        OPCode8D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8D", 0x8D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode8E : public Instruction {
+      public:
+        OPCode8E()
+          : Instruction(-1, 0x8E, nullptr) {}
+        OPCode8E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8E", 0x8E, Maker) {}
+        OPCode8E(int addr, Builder* Maker)
+          : Instruction(addr, "0x8E", 0x8E, Maker) {}
+        OPCode8E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8E", 0x8E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode8F : public Instruction {
+      public:
+        OPCode8F()
+          : Instruction(-1, 0x8F, nullptr) {}
+        OPCode8F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8F", 0x8F, Maker) {}
+        OPCode8F(int addr, Builder* Maker)
+          : Instruction(addr, "0x8F", 0x8F, Maker) {}
+        OPCode8F(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8F", 0x8F, Maker) {
+            addr++;
+        }
+    };
+    class OPCode98 : public Instruction {
+      public:
+        OPCode98()
+          : Instruction(-1, 0x98, nullptr) {}
+        OPCode98(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x98", 0x98, Maker) {}
+        OPCode98(int addr, Builder* Maker)
+          : Instruction(addr, "0x98", 0x98, Maker) {}
+        OPCode98(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x98", 0x98, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            this->AddOperande(operande(addr, "short", control_short));
+            short control_shrt = ReadShortFromByteArray(0, control_short);
+            switch (control_shrt) {
+                case 1:
+                case 2:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x3E8:
+                case 0x3E9:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode90 : public Instruction {
+      public:
+        OPCode90()
+          : Instruction(-1, 0x90, nullptr) {}
+        OPCode90(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x90", 0x90, Maker) {}
+        OPCode90(int addr, Builder* Maker)
+          : Instruction(addr, "0x90", 0x90, Maker) {}
+        OPCode90(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x90", 0x90, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode91 : public Instruction {
+      public:
+        OPCode91()
+          : Instruction(-1, 0x91, nullptr) {}
+        OPCode91(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x91", 0x91, Maker) {}
+        OPCode91(int addr, Builder* Maker)
+          : Instruction(addr, "0x91", 0x91, Maker) {}
+        OPCode91(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x91", 0x91, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
                 case 1:
                 case 5:
                 case 0xA:
                 case 0xB:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 2:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-
-                }
-
+            }
         }
     };
-    class OPCode92 : public Instruction
-    {
-        public:
-        OPCode92():Instruction(-1,0x92,nullptr){}
-        OPCode92(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x92", 0x92,Maker){}
-        OPCode92(int addr, Builder *Maker):Instruction(addr,"0x92",0x92,Maker){}
-        OPCode92(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x92", 0x92,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+    class OPCode92 : public Instruction {
+      public:
+        OPCode92()
+          : Instruction(-1, 0x92, nullptr) {}
+        OPCode92(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x92", 0x92, Maker) {}
+        OPCode92(int addr, Builder* Maker)
+          : Instruction(addr, "0x92", 0x92, Maker) {}
+        OPCode92(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x92", 0x92, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode93 : public Instruction
-    {
-        public:
-        OPCode93():Instruction(-1,0x93,nullptr){}
-        OPCode93(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x93", 0x93,Maker){}
-        OPCode93(int addr, Builder *Maker):Instruction(addr,"0x93",0x93,Maker){}
-        OPCode93(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x93", 0x93, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode93 : public Instruction {
+      public:
+        OPCode93()
+          : Instruction(-1, 0x93, nullptr) {}
+        OPCode93(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x93", 0x93, Maker) {}
+        OPCode93(int addr, Builder* Maker)
+          : Instruction(addr, "0x93", 0x93, Maker) {}
+        OPCode93(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x93", 0x93, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                }
-
+            }
         }
     };
-    class OPCode94 : public Instruction
-    {
-        public:
-        OPCode94():Instruction(-1,0x94,nullptr){}
-        OPCode94(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x94", 0x94,Maker){}
-        OPCode94(int addr, Builder *Maker):Instruction(addr,"0x94",0x94,Maker){}
-        OPCode94(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x94", 0x94,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode94 : public Instruction {
+      public:
+        OPCode94()
+          : Instruction(-1, 0x94, nullptr) {}
+        OPCode94(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x94", 0x94, Maker) {}
+        OPCode94(int addr, Builder* Maker)
+          : Instruction(addr, "0x94", 0x94, Maker) {}
+        OPCode94(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x94", 0x94, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
-                }
-
-
+            }
         }
     };
-    class OPCode95 : public Instruction
-    {
-        public:
-        OPCode95():Instruction(-1,0x95,nullptr){}
-        OPCode95(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x95", 0x95,Maker){}
-        OPCode95(int addr, Builder *Maker):Instruction(addr,"0x95",0x95,Maker){}
-        OPCode95(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x95", 0x95, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                }
-
-
+    class OPCode95 : public Instruction {
+      public:
+        OPCode95()
+          : Instruction(-1, 0x95, nullptr) {}
+        OPCode95(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x95", 0x95, Maker) {}
+        OPCode95(int addr, Builder* Maker)
+          : Instruction(addr, "0x95", 0x95, Maker) {}
+        OPCode95(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x95", 0x95, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
     };
-    class OPCode97 : public Instruction
-    {
-        public:
-        OPCode97():Instruction(-1,0x97,nullptr){}
-        OPCode97(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x97", 0x97,Maker){}
-        OPCode97(int addr, Builder *Maker):Instruction(addr,"0x97",0x97,Maker){}
-        OPCode97(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x97", 0x97, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
+    class OPCode97 : public Instruction {
+      public:
+        OPCode97()
+          : Instruction(-1, 0x97, nullptr) {}
+        OPCode97(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x97", 0x97, Maker) {}
+        OPCode97(int addr, Builder* Maker)
+          : Instruction(addr, "0x97", 0x97, Maker) {}
+        OPCode97(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x97", 0x97, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode99 : public Instruction
-    {
-        public:
-        OPCode99():Instruction(-1,0x99,nullptr){}
-        OPCode99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x99", 0x99,Maker){}
-        OPCode99(int addr, Builder *Maker):Instruction(addr,"0x99",0x99,Maker){}
-        OPCode99(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x99", 0x99, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+    class OPCode99 : public Instruction {
+      public:
+        OPCode99()
+          : Instruction(-1, 0x99, nullptr) {}
+        OPCode99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x99", 0x99, Maker) {}
+        OPCode99(int addr, Builder* Maker)
+          : Instruction(addr, "0x99", 0x99, Maker) {}
+        OPCode99(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x99", 0x99, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode9A : public Instruction
-    {
-        public:
-        OPCode9A():Instruction(-1,0x9A,nullptr){}
-        OPCode9A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9A", 0x9A,Maker){}
-        OPCode9A(int addr, Builder *Maker):Instruction(addr,"0x9A",0x9A,Maker){}
-        OPCode9A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9A", 0x9A, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-
+    class OPCode9A : public Instruction {
+      public:
+        OPCode9A()
+          : Instruction(-1, 0x9A, nullptr) {}
+        OPCode9A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9A", 0x9A, Maker) {}
+        OPCode9A(int addr, Builder* Maker)
+          : Instruction(addr, "0x9A", 0x9A, Maker) {}
+        OPCode9A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9A", 0x9A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode9B : public Instruction
-    {
-        public:
-        OPCode9B():Instruction(-1,0x9B,nullptr){}
-        OPCode9B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9B", 0x9B,Maker){}
-        OPCode9B(int addr, Builder *Maker):Instruction(addr,"0x9B",0x9B,Maker){}
-        OPCode9B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9B", 0x9B, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x00:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-
-                }
-
+    class OPCode9B : public Instruction {
+      public:
+        OPCode9B()
+          : Instruction(-1, 0x9B, nullptr) {}
+        OPCode9B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9B", 0x9B, Maker) {}
+        OPCode9B(int addr, Builder* Maker)
+          : Instruction(addr, "0x9B", 0x9B, Maker) {}
+        OPCode9B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9B", 0x9B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
     };
-    class OPCode9C : public Instruction
-    {
-        public:
-        OPCode9C():Instruction(-1,0x9C,nullptr){}
-        OPCode9C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9C", 0x9C,Maker){}
-        OPCode9C(int addr, Builder *Maker):Instruction(addr,"0x9C",0x9C,Maker){}
-        OPCode9C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9C", 0x9C, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode9C : public Instruction {
+      public:
+        OPCode9C()
+          : Instruction(-1, 0x9C, nullptr) {}
+        OPCode9C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9C", 0x9C, Maker) {}
+        OPCode9C(int addr, Builder* Maker)
+          : Instruction(addr, "0x9C", 0x9C, Maker) {}
+        OPCode9C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9C", 0x9C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
                 case 0x00:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x02:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
-                }
-
+            }
         }
     };
-    class OPCode9D : public Instruction
-    {
-        public:
-        OPCode9D():Instruction(-1,0x9D,nullptr){}
-        OPCode9D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9D", 0x9D,Maker){}
-        OPCode9D(int addr, Builder *Maker):Instruction(addr,"0x9D",0x9D,Maker){}
-        OPCode9D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9D", 0x9D, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+    class OPCode9D : public Instruction {
+      public:
+        OPCode9D()
+          : Instruction(-1, 0x9D, nullptr) {}
+        OPCode9D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9D", 0x9D, Maker) {}
+        OPCode9D(int addr, Builder* Maker)
+          : Instruction(addr, "0x9D", 0x9D, Maker) {}
+        OPCode9D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9D", 0x9D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCode9E : public Instruction
-    {
-        public:
-        OPCode9E():Instruction(-1,0x9E,nullptr){}
-        OPCode9E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9E", 0x9E,Maker){}
-        OPCode9E(int addr, Builder *Maker):Instruction(addr,"0x9E",0x9E,Maker){}
-        OPCode9E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9E", 0x9E, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode9E : public Instruction {
+      public:
+        OPCode9E()
+          : Instruction(-1, 0x9E, nullptr) {}
+        OPCode9E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9E", 0x9E, Maker) {}
+        OPCode9E(int addr, Builder* Maker)
+          : Instruction(addr, "0x9E", 0x9E, Maker) {}
+        OPCode9E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9E", 0x9E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
                 case 0xF:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x11:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x12:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                }
-
+            }
         }
     };
-    class OPCodeA0 : public Instruction
-    {
-        public:
-        OPCodeA0():Instruction(-1,0xA0,nullptr){}
-        OPCodeA0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA0", 0xA0,Maker){}
-        OPCodeA0(int addr, Builder *Maker):Instruction(addr,"0xA0",0xA0,Maker){}
-        OPCodeA0(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xA0", 0xA0,Maker){
-                addr++;
+    class OPCodeA0 : public Instruction {
+      public:
+        OPCodeA0()
+          : Instruction(-1, 0xA0, nullptr) {}
+        OPCodeA0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA0", 0xA0, Maker) {}
+        OPCodeA0(int addr, Builder* Maker)
+          : Instruction(addr, "0xA0", 0xA0, Maker) {}
+        OPCodeA0(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA0", 0xA0, Maker) {
+            addr++;
         }
     };
-    class OPCodeA1 : public Instruction
-    {
-        public:
-        OPCodeA1():Instruction(-1,0xA1,nullptr){}
-        OPCodeA1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA1", 0xA1,Maker){}
-        OPCodeA1(int addr, Builder *Maker):Instruction(addr,"0xA1",0xA1,Maker){}
-        OPCodeA1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA1", 0xA1,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCodeA1 : public Instruction {
+      public:
+        OPCodeA1()
+          : Instruction(-1, 0xA1, nullptr) {}
+        OPCodeA1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA1", 0xA1, Maker) {}
+        OPCodeA1(int addr, Builder* Maker)
+          : Instruction(addr, "0xA1", 0xA1, Maker) {}
+        OPCodeA1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA1", 0xA1, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCodeA3 : public Instruction
-    {
-        public:
-        OPCodeA3():Instruction(-1,0xA3,nullptr){}
-        OPCodeA3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA3", 0xA3,Maker){}
-        OPCodeA3(int addr, Builder *Maker):Instruction(addr,"0xA3",0xA3,Maker){}
-        OPCodeA3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA3", 0xA3,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCodeA3 : public Instruction {
+      public:
+        OPCodeA3()
+          : Instruction(-1, 0xA3, nullptr) {}
+        OPCodeA3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA3", 0xA3, Maker) {}
+        OPCodeA3(int addr, Builder* Maker)
+          : Instruction(addr, "0xA3", 0xA3, Maker) {}
+        OPCodeA3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA3", 0xA3, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCodeA4 : public Instruction
-    {
-        public:
-        OPCodeA4():Instruction(-1,0xA4,nullptr){}
-        OPCodeA4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA4", 0xA4,Maker){}
-        OPCodeA4(int addr, Builder *Maker):Instruction(addr,"0xA4",0xA4,Maker){}
-        OPCodeA4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA4", 0xA4,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//x21
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCodeA4 : public Instruction {
+      public:
+        OPCodeA4()
+          : Instruction(-1, 0xA4, nullptr) {}
+        OPCodeA4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA4", 0xA4, Maker) {}
+        OPCodeA4(int addr, Builder* Maker)
+          : Instruction(addr, "0xA4", 0xA4, Maker) {}
+        OPCodeA4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA4", 0xA4, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // x21
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCodeA6 : public Instruction
-    {
-        public:
-        OPCodeA6():Instruction(-1,0xA6,nullptr){}
-        OPCodeA6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA6", 0xA6,Maker){}
-        OPCodeA6(int addr, Builder *Maker):Instruction(addr,"0xA6",0xA6,Maker){}
-        OPCodeA6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA6", 0xA6,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
+    class OPCodeA6 : public Instruction {
+      public:
+        OPCodeA6()
+          : Instruction(-1, 0xA6, nullptr) {}
+        OPCodeA6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA6", 0xA6, Maker) {}
+        OPCodeA6(int addr, Builder* Maker)
+          : Instruction(addr, "0xA6", 0xA6, Maker) {}
+        OPCodeA6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA6", 0xA6, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCodeA8 : public Instruction
-    {
-        public:
-        OPCodeA8():Instruction(-1,0xA8,nullptr){}
-        OPCodeA8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA8", 0xA8,Maker){}
-        OPCodeA8(int addr, Builder *Maker):Instruction(addr,"0xA8",0xA8,Maker){}
-        OPCodeA8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA8", 0xA8,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
+    class OPCodeA8 : public Instruction {
+      public:
+        OPCodeA8()
+          : Instruction(-1, 0xA8, nullptr) {}
+        OPCodeA8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA8", 0xA8, Maker) {}
+        OPCodeA8(int addr, Builder* Maker)
+          : Instruction(addr, "0xA8", 0xA8, Maker) {}
+        OPCodeA8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA8", 0xA8, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCodeA9 : public Instruction
-    {
-        public:
-        OPCodeA9():Instruction(-1,0xA9,nullptr){}
-        OPCodeA9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA9", 0xA9,Maker){}
-        OPCodeA9(int addr, Builder *Maker):Instruction(addr,"0xA9",0xA9,Maker){}
-        OPCodeA9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA9", 0xA9,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+    class OPCodeA9 : public Instruction {
+      public:
+        OPCodeA9()
+          : Instruction(-1, 0xA9, nullptr) {}
+        OPCodeA9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA9", 0xA9, Maker) {}
+        OPCodeA9(int addr, Builder* Maker)
+          : Instruction(addr, "0xA9", 0xA9, Maker) {}
+        OPCodeA9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA9", 0xA9, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCodeAA : public Instruction
-    {
-        public:
-        OPCodeAA():Instruction(-1,0xAA,nullptr){}
-        OPCodeAA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAA", 0xAA,Maker){}
-        OPCodeAA(int addr, Builder *Maker):Instruction(addr,"0xAA",0xAA,Maker){}
-        OPCodeAA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAA", 0xAA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+    class OPCodeAA : public Instruction {
+      public:
+        OPCodeAA()
+          : Instruction(-1, 0xAA, nullptr) {}
+        OPCodeAA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAA", 0xAA, Maker) {}
+        OPCodeAA(int addr, Builder* Maker)
+          : Instruction(addr, "0xAA", 0xAA, Maker) {}
+        OPCodeAA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAA", 0xAA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCodeAB : public Instruction
-    {
-        public:
-        OPCodeAB():Instruction(-1,0xAB,nullptr){}
-        OPCodeAB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAB", 0xAB,Maker){}
-        OPCodeAB(int addr, Builder *Maker):Instruction(addr,"0xAB",0xAB,Maker){}
-        OPCodeAB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAB", 0xAB,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        for (int i = 4; i <=0x36; i++) this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-
-                    case 0x2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        for (int i = 3; i <=0x65; i+=2) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                }
-
-        }
-    };
-    class OPCodeAC : public Instruction
-    {
-        public:
-        OPCodeAC():Instruction(-1,0xAC,nullptr){}
-        OPCodeAC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAC", 0xAC,Maker){}
-        OPCodeAC(int addr, Builder *Maker):Instruction(addr,"0xAC",0xAC,Maker){}
-        OPCodeAC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAC", 0xAC,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x2:
-                    case 0x1:
-
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x3:
-                    case 0x4:
-                        fun_1403c90e0(addr, content, this, 1);
-
-                        break;
-                    case 0x5:
-                    case '\a':
-                    case '\t':
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
-
-        }
-    };
-    class OPCodeAD : public Instruction
-    {
-        public:
-        OPCodeAD():Instruction(-1,0xAD,nullptr){}
-        OPCodeAD(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAD", 0xAD,Maker){}
-        OPCodeAD(int addr, Builder *Maker):Instruction(addr,"0xAD",0xAD,Maker){}
-        OPCodeAD(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAD", 0xAD,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x00:
-                    case 0x01:
-                    case 0x03:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x02:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                }
-        }
-    };
-    class OPCodeAE : public Instruction
-    {
-        public:
-        OPCodeAE():Instruction(-1,0xAE,nullptr){}
-        OPCodeAE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAE", 0xAE,Maker){}
-        OPCodeAE(int addr, Builder *Maker):Instruction(addr,"0xAE",0xAE,Maker){}
-        OPCodeAE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAE", 0xAE,Maker){
-                addr++;
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-        }
-    };
-    class OPCodeAF : public Instruction
-    {
-        public:
-        OPCodeAF():Instruction(-1,0xAF,nullptr){}
-        OPCodeAF(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAF", 0xAF,Maker){}
-        OPCodeAF(int addr, Builder *Maker):Instruction(addr,"0xAF",0xAF,Maker){}
-        OPCodeAF(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAF", 0xAF,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCodeB1 : public Instruction
-    {
-        public:
-        OPCodeB1():Instruction(-1,0xB1,nullptr){}
-        OPCodeB1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB1", 0xB1,Maker){}
-        OPCodeB1(int addr, Builder *Maker):Instruction(addr,"0xB1",0xB1,Maker){}
-        OPCodeB1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB1", 0xB1,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCodeB2 : public Instruction
-    {
-        public:
-        OPCodeB2():Instruction(-1,0xB2,nullptr){}
-        OPCodeB2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB2", 0xB2,Maker){}
-        OPCodeB2(int addr, Builder *Maker):Instruction(addr,"0xB2",0xB2,Maker){}
-        OPCodeB2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB2", 0xB2,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-
-        }
-    };
-    class OPCodeB3 : public Instruction
-    {
-        public:
-        OPCodeB3():Instruction(-1,0xB3,nullptr){}
-        OPCodeB3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB3", 0xB3,Maker){}
-        OPCodeB3(int addr, Builder *Maker):Instruction(addr,"0xB3",0xB3,Maker){}
-        OPCodeB3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB3", 0xB3,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-
-        }
-    };
-    class OPCodeB4 : public Instruction
-    {
-        public:
-        OPCodeB4():Instruction(-1,0xB4,nullptr){}
-        OPCodeB4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB4", 0xB4,Maker){}
-        OPCodeB4(int addr, Builder *Maker):Instruction(addr,"0xB4",0xB4,Maker){}
-        OPCodeB4(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xB4", 0xB4,Maker){
-                addr++;
-
-
-        }
-    };
-    class OPCodeB5 : public Instruction
-    {
-        public:
-        OPCodeB5():Instruction(-1,0xB5,nullptr){}
-        OPCodeB5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB5", 0xB5,Maker){}
-        OPCodeB5(int addr, Builder *Maker):Instruction(addr,"0xB5",0xB5,Maker){}
-        OPCodeB5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB5", 0xB5,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-
-        }
-    };
-    class OPCodeB6 : public Instruction
-    {
-        public:
-        OPCodeB6():Instruction(-1,0xB6,nullptr){}
-        OPCodeB6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB6", 0xB6,Maker){}
-        OPCodeB6(int addr, Builder *Maker):Instruction(addr,"0xB6",0xB6,Maker){}
-        OPCodeB6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB6", 0xB6,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-
-        }
-    };
-    class OPCodeB7 : public Instruction
-    {
-        public:
-        OPCodeB7():Instruction(-1,0xB7,nullptr){}
-        OPCodeB7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB7", 0xB7,Maker){}
-        OPCodeB7(int addr, Builder *Maker):Instruction(addr,"0xB7",0xB7,Maker){}
-        OPCodeB7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB7", 0xB7,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-        }
-    };
-    class OPCodeBA : public Instruction
-    {
-        public:
-        OPCodeBA():Instruction(-1,0xBA,nullptr){}
-        OPCodeBA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBA", 0xBA,Maker){}
-        OPCodeBA(int addr, Builder *Maker):Instruction(addr,"0xBA",0xBA,Maker){}
-        OPCodeBA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBA", 0xBA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x14:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+    class OPCodeAB : public Instruction {
+      public:
+        OPCodeAB()
+          : Instruction(-1, 0xAB, nullptr) {}
+        OPCodeAB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAB", 0xAB, Maker) {}
+        OPCodeAB(int addr, Builder* Maker)
+          : Instruction(addr, "0xAB", 0xAB, Maker) {}
+        OPCodeAB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAB", 0xAB, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    for (int i = 4; i <= 0x36; i++)
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                }
-        }
-    };
-    class OPCodeB8 : public Instruction
-    {
-        public:
-        OPCodeB8():Instruction(-1,0xB8,nullptr){}
-        OPCodeB8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB8", 0xB8,Maker){}
-        OPCodeB8(int addr, Builder *Maker):Instruction(addr,"0xB8",0xB8,Maker){}
-        OPCodeB8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB8", 0xB8,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                fun_1403c90e0(addr, content, this, 1);
-                fun_1403c90e0(addr, content, this, 1);
 
+                case 0x2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    for (int i = 3; i <= 0x65; i += 2)
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
     };
-    class OPCodeB9 : public Instruction
-    {
-        public:
-        OPCodeB9():Instruction(-1,0xB9,nullptr){}
-        OPCodeB9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB9", 0xB9,Maker){}
-        OPCodeB9(int addr, Builder *Maker):Instruction(addr,"0xB9",0xB9,Maker){}
-        OPCodeB9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB9", 0xB9,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                }
+    class OPCodeAC : public Instruction {
+      public:
+        OPCodeAC()
+          : Instruction(-1, 0xAC, nullptr) {}
+        OPCodeAC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAC", 0xAC, Maker) {}
+        OPCodeAC(int addr, Builder* Maker)
+          : Instruction(addr, "0xAC", 0xAC, Maker) {}
+        OPCodeAC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAC", 0xAC, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x2:
+                case 0x1:
 
-        }
-    };
-    class OPCodeBB : public Instruction
-    {
-        public:
-        OPCodeBB():Instruction(-1,0xBB,nullptr){}
-        OPCodeBB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBB", 0xBB,Maker){}
-        OPCodeBB(int addr, Builder *Maker):Instruction(addr,"0xBB",0xBB,Maker){}
-        OPCodeBB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBB", 0xBB,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x3:
+                case 0x4:
+                    fun_1403c90e0(addr, content, this, 1);
 
+                    break;
+                case 0x5:
+                case '\a':
+                case '\t':
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
     };
-    class OPCodeBC : public Instruction
-    {
-        public:
-        OPCodeBC():Instruction(-1,0xBC,nullptr){}
-        OPCodeBC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBC", 0xBC,Maker){}
-        OPCodeBC(int addr, Builder *Maker):Instruction(addr,"0xBC",0xBC,Maker){}
-        OPCodeBC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBC", 0xBC,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                fun_1403c90e0(addr, content, this, 1);
-                switch((unsigned char)control_byte[0]){
+    class OPCodeAD : public Instruction {
+      public:
+        OPCodeAD()
+          : Instruction(-1, 0xAD, nullptr) {}
+        OPCodeAD(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAD", 0xAD, Maker) {}
+        OPCodeAD(int addr, Builder* Maker)
+          : Instruction(addr, "0xAD", 0xAD, Maker) {}
+        OPCodeAD(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAD", 0xAD, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                case 0x01:
+                case 0x03:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x02:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+    class OPCodeAE : public Instruction {
+      public:
+        OPCodeAE()
+          : Instruction(-1, 0xAE, nullptr) {}
+        OPCodeAE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAE", 0xAE, Maker) {}
+        OPCodeAE(int addr, Builder* Maker)
+          : Instruction(addr, "0xAE", 0xAE, Maker) {}
+        OPCodeAE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAE", 0xAE, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeAF : public Instruction {
+      public:
+        OPCodeAF()
+          : Instruction(-1, 0xAF, nullptr) {}
+        OPCodeAF(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAF", 0xAF, Maker) {}
+        OPCodeAF(int addr, Builder* Maker)
+          : Instruction(addr, "0xAF", 0xAF, Maker) {}
+        OPCodeAF(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAF", 0xAF, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    class OPCodeB1 : public Instruction {
+      public:
+        OPCodeB1()
+          : Instruction(-1, 0xB1, nullptr) {}
+        OPCodeB1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB1", 0xB1, Maker) {}
+        OPCodeB1(int addr, Builder* Maker)
+          : Instruction(addr, "0xB1", 0xB1, Maker) {}
+        OPCodeB1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB1", 0xB1, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCodeB2 : public Instruction {
+      public:
+        OPCodeB2()
+          : Instruction(-1, 0xB2, nullptr) {}
+        OPCodeB2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB2", 0xB2, Maker) {}
+        OPCodeB2(int addr, Builder* Maker)
+          : Instruction(addr, "0xB2", 0xB2, Maker) {}
+        OPCodeB2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB2", 0xB2, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeB3 : public Instruction {
+      public:
+        OPCodeB3()
+          : Instruction(-1, 0xB3, nullptr) {}
+        OPCodeB3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB3", 0xB3, Maker) {}
+        OPCodeB3(int addr, Builder* Maker)
+          : Instruction(addr, "0xB3", 0xB3, Maker) {}
+        OPCodeB3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB3", 0xB3, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCodeB4 : public Instruction {
+      public:
+        OPCodeB4()
+          : Instruction(-1, 0xB4, nullptr) {}
+        OPCodeB4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB4", 0xB4, Maker) {}
+        OPCodeB4(int addr, Builder* Maker)
+          : Instruction(addr, "0xB4", 0xB4, Maker) {}
+        OPCodeB4(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB4", 0xB4, Maker) {
+            addr++;
+        }
+    };
+    class OPCodeB5 : public Instruction {
+      public:
+        OPCodeB5()
+          : Instruction(-1, 0xB5, nullptr) {}
+        OPCodeB5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB5", 0xB5, Maker) {}
+        OPCodeB5(int addr, Builder* Maker)
+          : Instruction(addr, "0xB5", 0xB5, Maker) {}
+        OPCodeB5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB5", 0xB5, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCodeB6 : public Instruction {
+      public:
+        OPCodeB6()
+          : Instruction(-1, 0xB6, nullptr) {}
+        OPCodeB6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB6", 0xB6, Maker) {}
+        OPCodeB6(int addr, Builder* Maker)
+          : Instruction(addr, "0xB6", 0xB6, Maker) {}
+        OPCodeB6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB6", 0xB6, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCodeB7 : public Instruction {
+      public:
+        OPCodeB7()
+          : Instruction(-1, 0xB7, nullptr) {}
+        OPCodeB7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB7", 0xB7, Maker) {}
+        OPCodeB7(int addr, Builder* Maker)
+          : Instruction(addr, "0xB7", 0xB7, Maker) {}
+        OPCodeB7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB7", 0xB7, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeBA : public Instruction {
+      public:
+        OPCodeBA()
+          : Instruction(-1, 0xBA, nullptr) {}
+        OPCodeBA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBA", 0xBA, Maker) {}
+        OPCodeBA(int addr, Builder* Maker)
+          : Instruction(addr, "0xBA", 0xBA, Maker) {}
+        OPCodeBA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBA", 0xBA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x14:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCodeB8 : public Instruction {
+      public:
+        OPCodeB8()
+          : Instruction(-1, 0xB8, nullptr) {}
+        OPCodeB8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB8", 0xB8, Maker) {}
+        OPCodeB8(int addr, Builder* Maker)
+          : Instruction(addr, "0xB8", 0xB8, Maker) {}
+        OPCodeB8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB8", 0xB8, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            fun_1403c90e0(addr, content, this, 1);
+            fun_1403c90e0(addr, content, this, 1);
+        }
+    };
+    class OPCodeB9 : public Instruction {
+      public:
+        OPCodeB9()
+          : Instruction(-1, 0xB9, nullptr) {}
+        OPCodeB9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB9", 0xB9, Maker) {}
+        OPCodeB9(int addr, Builder* Maker)
+          : Instruction(addr, "0xB9", 0xB9, Maker) {}
+        OPCodeB9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB9", 0xB9, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
                 case 1:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 2:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+    class OPCodeBB : public Instruction {
+      public:
+        OPCodeBB()
+          : Instruction(-1, 0xBB, nullptr) {}
+        OPCodeBB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBB", 0xBB, Maker) {}
+        OPCodeBB(int addr, Builder* Maker)
+          : Instruction(addr, "0xBB", 0xBB, Maker) {}
+        OPCodeBB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBB", 0xBB, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeBC : public Instruction {
+      public:
+        OPCodeBC()
+          : Instruction(-1, 0xBC, nullptr) {}
+        OPCodeBC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBC", 0xBC, Maker) {}
+        OPCodeBC(int addr, Builder* Maker)
+          : Instruction(addr, "0xBC", 0xBC, Maker) {}
+        OPCodeBC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBC", 0xBC, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            fun_1403c90e0(addr, content, this, 1);
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 4:
                 case 5:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 7:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 8:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 9:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                  break;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 case 10:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                  break;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
                 case 0xb:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xc:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xd:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xe:
                     fun_1403c90e0(addr, content, this, 1);
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xf:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0x10:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                  break;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 case 0x11:
                 case 0x12:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                  break;
-
-
-                }
-
-        }
-    };
-    class OPCodeBE : public Instruction
-    {
-        public:
-        OPCodeBE():Instruction(-1,0xBE,nullptr){}
-        OPCodeBE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBE", 0xBE,Maker){}
-        OPCodeBE(int addr, Builder *Maker):Instruction(addr,"0xBE",0xBE,Maker){}
-        OPCodeBE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBE", 0xBE,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCodeC0 : public Instruction
-    {
-        public:
-        OPCodeC0():Instruction(-1,0xC0,nullptr){}
-        OPCodeC0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC0", 0xC0,Maker){}
-        OPCodeC0(int addr, Builder *Maker):Instruction(addr,"0xC0",0xC0,Maker){}
-        OPCodeC0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC0", 0xC0,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                short control_shrt = ReadShortFromByteArray(0, control_short);
-                this->AddOperande(operande(addr,"short", control_short));
-                switch(control_shrt){
-                    case 0x2:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    default:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-
-
-                }
-
-        }
-    };
-    class OPCodeC2 : public Instruction
-    {
-        public:
-        OPCodeC2():Instruction(-1,0xC2,nullptr){}
-        OPCodeC2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC2", 0xC2,Maker){}
-        OPCodeC2(int addr, Builder *Maker):Instruction(addr,"0xC2",0xC2,Maker){}
-        OPCodeC2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC2", 0xC2,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCodeC3 : public Instruction
-    {
-        public:
-        OPCodeC3():Instruction(-1,0xC3,nullptr){}
-        OPCodeC3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC3", 0xC3,Maker){}
-        OPCodeC3(int addr, Builder *Maker):Instruction(addr,"0xC3",0xC3,Maker){}
-        OPCodeC3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC3", 0xC3,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x1:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeC4 : public Instruction
-    {
-        public:
-        OPCodeC4():Instruction(-1,0xC4,nullptr){}
-        OPCodeC4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC4", 0xC4,Maker){}
-        OPCodeC4(int addr, Builder *Maker):Instruction(addr,"0xC4",0xC4,Maker){}
-        OPCodeC4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC4", 0xC4,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-
-                        break;
-                    case 0x1:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        fun_1403c90e0(addr, content, this, 0);
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                    case 0x5:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeC5 : public Instruction
-    {
-        public:
-        OPCodeC5():Instruction(-1,0xC5,nullptr){}
-        OPCodeC5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC5", 0xC5,Maker){}
-        OPCodeC5(int addr, Builder *Maker):Instruction(addr,"0xC5",0xC5,Maker){}
-        OPCodeC5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC5", 0xC5,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-
-        }
-    };
-    class OPCodeC6 : public Instruction
-    {
-        public:
-        OPCodeC6():Instruction(-1,0xC6,nullptr){}
-        OPCodeC6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC6", 0xC6,Maker){}
-        OPCodeC6(int addr, Builder *Maker):Instruction(addr,"0xC6",0xC6,Maker){}
-        OPCodeC6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC6", 0xC6,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x2:
-                    case 0x3:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x4:
-                    case 0x5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x6:
-                    case 0x7:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                 }
-
-        }
-    };
-    class OPCodeC7 : public Instruction
-    {
-        public:
-        OPCodeC7():Instruction(-1,0xC7,nullptr){}
-        OPCodeC7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC7", 0xC7,Maker){}
-        OPCodeC7(int addr, Builder *Maker):Instruction(addr,"0xC7",0xC7,Maker){}
-        OPCodeC7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC7", 0xC7,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-
-                    case 0x1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                 }
-
-        }
-    };
-    class OPCodeC8 : public Instruction
-    {
-        public:
-        OPCodeC8():Instruction(-1,0xC8,nullptr){}
-        OPCodeC8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC8", 0xC8,Maker){}
-        OPCodeC8(int addr, Builder *Maker):Instruction(addr,"0xC8",0xC8,Maker){}
-        OPCodeC8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC8", 0xC8,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-        }
-    };
-    class OPCodeC9 : public Instruction
-    {
-        public:
-        OPCodeC9():Instruction(-1,0xC9,nullptr){}
-        OPCodeC9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC9", 0xC9,Maker){}
-        OPCodeC9(int addr, Builder *Maker):Instruction(addr,"0xC9",0xC9,Maker){}
-        OPCodeC9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC9", 0xC9,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                    case 0x1:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
-                }
-        }
-    };
-    class OPCodeCA : public Instruction
-    {
-        public:
-        OPCodeCA():Instruction(-1,0xCA,nullptr){}
-        OPCodeCA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCA", 0xCA,Maker){}
-        OPCodeCA(int addr, Builder *Maker):Instruction(addr,"0xCA",0xCA,Maker){}
-        OPCodeCA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCA", 0xCA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeCB : public Instruction
-    {
-        public:
-        OPCodeCB():Instruction(-1,0xCB,nullptr){}
-        OPCodeCB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCB", 0xCB,Maker){}
-        OPCodeCB(int addr, Builder *Maker):Instruction(addr,"0xCB",0xCB,Maker){}
-        OPCodeCB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCB", 0xCB,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCodeCC : public Instruction
-    {
-        public:
-        OPCodeCC():Instruction(-1,0xCC,nullptr){}
-        OPCodeCC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCC", 0xCC,Maker){}
-        OPCodeCC(int addr, Builder *Maker):Instruction(addr,"0xCC",0xCC,Maker){}
-        OPCodeCC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCC", 0xCC,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCodeCD : public Instruction
-    {
-        public:
-        OPCodeCD():Instruction(-1,0xCD,nullptr){}
-        OPCodeCD(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCD", 0xCD,Maker){}
-        OPCodeCD(int addr, Builder *Maker):Instruction(addr,"0xCD",0xCD,Maker){}
-        OPCodeCD(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCD", 0xCD,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-
-                }
-
-        }
-    };
-
-
-    std::shared_ptr<Instruction> CreateInstructionFromDAT(int &addr, QByteArray &dat_content, int function_type){
-        int OP = (dat_content[addr]&0xFF);
-        //qDebug() << "OP: " << hex << OP << " at " << addr;
-        if (function_type == 0){ //the function is read with OPCodes
-
-
-            switch(OP){
-                case 0x00: return std::make_shared<OPCode0>(addr,dat_content,this);
-                case 0x01: return std::make_shared<OPCode1>(addr,dat_content,this);
-                case 0x02: return std::make_shared<OPCode2>(addr,dat_content,this);
-                case 0x03: return std::make_shared<OPCode3>(addr,dat_content,this);
-                case 0x04: return std::make_shared<OPCode4>(addr,dat_content,this);
-                case 0x05: return std::make_shared<OPCode5>(addr,dat_content,this);
-                case 0x06: return std::make_shared<OPCode6>(addr,dat_content,this);
-                case 0x07: return std::make_shared<OPCode7>(addr,dat_content,this);
-                case 0x08: return std::make_shared<OPCode8>(addr,dat_content,this);
-                case 0x0A: return std::make_shared<OPCodeA>(addr,dat_content,this);
-                case 0x0C: return std::make_shared<OPCodeC>(addr,dat_content,this);
-                case 0x0D: return std::make_shared<OPCode0D>(addr,dat_content,this);
-                case 0x0E: return std::make_shared<OPCodeE>(addr,dat_content,this);
-                case 0x10: return std::make_shared<OPCode10>(addr,dat_content,this);
-                case 0x11: return std::make_shared<OPCode11>(addr,dat_content,this);
-                case 0x12: return std::make_shared<OPCode12>(addr,dat_content,this);
-                case 0x13: return std::make_shared<OPCode13>(addr,dat_content,this);
-                case 0x14: return std::make_shared<OPCode14>(addr,dat_content,this);
-                case 0x15: return std::make_shared<OPCode15>(addr,dat_content,this);
-                case 0x16: return std::make_shared<OPCode16>(addr,dat_content,this);
-                case 0x17: return std::make_shared<OPCode17>(addr,dat_content,this);
-                case 0x18: return std::make_shared<OPCode18>(addr,dat_content,this);
-                case 0x1A: return std::make_shared<OPCode1A>(addr,dat_content,this);
-                case 0x1D: return std::make_shared<OPCode1D>(addr,dat_content,this);
-                case 0x1E: return std::make_shared<OPCode1E>(addr,dat_content,this);
-                case 0x1F: return std::make_shared<OPCode1F>(addr,dat_content,this);
-                case 0x20: return std::make_shared<OPCode20>(addr,dat_content,this);
-                case 0x21: return std::make_shared<OPCode21>(addr,dat_content,this);
-                case 0x22: return std::make_shared<OPCode22>(addr,dat_content,this);
-                case 0x23: return std::make_shared<OPCode23>(addr,dat_content,this);
-                case 0x24: return std::make_shared<OPCode24>(addr,dat_content,this);
-                case 0x25: return std::make_shared<OPCode25>(addr,dat_content,this);
-                case 0x26: return std::make_shared<OPCode26>(addr,dat_content,this);
-                case 0x27: return std::make_shared<OPCode27>(addr,dat_content,this);
-                case 0x28: return std::make_shared<OPCode28>(addr,dat_content,this);
-                case 0x29: return std::make_shared<OPCode29>(addr,dat_content,this);
-                case 0x2A: return std::make_shared<OPCode2A>(addr,dat_content,this);
-                case 0x2B: return std::make_shared<OPCode2B>(addr,dat_content,this);
-                case 0x2C: return std::make_shared<OPCode2C>(addr,dat_content,this);
-                case 0x2D: return std::make_shared<OPCode2D>(addr,dat_content,this);
-                case 0x2E: return std::make_shared<OPCode2E>(addr,dat_content,this);
-                case 0x2F: return std::make_shared<OPCode2F>(addr,dat_content,this);
-                case 0x30: return std::make_shared<OPCode30>(addr,dat_content,this);
-                case 0x31: return std::make_shared<OPCode31>(addr,dat_content,this);
-                case 0x32: return std::make_shared<OPCode32>(addr,dat_content,this);
-                case 0x33: return std::make_shared<OPCode33>(addr,dat_content,this);
-                case 0x34: return std::make_shared<OPCode34>(addr,dat_content,this);
-                case 0x35: return std::make_shared<OPCode35>(addr,dat_content,this);
-                case 0x36: return std::make_shared<OPCode36>(addr,dat_content,this);
-                case 0x37: return std::make_shared<OPCode37>(addr,dat_content,this);
-                case 0x38: return std::make_shared<OPCode38>(addr,dat_content,this);
-                case 0x39: return std::make_shared<OPCode39>(addr,dat_content,this);
-                case 0x3A: return std::make_shared<OPCode3A>(addr,dat_content,this);
-                case 0x3B: return std::make_shared<OPCode3B>(addr,dat_content,this);
-                case 0x3C: return std::make_shared<OPCode3C>(addr,dat_content,this);
-                case 0x3D: return std::make_shared<OPCode3D>(addr,dat_content,this);
-                case 0x3E: return std::make_shared<OPCode3E>(addr,dat_content,this);
-                case 0x3F: return std::make_shared<OPCode3F>(addr,dat_content,this);
-                case 0x40: return std::make_shared<OPCode40>(addr,dat_content,this);
-                case 0x41: return std::make_shared<OPCode41>(addr,dat_content,this);
-                case 0x42: return std::make_shared<OPCode42>(addr,dat_content,this);
-                case 0x43: return std::make_shared<OPCode43>(addr,dat_content,this);
-                case 0x44: return std::make_shared<OPCode44>(addr,dat_content,this);
-                case 0x45: return std::make_shared<OPCode45>(addr,dat_content,this);
-                case 0x46: return std::make_shared<OPCode46>(addr,dat_content,this);
-                case 0x47: return std::make_shared<OPCode47>(addr,dat_content,this);
-                case 0x48: return std::make_shared<OPCode48>(addr,dat_content,this);
-                case 0x49: return std::make_shared<OPCode49>(addr,dat_content,this);
-                case 0x4A: return std::make_shared<OPCode4A>(addr,dat_content,this);
-                case 0x4B: return std::make_shared<OPCode4B>(addr,dat_content,this);
-                case 0x4C: return std::make_shared<OPCode4C>(addr,dat_content,this);
-                case 0x4D: return std::make_shared<OPCode4D>(addr,dat_content,this);
-                case 0x4E: return std::make_shared<OPCode4E>(addr,dat_content,this);
-                case 0x4F: return std::make_shared<OPCode4F>(addr,dat_content,this);
-                case 0x50: return std::make_shared<OPCode50>(addr,dat_content,this);
-                case 0x51: return std::make_shared<OPCode51>(addr,dat_content,this);
-                case 0x52: return std::make_shared<OPCode52>(addr,dat_content,this);
-                case 0x53: return std::make_shared<OPCode53>(addr,dat_content,this);
-                case 0x54: return std::make_shared<OPCode54>(addr,dat_content,this);
-                case 0x55: return std::make_shared<OPCode55>(addr,dat_content,this);
-                case 0x56: return std::make_shared<OPCode56>(addr,dat_content,this);
-                case 0x57: return std::make_shared<OPCode57>(addr,dat_content,this);
-                case 0x58: return std::make_shared<OPCode58>(addr,dat_content,this);
-                case 0x5A: return std::make_shared<OPCode5A>(addr,dat_content,this);
-                case 0x5B: return std::make_shared<OPCode5B>(addr,dat_content,this);
-                case 0x5C: return std::make_shared<OPCode5C>(addr,dat_content,this);
-                case 0x5D: return std::make_shared<OPCode5D>(addr,dat_content,this);
-                case 0x5E: return std::make_shared<OPCode5E>(addr,dat_content,this);
-                case 0x60: return std::make_shared<OPCode60>(addr,dat_content,this);
-                case 0x61: return std::make_shared<OPCode61>(addr,dat_content,this);
-                case 0x62: return std::make_shared<OPCode62>(addr,dat_content,this);
-                case 0x63: return std::make_shared<OPCode63>(addr,dat_content,this);
-                case 0x64: return std::make_shared<OPCode64>(addr,dat_content,this);
-                case 0x65: return std::make_shared<OPCode65>(addr,dat_content,this);
-                case 0x66: return std::make_shared<OPCode66>(addr,dat_content,this);
-                case 0x67: return std::make_shared<OPCode67>(addr,dat_content,this);
-                case 0x68: return std::make_shared<OPCode68>(addr,dat_content,this);
-                case 0x69: return std::make_shared<OPCode69>(addr,dat_content,this);
-                case 0x6A: return std::make_shared<OPCode6A>(addr,dat_content,this);
-                case 0x6B: return std::make_shared<OPCode6B>(addr,dat_content,this);
-                case 0x6C: return std::make_shared<OPCode6C>(addr,dat_content,this);
-                case 0x6E: return std::make_shared<OPCode6E>(addr,dat_content,this);
-                case 0x6F: return std::make_shared<OPCode6F>(addr,dat_content,this);
-                case 0x70: return std::make_shared<OPCode70>(addr,dat_content,this);
-                case 0x72: return std::make_shared<OPCode72>(addr,dat_content,this);
-                case 0x73: return std::make_shared<OPCode73>(addr,dat_content,this);
-                case 0x74: return std::make_shared<OPCode74>(addr,dat_content,this);
-                case 0x75: return std::make_shared<OPCode75>(addr,dat_content,this);
-                case 0x76: return std::make_shared<OPCode76>(addr,dat_content,this);
-                case 0x77: return std::make_shared<OPCode77>(addr,dat_content,this);
-                case 0x78: return std::make_shared<OPCode78>(addr,dat_content,this);
-                case 0x79: return std::make_shared<OPCode79>(addr,dat_content,this);
-                case 0x7A: return std::make_shared<OPCode7A>(addr,dat_content,this);
-                case 0x7B: return std::make_shared<OPCode7B>(addr,dat_content,this);
-                case 0x7C: return std::make_shared<OPCode7C>(addr,dat_content,this);
-                case 0x7D: return std::make_shared<OPCode7D>(addr,dat_content,this);
-                case 0x7E: return std::make_shared<OPCode7E>(addr,dat_content,this);
-                case 0x80: return std::make_shared<OPCode80>(addr,dat_content,this);
-                case 0x82: return std::make_shared<OPCode82>(addr,dat_content,this);
-                case 0x83: return std::make_shared<OPCode83>(addr,dat_content,this);
-                case 0x84: return std::make_shared<OPCode84>(addr,dat_content,this);
-                case 0x86: return std::make_shared<OPCode86>(addr,dat_content,this);
-                case 0x87: return std::make_shared<OPCode87>(addr,dat_content,this);
-                case 0x88: return std::make_shared<OPCode88>(addr,dat_content,this);
-                case 0x89: return std::make_shared<OPCode89>(addr,dat_content,this);
-                case 0x8A: return std::make_shared<OPCode8A>(addr,dat_content,this);
-                case 0x8B: return std::make_shared<OPCode8B>(addr,dat_content,this);
-                case 0x8C: return std::make_shared<OPCode8C>(addr,dat_content,this);
-                case 0x8D: return std::make_shared<OPCode8D>(addr,dat_content,this);
-                case 0x8E: return std::make_shared<OPCode8E>(addr,dat_content,this);
-                case 0x8F: return std::make_shared<OPCode8F>(addr,dat_content,this);
-                case 0x90: return std::make_shared<OPCode90>(addr,dat_content,this);
-                case 0x91: return std::make_shared<OPCode91>(addr,dat_content,this);
-                case 0x92: return std::make_shared<OPCode92>(addr,dat_content,this);
-                case 0x93: return std::make_shared<OPCode93>(addr,dat_content,this);
-                case 0x94: return std::make_shared<OPCode94>(addr,dat_content,this);
-                case 0x95: return std::make_shared<OPCode95>(addr,dat_content,this);
-                case 0x97: return std::make_shared<OPCode97>(addr,dat_content,this);
-                case 0x98: return std::make_shared<OPCode98>(addr,dat_content,this);
-                case 0x99: return std::make_shared<OPCode99>(addr,dat_content,this);
-                case 0x9A: return std::make_shared<OPCode9A>(addr,dat_content,this);
-                case 0x9B: return std::make_shared<OPCode9B>(addr,dat_content,this);
-                case 0x9C: return std::make_shared<OPCode9C>(addr,dat_content,this);
-                case 0x9D: return std::make_shared<OPCode9D>(addr,dat_content,this);
-                case 0x9E: return std::make_shared<OPCode9E>(addr,dat_content,this);
-                case 0xA0: return std::make_shared<OPCodeA0>(addr,dat_content,this);
-                case 0xA1: return std::make_shared<OPCodeA1>(addr,dat_content,this);
-                case 0xA3: return std::make_shared<OPCodeA3>(addr,dat_content,this);
-                case 0xA4: return std::make_shared<OPCodeA4>(addr,dat_content,this);
-                case 0xA6: return std::make_shared<OPCodeA6>(addr,dat_content,this);
-                case 0xA8: return std::make_shared<OPCodeA8>(addr,dat_content,this);
-                case 0xA9: return std::make_shared<OPCodeA9>(addr,dat_content,this);
-                case 0xAA: return std::make_shared<OPCodeAA>(addr,dat_content,this);
-                case 0xAB: return std::make_shared<OPCodeAB>(addr,dat_content,this);
-                case 0xAC: return std::make_shared<OPCodeAC>(addr,dat_content,this);
-                case 0xAD: return std::make_shared<OPCodeAD>(addr,dat_content,this);
-                case 0xAE: return std::make_shared<OPCodeAE>(addr,dat_content,this);
-                case 0xAF: return std::make_shared<OPCodeAF>(addr,dat_content,this);
-                case 0xB1: return std::make_shared<OPCodeB1>(addr,dat_content,this);
-                case 0xB2: return std::make_shared<OPCodeB2>(addr,dat_content,this);
-                case 0xB3: return std::make_shared<OPCodeB3>(addr,dat_content,this);
-                case 0xB4: return std::make_shared<OPCodeB4>(addr,dat_content,this);
-                case 0xB5: return std::make_shared<OPCodeB5>(addr,dat_content,this);
-                case 0xB6: return std::make_shared<OPCodeB6>(addr,dat_content,this);
-                case 0xB7: return std::make_shared<OPCodeB7>(addr,dat_content,this);
-                case 0xB8: return std::make_shared<OPCodeB8>(addr,dat_content,this);
-                case 0xB9: return std::make_shared<OPCodeB9>(addr,dat_content,this);
-                case 0xBA: return std::make_shared<OPCodeBA>(addr,dat_content,this);
-                case 0xBB: return std::make_shared<OPCodeBB>(addr,dat_content,this);
-                case 0xBC: return std::make_shared<OPCodeBC>(addr,dat_content,this);
-                case 0xBE: return std::make_shared<OPCodeBE>(addr,dat_content,this);
-                case 0xC0: return std::make_shared<OPCodeC0>(addr,dat_content,this);
-                case 0xC2: return std::make_shared<OPCodeC2>(addr,dat_content,this);
-                case 0xC3: return std::make_shared<OPCodeC3>(addr,dat_content,this);
-                case 0xC4: return std::make_shared<OPCodeC4>(addr,dat_content,this);
-                case 0xC5: return std::make_shared<OPCodeC5>(addr,dat_content,this);
-                case 0xC6: return std::make_shared<OPCodeC6>(addr,dat_content,this);
-                case 0xC7: return std::make_shared<OPCodeC7>(addr,dat_content,this);
-                case 0xC8: return std::make_shared<OPCodeC8>(addr,dat_content,this);
-                case 0xC9: return std::make_shared<OPCodeC9>(addr,dat_content,this);
-                case 0xCA: return std::make_shared<OPCodeCA>(addr,dat_content,this);
-                case 0xCB: return std::make_shared<OPCodeCB>(addr,dat_content,this);
-                case 0xCC: return std::make_shared<OPCodeCC>(addr,dat_content,this);
-                case 0xCD: return std::make_shared<OPCodeCD>(addr,dat_content,this);
-
-                default:
-                std::stringstream stream;
-                stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
-                /*std::string result( stream.str() );
-
-                qFatal(result.c_str());*/
-                error = true;
-                addr++;
-                return std::shared_ptr<Instruction>();
             }
         }
-        else if (function_type==1){//the function is a "CreateMonsters" function
-
-            return std::make_shared<CreateMonsters>(addr,dat_content,this);
+    };
+    class OPCodeBE : public Instruction {
+      public:
+        OPCodeBE()
+          : Instruction(-1, 0xBE, nullptr) {}
+        OPCodeBE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBE", 0xBE, Maker) {}
+        OPCodeBE(int addr, Builder* Maker)
+          : Instruction(addr, "0xBE", 0xBE, Maker) {}
+        OPCodeBE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBE", 0xBE, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-        else if (function_type==2){//the function is a "effect" function
-
-            return std::make_shared<EffectsInstr>(addr,dat_content,this);
+    };
+    class OPCodeC0 : public Instruction {
+      public:
+        OPCodeC0()
+          : Instruction(-1, 0xC0, nullptr) {}
+        OPCodeC0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC0", 0xC0, Maker) {}
+        OPCodeC0(int addr, Builder* Maker)
+          : Instruction(addr, "0xC0", 0xC0, Maker) {}
+        OPCodeC0(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC0", 0xC0, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            short control_shrt = ReadShortFromByteArray(0, control_short);
+            this->AddOperande(operande(addr, "short", control_short));
+            switch (control_shrt) {
+                case 0x2:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                default:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
-        else if (function_type==3){
-
-            return std::make_shared<ActionTable>(addr,dat_content,this);
+    };
+    class OPCodeC2 : public Instruction {
+      public:
+        OPCodeC2()
+          : Instruction(-1, 0xC2, nullptr) {}
+        OPCodeC2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC2", 0xC2, Maker) {}
+        OPCodeC2(int addr, Builder* Maker)
+          : Instruction(addr, "0xC2", 0xC2, Maker) {}
+        OPCodeC2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC2", 0xC2, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
-        else if (function_type==4){
-
-            return std::make_shared<AlgoTable>(addr,dat_content,this);
+    };
+    class OPCodeC3 : public Instruction {
+      public:
+        OPCodeC3()
+          : Instruction(-1, 0xC3, nullptr) {}
+        OPCodeC3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC3", 0xC3, Maker) {}
+        OPCodeC3(int addr, Builder* Maker)
+          : Instruction(addr, "0xC3", 0xC3, Maker) {}
+        OPCodeC3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC3", 0xC3, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x1:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
         }
-        else if (function_type==5){
+    };
+    class OPCodeC4 : public Instruction {
+      public:
+        OPCodeC4()
+          : Instruction(-1, 0xC4, nullptr) {}
+        OPCodeC4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC4", 0xC4, Maker) {}
+        OPCodeC4(int addr, Builder* Maker)
+          : Instruction(addr, "0xC4", 0xC4, Maker) {}
+        OPCodeC4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC4", 0xC4, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
 
-            return std::make_shared<WeaponAttTable>(addr,dat_content,this);
+                    break;
+                case 0x1:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    fun_1403c90e0(addr, content, this, 0);
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                case 0x5:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
         }
-        else if (function_type==6){
+    };
+    class OPCodeC5 : public Instruction {
+      public:
+        OPCodeC5()
+          : Instruction(-1, 0xC5, nullptr) {}
+        OPCodeC5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC5", 0xC5, Maker) {}
+        OPCodeC5(int addr, Builder* Maker)
+          : Instruction(addr, "0xC5", 0xC5, Maker) {}
+        OPCodeC5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC5", 0xC5, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            return std::make_shared<BreakTable>(addr,dat_content,this);
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
         }
-        else if (function_type==7){
+    };
+    class OPCodeC6 : public Instruction {
+      public:
+        OPCodeC6()
+          : Instruction(-1, 0xC6, nullptr) {}
+        OPCodeC6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC6", 0xC6, Maker) {}
+        OPCodeC6(int addr, Builder* Maker)
+          : Instruction(addr, "0xC6", 0xC6, Maker) {}
+        OPCodeC6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC6", 0xC6, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            return std::make_shared<SummonTable>(addr,dat_content,this);
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x2:
+                case 0x3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x4:
+                case 0x5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x6:
+                case 0x7:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
-        else if (function_type==8){
+    };
+    class OPCodeC7 : public Instruction {
+      public:
+        OPCodeC7()
+          : Instruction(-1, 0xC7, nullptr) {}
+        OPCodeC7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC7", 0xC7, Maker) {}
+        OPCodeC7(int addr, Builder* Maker)
+          : Instruction(addr, "0xC7", 0xC7, Maker) {}
+        OPCodeC7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC7", 0xC7, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            return std::make_shared<ReactionTable>(addr,dat_content,this);
+                case 0x1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
-        else if (function_type==9){
-
-            return std::make_shared<PartTable>(addr,dat_content,this);
+    };
+    class OPCodeC8 : public Instruction {
+      public:
+        OPCodeC8()
+          : Instruction(-1, 0xC8, nullptr) {}
+        OPCodeC8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC8", 0xC8, Maker) {}
+        OPCodeC8(int addr, Builder* Maker)
+          : Instruction(addr, "0xC8", 0xC8, Maker) {}
+        OPCodeC8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC8", 0xC8, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-        else if (function_type==10){
-
-            return std::make_shared<AnimeClipTable>(addr,dat_content,this);
+    };
+    class OPCodeC9 : public Instruction {
+      public:
+        OPCodeC9()
+          : Instruction(-1, 0xC9, nullptr) {}
+        OPCodeC9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC9", 0xC9, Maker) {}
+        OPCodeC9(int addr, Builder* Maker)
+          : Instruction(addr, "0xC9", 0xC9, Maker) {}
+        OPCodeC9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC9", 0xC9, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
-        else if (function_type==11){
-
-            return std::make_shared<FieldMonsterData>(addr,dat_content,this);
+    };
+    class OPCodeCA : public Instruction {
+      public:
+        OPCodeCA()
+          : Instruction(-1, 0xCA, nullptr) {}
+        OPCodeCA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCA", 0xCA, Maker) {}
+        OPCodeCA(int addr, Builder* Maker)
+          : Instruction(addr, "0xCA", 0xCA, Maker) {}
+        OPCodeCA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCA", 0xCA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
-        else if (function_type==12){
-
-            return std::make_shared<FieldFollowData>(addr,dat_content,this);
+    };
+    class OPCodeCB : public Instruction {
+      public:
+        OPCodeCB()
+          : Instruction(-1, 0xCB, nullptr) {}
+        OPCodeCB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCB", 0xCB, Maker) {}
+        OPCodeCB(int addr, Builder* Maker)
+          : Instruction(addr, "0xCB", 0xCB, Maker) {}
+        OPCodeCB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCB", 0xCB, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
-        else if (function_type==13){
-
-            return std::make_shared<FC_autoX>(addr,dat_content,this);
+    };
+    class OPCodeCC : public Instruction {
+      public:
+        OPCodeCC()
+          : Instruction(-1, 0xCC, nullptr) {}
+        OPCodeCC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCC", 0xCC, Maker) {}
+        OPCodeCC(int addr, Builder* Maker)
+          : Instruction(addr, "0xCC", 0xCC, Maker) {}
+        OPCodeCC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCC", 0xCC, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
-        else if (function_type==14){
-
-            return std::make_shared<BookData99>(addr,dat_content,this);
+    };
+    class OPCodeCD : public Instruction {
+      public:
+        OPCodeCD()
+          : Instruction(-1, 0xCD, nullptr) {}
+        OPCodeCD(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCD", 0xCD, Maker) {}
+        OPCodeCD(int addr, Builder* Maker)
+          : Instruction(addr, "0xCD", 0xCD, Maker) {}
+        OPCodeCD(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCD", 0xCD, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
         }
-        else if (function_type==15){
+    };
 
-            return std::make_shared<BookDataX>(addr,dat_content,this);
+    std::shared_ptr<Instruction> CreateInstructionFromDAT(int& addr, QByteArray& dat_content, int function_type) {
+        int OP = (dat_content[addr] & 0xFF);
+        // qDebug() << "OP: " << hex << OP << " at " << addr;
+        if (function_type == 0) { // the function is read with OPCodes
+
+            switch (OP) {
+                case 0x00:
+                    return std::make_shared<OPCode0>(addr, dat_content, this);
+                case 0x01:
+                    return std::make_shared<OPCode1>(addr, dat_content, this);
+                case 0x02:
+                    return std::make_shared<OPCode2>(addr, dat_content, this);
+                case 0x03:
+                    return std::make_shared<OPCode3>(addr, dat_content, this);
+                case 0x04:
+                    return std::make_shared<OPCode4>(addr, dat_content, this);
+                case 0x05:
+                    return std::make_shared<OPCode5>(addr, dat_content, this);
+                case 0x06:
+                    return std::make_shared<OPCode6>(addr, dat_content, this);
+                case 0x07:
+                    return std::make_shared<OPCode7>(addr, dat_content, this);
+                case 0x08:
+                    return std::make_shared<OPCode8>(addr, dat_content, this);
+                case 0x0A:
+                    return std::make_shared<OPCodeA>(addr, dat_content, this);
+                case 0x0C:
+                    return std::make_shared<OPCodeC>(addr, dat_content, this);
+                case 0x0D:
+                    return std::make_shared<OPCode0D>(addr, dat_content, this);
+                case 0x0E:
+                    return std::make_shared<OPCodeE>(addr, dat_content, this);
+                case 0x10:
+                    return std::make_shared<OPCode10>(addr, dat_content, this);
+                case 0x11:
+                    return std::make_shared<OPCode11>(addr, dat_content, this);
+                case 0x12:
+                    return std::make_shared<OPCode12>(addr, dat_content, this);
+                case 0x13:
+                    return std::make_shared<OPCode13>(addr, dat_content, this);
+                case 0x14:
+                    return std::make_shared<OPCode14>(addr, dat_content, this);
+                case 0x15:
+                    return std::make_shared<OPCode15>(addr, dat_content, this);
+                case 0x16:
+                    return std::make_shared<OPCode16>(addr, dat_content, this);
+                case 0x17:
+                    return std::make_shared<OPCode17>(addr, dat_content, this);
+                case 0x18:
+                    return std::make_shared<OPCode18>(addr, dat_content, this);
+                case 0x1A:
+                    return std::make_shared<OPCode1A>(addr, dat_content, this);
+                case 0x1D:
+                    return std::make_shared<OPCode1D>(addr, dat_content, this);
+                case 0x1E:
+                    return std::make_shared<OPCode1E>(addr, dat_content, this);
+                case 0x1F:
+                    return std::make_shared<OPCode1F>(addr, dat_content, this);
+                case 0x20:
+                    return std::make_shared<OPCode20>(addr, dat_content, this);
+                case 0x21:
+                    return std::make_shared<OPCode21>(addr, dat_content, this);
+                case 0x22:
+                    return std::make_shared<OPCode22>(addr, dat_content, this);
+                case 0x23:
+                    return std::make_shared<OPCode23>(addr, dat_content, this);
+                case 0x24:
+                    return std::make_shared<OPCode24>(addr, dat_content, this);
+                case 0x25:
+                    return std::make_shared<OPCode25>(addr, dat_content, this);
+                case 0x26:
+                    return std::make_shared<OPCode26>(addr, dat_content, this);
+                case 0x27:
+                    return std::make_shared<OPCode27>(addr, dat_content, this);
+                case 0x28:
+                    return std::make_shared<OPCode28>(addr, dat_content, this);
+                case 0x29:
+                    return std::make_shared<OPCode29>(addr, dat_content, this);
+                case 0x2A:
+                    return std::make_shared<OPCode2A>(addr, dat_content, this);
+                case 0x2B:
+                    return std::make_shared<OPCode2B>(addr, dat_content, this);
+                case 0x2C:
+                    return std::make_shared<OPCode2C>(addr, dat_content, this);
+                case 0x2D:
+                    return std::make_shared<OPCode2D>(addr, dat_content, this);
+                case 0x2E:
+                    return std::make_shared<OPCode2E>(addr, dat_content, this);
+                case 0x2F:
+                    return std::make_shared<OPCode2F>(addr, dat_content, this);
+                case 0x30:
+                    return std::make_shared<OPCode30>(addr, dat_content, this);
+                case 0x31:
+                    return std::make_shared<OPCode31>(addr, dat_content, this);
+                case 0x32:
+                    return std::make_shared<OPCode32>(addr, dat_content, this);
+                case 0x33:
+                    return std::make_shared<OPCode33>(addr, dat_content, this);
+                case 0x34:
+                    return std::make_shared<OPCode34>(addr, dat_content, this);
+                case 0x35:
+                    return std::make_shared<OPCode35>(addr, dat_content, this);
+                case 0x36:
+                    return std::make_shared<OPCode36>(addr, dat_content, this);
+                case 0x37:
+                    return std::make_shared<OPCode37>(addr, dat_content, this);
+                case 0x38:
+                    return std::make_shared<OPCode38>(addr, dat_content, this);
+                case 0x39:
+                    return std::make_shared<OPCode39>(addr, dat_content, this);
+                case 0x3A:
+                    return std::make_shared<OPCode3A>(addr, dat_content, this);
+                case 0x3B:
+                    return std::make_shared<OPCode3B>(addr, dat_content, this);
+                case 0x3C:
+                    return std::make_shared<OPCode3C>(addr, dat_content, this);
+                case 0x3D:
+                    return std::make_shared<OPCode3D>(addr, dat_content, this);
+                case 0x3E:
+                    return std::make_shared<OPCode3E>(addr, dat_content, this);
+                case 0x3F:
+                    return std::make_shared<OPCode3F>(addr, dat_content, this);
+                case 0x40:
+                    return std::make_shared<OPCode40>(addr, dat_content, this);
+                case 0x41:
+                    return std::make_shared<OPCode41>(addr, dat_content, this);
+                case 0x42:
+                    return std::make_shared<OPCode42>(addr, dat_content, this);
+                case 0x43:
+                    return std::make_shared<OPCode43>(addr, dat_content, this);
+                case 0x44:
+                    return std::make_shared<OPCode44>(addr, dat_content, this);
+                case 0x45:
+                    return std::make_shared<OPCode45>(addr, dat_content, this);
+                case 0x46:
+                    return std::make_shared<OPCode46>(addr, dat_content, this);
+                case 0x47:
+                    return std::make_shared<OPCode47>(addr, dat_content, this);
+                case 0x48:
+                    return std::make_shared<OPCode48>(addr, dat_content, this);
+                case 0x49:
+                    return std::make_shared<OPCode49>(addr, dat_content, this);
+                case 0x4A:
+                    return std::make_shared<OPCode4A>(addr, dat_content, this);
+                case 0x4B:
+                    return std::make_shared<OPCode4B>(addr, dat_content, this);
+                case 0x4C:
+                    return std::make_shared<OPCode4C>(addr, dat_content, this);
+                case 0x4D:
+                    return std::make_shared<OPCode4D>(addr, dat_content, this);
+                case 0x4E:
+                    return std::make_shared<OPCode4E>(addr, dat_content, this);
+                case 0x4F:
+                    return std::make_shared<OPCode4F>(addr, dat_content, this);
+                case 0x50:
+                    return std::make_shared<OPCode50>(addr, dat_content, this);
+                case 0x51:
+                    return std::make_shared<OPCode51>(addr, dat_content, this);
+                case 0x52:
+                    return std::make_shared<OPCode52>(addr, dat_content, this);
+                case 0x53:
+                    return std::make_shared<OPCode53>(addr, dat_content, this);
+                case 0x54:
+                    return std::make_shared<OPCode54>(addr, dat_content, this);
+                case 0x55:
+                    return std::make_shared<OPCode55>(addr, dat_content, this);
+                case 0x56:
+                    return std::make_shared<OPCode56>(addr, dat_content, this);
+                case 0x57:
+                    return std::make_shared<OPCode57>(addr, dat_content, this);
+                case 0x58:
+                    return std::make_shared<OPCode58>(addr, dat_content, this);
+                case 0x5A:
+                    return std::make_shared<OPCode5A>(addr, dat_content, this);
+                case 0x5B:
+                    return std::make_shared<OPCode5B>(addr, dat_content, this);
+                case 0x5C:
+                    return std::make_shared<OPCode5C>(addr, dat_content, this);
+                case 0x5D:
+                    return std::make_shared<OPCode5D>(addr, dat_content, this);
+                case 0x5E:
+                    return std::make_shared<OPCode5E>(addr, dat_content, this);
+                case 0x60:
+                    return std::make_shared<OPCode60>(addr, dat_content, this);
+                case 0x61:
+                    return std::make_shared<OPCode61>(addr, dat_content, this);
+                case 0x62:
+                    return std::make_shared<OPCode62>(addr, dat_content, this);
+                case 0x63:
+                    return std::make_shared<OPCode63>(addr, dat_content, this);
+                case 0x64:
+                    return std::make_shared<OPCode64>(addr, dat_content, this);
+                case 0x65:
+                    return std::make_shared<OPCode65>(addr, dat_content, this);
+                case 0x66:
+                    return std::make_shared<OPCode66>(addr, dat_content, this);
+                case 0x67:
+                    return std::make_shared<OPCode67>(addr, dat_content, this);
+                case 0x68:
+                    return std::make_shared<OPCode68>(addr, dat_content, this);
+                case 0x69:
+                    return std::make_shared<OPCode69>(addr, dat_content, this);
+                case 0x6A:
+                    return std::make_shared<OPCode6A>(addr, dat_content, this);
+                case 0x6B:
+                    return std::make_shared<OPCode6B>(addr, dat_content, this);
+                case 0x6C:
+                    return std::make_shared<OPCode6C>(addr, dat_content, this);
+                case 0x6E:
+                    return std::make_shared<OPCode6E>(addr, dat_content, this);
+                case 0x6F:
+                    return std::make_shared<OPCode6F>(addr, dat_content, this);
+                case 0x70:
+                    return std::make_shared<OPCode70>(addr, dat_content, this);
+                case 0x72:
+                    return std::make_shared<OPCode72>(addr, dat_content, this);
+                case 0x73:
+                    return std::make_shared<OPCode73>(addr, dat_content, this);
+                case 0x74:
+                    return std::make_shared<OPCode74>(addr, dat_content, this);
+                case 0x75:
+                    return std::make_shared<OPCode75>(addr, dat_content, this);
+                case 0x76:
+                    return std::make_shared<OPCode76>(addr, dat_content, this);
+                case 0x77:
+                    return std::make_shared<OPCode77>(addr, dat_content, this);
+                case 0x78:
+                    return std::make_shared<OPCode78>(addr, dat_content, this);
+                case 0x79:
+                    return std::make_shared<OPCode79>(addr, dat_content, this);
+                case 0x7A:
+                    return std::make_shared<OPCode7A>(addr, dat_content, this);
+                case 0x7B:
+                    return std::make_shared<OPCode7B>(addr, dat_content, this);
+                case 0x7C:
+                    return std::make_shared<OPCode7C>(addr, dat_content, this);
+                case 0x7D:
+                    return std::make_shared<OPCode7D>(addr, dat_content, this);
+                case 0x7E:
+                    return std::make_shared<OPCode7E>(addr, dat_content, this);
+                case 0x80:
+                    return std::make_shared<OPCode80>(addr, dat_content, this);
+                case 0x82:
+                    return std::make_shared<OPCode82>(addr, dat_content, this);
+                case 0x83:
+                    return std::make_shared<OPCode83>(addr, dat_content, this);
+                case 0x84:
+                    return std::make_shared<OPCode84>(addr, dat_content, this);
+                case 0x86:
+                    return std::make_shared<OPCode86>(addr, dat_content, this);
+                case 0x87:
+                    return std::make_shared<OPCode87>(addr, dat_content, this);
+                case 0x88:
+                    return std::make_shared<OPCode88>(addr, dat_content, this);
+                case 0x89:
+                    return std::make_shared<OPCode89>(addr, dat_content, this);
+                case 0x8A:
+                    return std::make_shared<OPCode8A>(addr, dat_content, this);
+                case 0x8B:
+                    return std::make_shared<OPCode8B>(addr, dat_content, this);
+                case 0x8C:
+                    return std::make_shared<OPCode8C>(addr, dat_content, this);
+                case 0x8D:
+                    return std::make_shared<OPCode8D>(addr, dat_content, this);
+                case 0x8E:
+                    return std::make_shared<OPCode8E>(addr, dat_content, this);
+                case 0x8F:
+                    return std::make_shared<OPCode8F>(addr, dat_content, this);
+                case 0x90:
+                    return std::make_shared<OPCode90>(addr, dat_content, this);
+                case 0x91:
+                    return std::make_shared<OPCode91>(addr, dat_content, this);
+                case 0x92:
+                    return std::make_shared<OPCode92>(addr, dat_content, this);
+                case 0x93:
+                    return std::make_shared<OPCode93>(addr, dat_content, this);
+                case 0x94:
+                    return std::make_shared<OPCode94>(addr, dat_content, this);
+                case 0x95:
+                    return std::make_shared<OPCode95>(addr, dat_content, this);
+                case 0x97:
+                    return std::make_shared<OPCode97>(addr, dat_content, this);
+                case 0x98:
+                    return std::make_shared<OPCode98>(addr, dat_content, this);
+                case 0x99:
+                    return std::make_shared<OPCode99>(addr, dat_content, this);
+                case 0x9A:
+                    return std::make_shared<OPCode9A>(addr, dat_content, this);
+                case 0x9B:
+                    return std::make_shared<OPCode9B>(addr, dat_content, this);
+                case 0x9C:
+                    return std::make_shared<OPCode9C>(addr, dat_content, this);
+                case 0x9D:
+                    return std::make_shared<OPCode9D>(addr, dat_content, this);
+                case 0x9E:
+                    return std::make_shared<OPCode9E>(addr, dat_content, this);
+                case 0xA0:
+                    return std::make_shared<OPCodeA0>(addr, dat_content, this);
+                case 0xA1:
+                    return std::make_shared<OPCodeA1>(addr, dat_content, this);
+                case 0xA3:
+                    return std::make_shared<OPCodeA3>(addr, dat_content, this);
+                case 0xA4:
+                    return std::make_shared<OPCodeA4>(addr, dat_content, this);
+                case 0xA6:
+                    return std::make_shared<OPCodeA6>(addr, dat_content, this);
+                case 0xA8:
+                    return std::make_shared<OPCodeA8>(addr, dat_content, this);
+                case 0xA9:
+                    return std::make_shared<OPCodeA9>(addr, dat_content, this);
+                case 0xAA:
+                    return std::make_shared<OPCodeAA>(addr, dat_content, this);
+                case 0xAB:
+                    return std::make_shared<OPCodeAB>(addr, dat_content, this);
+                case 0xAC:
+                    return std::make_shared<OPCodeAC>(addr, dat_content, this);
+                case 0xAD:
+                    return std::make_shared<OPCodeAD>(addr, dat_content, this);
+                case 0xAE:
+                    return std::make_shared<OPCodeAE>(addr, dat_content, this);
+                case 0xAF:
+                    return std::make_shared<OPCodeAF>(addr, dat_content, this);
+                case 0xB1:
+                    return std::make_shared<OPCodeB1>(addr, dat_content, this);
+                case 0xB2:
+                    return std::make_shared<OPCodeB2>(addr, dat_content, this);
+                case 0xB3:
+                    return std::make_shared<OPCodeB3>(addr, dat_content, this);
+                case 0xB4:
+                    return std::make_shared<OPCodeB4>(addr, dat_content, this);
+                case 0xB5:
+                    return std::make_shared<OPCodeB5>(addr, dat_content, this);
+                case 0xB6:
+                    return std::make_shared<OPCodeB6>(addr, dat_content, this);
+                case 0xB7:
+                    return std::make_shared<OPCodeB7>(addr, dat_content, this);
+                case 0xB8:
+                    return std::make_shared<OPCodeB8>(addr, dat_content, this);
+                case 0xB9:
+                    return std::make_shared<OPCodeB9>(addr, dat_content, this);
+                case 0xBA:
+                    return std::make_shared<OPCodeBA>(addr, dat_content, this);
+                case 0xBB:
+                    return std::make_shared<OPCodeBB>(addr, dat_content, this);
+                case 0xBC:
+                    return std::make_shared<OPCodeBC>(addr, dat_content, this);
+                case 0xBE:
+                    return std::make_shared<OPCodeBE>(addr, dat_content, this);
+                case 0xC0:
+                    return std::make_shared<OPCodeC0>(addr, dat_content, this);
+                case 0xC2:
+                    return std::make_shared<OPCodeC2>(addr, dat_content, this);
+                case 0xC3:
+                    return std::make_shared<OPCodeC3>(addr, dat_content, this);
+                case 0xC4:
+                    return std::make_shared<OPCodeC4>(addr, dat_content, this);
+                case 0xC5:
+                    return std::make_shared<OPCodeC5>(addr, dat_content, this);
+                case 0xC6:
+                    return std::make_shared<OPCodeC6>(addr, dat_content, this);
+                case 0xC7:
+                    return std::make_shared<OPCodeC7>(addr, dat_content, this);
+                case 0xC8:
+                    return std::make_shared<OPCodeC8>(addr, dat_content, this);
+                case 0xC9:
+                    return std::make_shared<OPCodeC9>(addr, dat_content, this);
+                case 0xCA:
+                    return std::make_shared<OPCodeCA>(addr, dat_content, this);
+                case 0xCB:
+                    return std::make_shared<OPCodeCB>(addr, dat_content, this);
+                case 0xCC:
+                    return std::make_shared<OPCodeCC>(addr, dat_content, this);
+                case 0xCD:
+                    return std::make_shared<OPCodeCD>(addr, dat_content, this);
+
+                default:
+                    std::stringstream stream;
+                    stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
+                    /*std::string result( stream.str() );
+
+                    qFatal(result.c_str());*/
+                    error = true;
+                    addr++;
+                    return std::shared_ptr<Instruction>();
+            }
+        } else if (function_type == 1) { // the function is a "CreateMonsters" function
+
+            return std::make_shared<CreateMonsters>(addr, dat_content, this);
+        } else if (function_type == 2) { // the function is a "effect" function
+
+            return std::make_shared<EffectsInstr>(addr, dat_content, this);
+        } else if (function_type == 3) {
+
+            return std::make_shared<ActionTable>(addr, dat_content, this);
+        } else if (function_type == 4) {
+
+            return std::make_shared<AlgoTable>(addr, dat_content, this);
+        } else if (function_type == 5) {
+
+            return std::make_shared<WeaponAttTable>(addr, dat_content, this);
+        } else if (function_type == 6) {
+
+            return std::make_shared<BreakTable>(addr, dat_content, this);
+        } else if (function_type == 7) {
+
+            return std::make_shared<SummonTable>(addr, dat_content, this);
+        } else if (function_type == 8) {
+
+            return std::make_shared<ReactionTable>(addr, dat_content, this);
+        } else if (function_type == 9) {
+
+            return std::make_shared<PartTable>(addr, dat_content, this);
+        } else if (function_type == 10) {
+
+            return std::make_shared<AnimeClipTable>(addr, dat_content, this);
+        } else if (function_type == 11) {
+
+            return std::make_shared<FieldMonsterData>(addr, dat_content, this);
+        } else if (function_type == 12) {
+
+            return std::make_shared<FieldFollowData>(addr, dat_content, this);
+        } else if (function_type == 13) {
+
+            return std::make_shared<FC_autoX>(addr, dat_content, this);
+        } else if (function_type == 14) {
+
+            return std::make_shared<BookData99>(addr, dat_content, this);
+        } else if (function_type == 15) {
+
+            return std::make_shared<BookDataX>(addr, dat_content, this);
         }
 
         return std::shared_ptr<Instruction>();
     }
-    bool CreateHeaderFromDAT(QByteArray &dat_content){
+    bool CreateHeaderFromDAT(QByteArray& dat_content) {
 
-        //Header structure:
-        //The first 0x20 is something used to check if the file is a valid file: it will always be that value
-        //The second 0x20 is the offset for the file name (shouldn't change too)
-        //The next integer is the position of the first pointer
-        //The 4th: probably the length in bytes of the pointer section
-        //The fifth: probably the position of the "names positions" section (right after the pointer section)
-        //The sixth: the number of functions inside the file
-        //the seventh: the position one byte after the 0x00 separator at the end of the functions section
-        //the eighth: 0xABCDEF00 => seems to always be there (no idea why)
-        //Then the name of the file
-        //Then the pointer section
-        //Then the "names positions" section
-        //Then the functions section
-        //Done; here the "function" objects holds the number of functions, the addr, name positions
-        //everything else can be deduced to recreate the header
+        // Header structure:
+        // The first 0x20 is something used to check if the file is a valid file: it will always be that value
+        // The second 0x20 is the offset for the file name (shouldn't change too)
+        // The next integer is the position of the first pointer
+        // The 4th: probably the length in bytes of the pointer section
+        // The fifth: probably the position of the "names positions" section (right after the pointer section)
+        // The sixth: the number of functions inside the file
+        // the seventh: the position one byte after the 0x00 separator at the end of the functions section
+        // the eighth: 0xABCDEF00 => seems to always be there (no idea why)
+        // Then the name of the file
+        // Then the pointer section
+        // Then the "names positions" section
+        // Then the functions section
+        // Done; here the "function" objects holds the number of functions, the addr, name positions
+        // everything else can be deduced to recreate the header
         display_text("Reading header...");
         uint nb_functions = ReadIntegerFromByteArray(0x14, dat_content);
         uint position_filename = ReadIntegerFromByteArray(0x4, dat_content);
@@ -6383,233 +6953,431 @@ class CS3Builder : public Builder
         QString filename = ReadStringFromByteArray(position, dat_content);
         SceneName = filename;
         int start_offset_area = ReadIntegerFromByteArray(0x8, dat_content);
-        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++){
-            position = start_offset_area + 4*idx_fun;
-            next_position = start_offset_area + 4*(idx_fun+1);
+        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++) {
+            position = start_offset_area + 4 * idx_fun;
+            next_position = start_offset_area + 4 * (idx_fun + 1);
             int addr = ReadIntegerFromByteArray(position, dat_content);
-            position = start_offset_area + 4*nb_functions + 2 * idx_fun;
+            position = start_offset_area + 4 * nb_functions + 2 * idx_fun;
             short name_pos = ReadShortFromByteArray(position, dat_content);
             int name_pos_int = name_pos;
             QString function_name = ReadStringFromByteArray(name_pos_int, dat_content);
             int end_addr;
-            if (idx_fun == nb_functions-1) //we are at the last function, so it ends at the end of the file
+            if (idx_fun == nb_functions - 1) // we are at the last function, so it ends at the end of the file
                 end_addr = dat_content.size();
-            else
-            {
+            else {
                 end_addr = ReadIntegerFromByteArray(next_position, dat_content);
             }
-            FunctionsToParse.push_back(function(idx_fun,function_name,name_pos,addr,end_addr));
-
+            FunctionsToParse.push_back(function(idx_fun, function_name, name_pos, addr, end_addr));
         }
         display_text("Header parsed.");
         return true;
     }
-    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int &addr, int row, QXlsx::Document &xls_content){
+    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int& addr, int row, QXlsx::Document& xls_content) {
 
-        uint OP = xls_content.read(row+1, 2).toInt();
+        uint OP = xls_content.read(row + 1, 2).toInt();
 
-        switch(OP){
-            case 0x00: return std::make_shared<OPCode0>(addr,row, xls_content,this);
-            case 0x01: return std::make_shared<OPCode1>(addr,row, xls_content,this);
-            case 0x02: return std::make_shared<OPCode2>(addr,row, xls_content,this);
-            case 0x03: return std::make_shared<OPCode3>(addr,row, xls_content,this);
-            case 0x04: return std::make_shared<OPCode4>(addr,row, xls_content,this);
-            case 0x05: return std::make_shared<OPCode5>(addr,row, xls_content,this);
-            case 0x06: return std::make_shared<OPCode6>(addr,row, xls_content,this);
-            case 0x07: return std::make_shared<OPCode7>(addr,row, xls_content,this);
-            case 0x08: return std::make_shared<OPCode8>(addr,row, xls_content,this);
-            case 0x0A: return std::make_shared<OPCodeA>(addr,row, xls_content,this);
-            case 0x0C: return std::make_shared<OPCodeC>(addr,row, xls_content,this);
-            case 0x0D: return std::make_shared<OPCode0D>(addr,row, xls_content,this);
-            case 0x0E: return std::make_shared<OPCodeE>(addr,row, xls_content,this);
-            case 0x10: return std::make_shared<OPCode10>(addr,row, xls_content,this);
-            case 0x11: return std::make_shared<OPCode11>(addr,row, xls_content,this);
-            case 0x12: return std::make_shared<OPCode12>(addr,row, xls_content,this);
-            case 0x13: return std::make_shared<OPCode13>(addr,row, xls_content,this);
-            case 0x14: return std::make_shared<OPCode14>(addr,row, xls_content,this);
-            case 0x15: return std::make_shared<OPCode15>(addr,row, xls_content,this);
-            case 0x16: return std::make_shared<OPCode16>(addr,row, xls_content,this);
-            case 0x17: return std::make_shared<OPCode17>(addr,row, xls_content,this);
-            case 0x18: return std::make_shared<OPCode18>(addr,row, xls_content,this);
-            case 0x1A: return std::make_shared<OPCode1A>(addr,row, xls_content,this);
-            case 0x1D: return std::make_shared<OPCode1D>(addr,row, xls_content,this);
-            case 0x1E: return std::make_shared<OPCode1E>(addr,row, xls_content,this);
-            case 0x1F: return std::make_shared<OPCode1F>(addr,row, xls_content,this);
-            case 0x20: return std::make_shared<OPCode20>(addr,row, xls_content,this);
-            case 0x21: return std::make_shared<OPCode21>(addr,row, xls_content,this);
-            case 0x22: return std::make_shared<OPCode22>(addr,row, xls_content,this);
-            case 0x23: return std::make_shared<OPCode23>(addr,row, xls_content,this);
-            case 0x24: return std::make_shared<OPCode24>(addr,row, xls_content,this);
-            case 0x25: return std::make_shared<OPCode25>(addr,row, xls_content,this);
-            case 0x26: return std::make_shared<OPCode26>(addr,row, xls_content,this);
-            case 0x27: return std::make_shared<OPCode27>(addr,row, xls_content,this);
-            case 0x28: return std::make_shared<OPCode28>(addr,row, xls_content,this);
-            case 0x29: return std::make_shared<OPCode29>(addr,row, xls_content,this);
-            case 0x2A: return std::make_shared<OPCode2A>(addr,row, xls_content,this);
-            case 0x2B: return std::make_shared<OPCode2B>(addr,row, xls_content,this);
-            case 0x2C: return std::make_shared<OPCode2C>(addr,row, xls_content,this);
-            case 0x2D: return std::make_shared<OPCode2D>(addr,row, xls_content,this);
-            case 0x2E: return std::make_shared<OPCode2E>(addr,row, xls_content,this);
-            case 0x2F: return std::make_shared<OPCode2F>(addr,row, xls_content,this);
-            case 0x30: return std::make_shared<OPCode30>(addr,row, xls_content,this);
-            case 0x31: return std::make_shared<OPCode31>(addr,row, xls_content,this);
-            case 0x32: return std::make_shared<OPCode32>(addr,row, xls_content,this);
-            case 0x33: return std::make_shared<OPCode33>(addr,row, xls_content,this);
-            case 0x34: return std::make_shared<OPCode34>(addr,row, xls_content,this);
-            case 0x35: return std::make_shared<OPCode35>(addr,row, xls_content,this);
-            case 0x36: return std::make_shared<OPCode36>(addr,row, xls_content,this);
-            case 0x37: return std::make_shared<OPCode37>(addr,row, xls_content,this);
-            case 0x38: return std::make_shared<OPCode38>(addr,row, xls_content,this);
-            case 0x39: return std::make_shared<OPCode39>(addr,row, xls_content,this);
-            case 0x3A: return std::make_shared<OPCode3A>(addr,row, xls_content,this);
-            case 0x3B: return std::make_shared<OPCode3B>(addr,row, xls_content,this);
-            case 0x3C: return std::make_shared<OPCode3C>(addr,row, xls_content,this);
-            case 0x3D: return std::make_shared<OPCode3D>(addr,row, xls_content,this);
-            case 0x3E: return std::make_shared<OPCode3E>(addr,row, xls_content,this);
-            case 0x3F: return std::make_shared<OPCode3F>(addr,row, xls_content,this);
-            case 0x40: return std::make_shared<OPCode40>(addr,row, xls_content,this);
-            case 0x41: return std::make_shared<OPCode41>(addr,row, xls_content,this);
-            case 0x42: return std::make_shared<OPCode42>(addr,row, xls_content,this);
-            case 0x43: return std::make_shared<OPCode43>(addr,row, xls_content,this);
-            case 0x44: return std::make_shared<OPCode44>(addr,row, xls_content,this);
-            case 0x45: return std::make_shared<OPCode45>(addr,row, xls_content,this);
-            case 0x46: return std::make_shared<OPCode46>(addr,row, xls_content,this);
-            case 0x47: return std::make_shared<OPCode47>(addr,row, xls_content,this);
-            case 0x48: return std::make_shared<OPCode48>(addr,row, xls_content,this);
-            case 0x49: return std::make_shared<OPCode49>(addr,row, xls_content,this);
-            case 0x4A: return std::make_shared<OPCode4A>(addr,row, xls_content,this);
-            case 0x4B: return std::make_shared<OPCode4B>(addr,row, xls_content,this);
-            case 0x4C: return std::make_shared<OPCode4C>(addr,row, xls_content,this);
-            case 0x4D: return std::make_shared<OPCode4D>(addr,row, xls_content,this);
-            case 0x4E: return std::make_shared<OPCode4E>(addr,row, xls_content,this);
-            case 0x4F: return std::make_shared<OPCode4F>(addr,row, xls_content,this);
-            case 0x50: return std::make_shared<OPCode50>(addr,row, xls_content,this);
-            case 0x51: return std::make_shared<OPCode51>(addr,row, xls_content,this);
-            case 0x52: return std::make_shared<OPCode52>(addr,row, xls_content,this);
-            case 0x53: return std::make_shared<OPCode53>(addr,row, xls_content,this);
-            case 0x54: return std::make_shared<OPCode54>(addr,row, xls_content,this);
-            case 0x55: return std::make_shared<OPCode55>(addr,row, xls_content,this);
-            case 0x56: return std::make_shared<OPCode56>(addr,row, xls_content,this);
-            case 0x57: return std::make_shared<OPCode57>(addr,row, xls_content,this);
-            case 0x58: return std::make_shared<OPCode58>(addr,row, xls_content,this);
-            case 0x5A: return std::make_shared<OPCode5A>(addr,row, xls_content,this);
-            case 0x5B: return std::make_shared<OPCode5B>(addr,row, xls_content,this);
-            case 0x5C: return std::make_shared<OPCode5C>(addr,row, xls_content,this);
-            case 0x5D: return std::make_shared<OPCode5D>(addr,row, xls_content,this);
-            case 0x5E: return std::make_shared<OPCode5E>(addr,row, xls_content,this);
-            case 0x60: return std::make_shared<OPCode60>(addr,row, xls_content,this);
-            case 0x61: return std::make_shared<OPCode61>(addr,row, xls_content,this);
-            case 0x62: return std::make_shared<OPCode62>(addr,row, xls_content,this);
-            case 0x63: return std::make_shared<OPCode63>(addr,row, xls_content,this);
-            case 0x64: return std::make_shared<OPCode64>(addr,row, xls_content,this);
-            case 0x65: return std::make_shared<OPCode65>(addr,row, xls_content,this);
-            case 0x66: return std::make_shared<OPCode66>(addr,row, xls_content,this);
-            case 0x67: return std::make_shared<OPCode67>(addr,row, xls_content,this);
-            case 0x68: return std::make_shared<OPCode68>(addr,row, xls_content,this);
-            case 0x69: return std::make_shared<OPCode69>(addr,row, xls_content,this);
-            case 0x6A: return std::make_shared<OPCode6A>(addr,row, xls_content,this);
-            case 0x6B: return std::make_shared<OPCode6B>(addr,row, xls_content,this);
-            case 0x6C: return std::make_shared<OPCode6C>(addr,row, xls_content,this);
-            case 0x6E: return std::make_shared<OPCode6E>(addr,row, xls_content,this);
-            case 0x6F: return std::make_shared<OPCode6F>(addr,row, xls_content,this);
-            case 0x70: return std::make_shared<OPCode70>(addr,row, xls_content,this);
-            case 0x72: return std::make_shared<OPCode72>(addr,row, xls_content,this);
-            case 0x73: return std::make_shared<OPCode74>(addr,row, xls_content,this);
-            case 0x74: return std::make_shared<OPCode74>(addr,row, xls_content,this);
-            case 0x75: return std::make_shared<OPCode75>(addr,row, xls_content,this);
-            case 0x76: return std::make_shared<OPCode76>(addr,row, xls_content,this);
-            case 0x77: return std::make_shared<OPCode77>(addr,row, xls_content,this);
-            case 0x78: return std::make_shared<OPCode78>(addr,row, xls_content,this);
-            case 0x79: return std::make_shared<OPCode79>(addr,row, xls_content,this);
-            case 0x7A: return std::make_shared<OPCode7A>(addr,row, xls_content,this);
-            case 0x7B: return std::make_shared<OPCode7B>(addr,row, xls_content,this);
-            case 0x7C: return std::make_shared<OPCode7C>(addr,row, xls_content,this);
-            case 0x7D: return std::make_shared<OPCode7D>(addr,row, xls_content,this);
-            case 0x7E: return std::make_shared<OPCode7E>(addr,row, xls_content,this);
-            case 0x80: return std::make_shared<OPCode80>(addr,row, xls_content,this);
-            case 0x82: return std::make_shared<OPCode82>(addr,row, xls_content,this);
-            case 0x83: return std::make_shared<OPCode83>(addr,row, xls_content,this);
-            case 0x84: return std::make_shared<OPCode84>(addr,row, xls_content,this);
-            case 0x86: return std::make_shared<OPCode86>(addr,row, xls_content,this);
-            case 0x87: return std::make_shared<OPCode87>(addr,row, xls_content,this);
-            case 0x88: return std::make_shared<OPCode88>(addr,row, xls_content,this);
-            case 0x89: return std::make_shared<OPCode89>(addr,row, xls_content,this);
-            case 0x8A: return std::make_shared<OPCode8A>(addr,row, xls_content,this);
-            case 0x8B: return std::make_shared<OPCode8B>(addr,row, xls_content,this);
-            case 0x8C: return std::make_shared<OPCode8C>(addr,row, xls_content,this);
-            case 0x8D: return std::make_shared<OPCode8D>(addr,row, xls_content,this);
-            case 0x8E: return std::make_shared<OPCode8E>(addr,row, xls_content,this);
-            case 0x8F: return std::make_shared<OPCode8F>(addr,row, xls_content,this);
-            case 0x90: return std::make_shared<OPCode90>(addr,row, xls_content,this);
-            case 0x91: return std::make_shared<OPCode91>(addr,row, xls_content,this);
-            case 0x92: return std::make_shared<OPCode92>(addr,row, xls_content,this);
-            case 0x93: return std::make_shared<OPCode93>(addr,row, xls_content,this);
-            case 0x94: return std::make_shared<OPCode94>(addr,row, xls_content,this);
-            case 0x95: return std::make_shared<OPCode95>(addr,row, xls_content,this);
-            case 0x97: return std::make_shared<OPCode97>(addr,row, xls_content,this);
-            case 0x98: return std::make_shared<OPCode98>(addr,row, xls_content,this);
-            case 0x99: return std::make_shared<OPCode99>(addr,row, xls_content,this);
-            case 0x9A: return std::make_shared<OPCode9A>(addr,row, xls_content,this);
-            case 0x9B: return std::make_shared<OPCode9B>(addr,row, xls_content,this);
-            case 0x9C: return std::make_shared<OPCode9C>(addr,row, xls_content,this);
-            case 0x9D: return std::make_shared<OPCode9D>(addr,row, xls_content,this);
-            case 0x9E: return std::make_shared<OPCode9E>(addr,row, xls_content,this);
-            case 0xA0: return std::make_shared<OPCodeA0>(addr,row, xls_content,this);
-            case 0xA1: return std::make_shared<OPCodeA1>(addr,row, xls_content,this);
-            case 0xA3: return std::make_shared<OPCodeA3>(addr,row, xls_content,this);
-            case 0xA4: return std::make_shared<OPCodeA4>(addr,row, xls_content,this);
-            case 0xA6: return std::make_shared<OPCodeA6>(addr,row, xls_content,this);
-            case 0xA8: return std::make_shared<OPCodeA8>(addr,row, xls_content,this);
-            case 0xA9: return std::make_shared<OPCodeA9>(addr,row, xls_content,this);
-            case 0xAA: return std::make_shared<OPCodeAA>(addr,row, xls_content,this);
-            case 0xAB: return std::make_shared<OPCodeAB>(addr,row, xls_content,this);
-            case 0xAC: return std::make_shared<OPCodeAC>(addr,row, xls_content,this);
-            case 0xAD: return std::make_shared<OPCodeAD>(addr,row, xls_content,this);
-            case 0xAE: return std::make_shared<OPCodeAE>(addr,row, xls_content,this);
-            case 0xAF: return std::make_shared<OPCodeAF>(addr,row, xls_content,this);
-            case 0xB1: return std::make_shared<OPCodeB1>(addr,row, xls_content,this);
-            case 0xB2: return std::make_shared<OPCodeB2>(addr,row, xls_content,this);
-            case 0xB3: return std::make_shared<OPCodeB3>(addr,row, xls_content,this);
-            case 0xB4: return std::make_shared<OPCodeB4>(addr,row, xls_content,this);
-            case 0xB5: return std::make_shared<OPCodeB5>(addr,row, xls_content,this);
-            case 0xB6: return std::make_shared<OPCodeB6>(addr,row, xls_content,this);
-            case 0xB7: return std::make_shared<OPCodeB7>(addr,row, xls_content,this);
-            case 0xB8: return std::make_shared<OPCodeB8>(addr,row, xls_content,this);
-            case 0xB9: return std::make_shared<OPCodeB9>(addr,row, xls_content,this);
-            case 0xBA: return std::make_shared<OPCodeBA>(addr,row, xls_content,this);
-            case 0xBB: return std::make_shared<OPCodeBB>(addr,row, xls_content,this);
-            case 0xBC: return std::make_shared<OPCodeBC>(addr,row, xls_content,this);
-            case 0xBE: return std::make_shared<OPCodeBE>(addr,row, xls_content,this);
-            case 0xC0: return std::make_shared<OPCodeC0>(addr,row, xls_content,this);
-            case 0xC2: return std::make_shared<OPCodeC2>(addr,row, xls_content,this);
-            case 0xC3: return std::make_shared<OPCodeC3>(addr,row, xls_content,this);
-            case 0xC4: return std::make_shared<OPCodeC4>(addr,row, xls_content,this);
-            case 0xC5: return std::make_shared<OPCodeC5>(addr,row, xls_content,this);
-            case 0xC6: return std::make_shared<OPCodeC6>(addr,row, xls_content,this);
-            case 0xC7: return std::make_shared<OPCodeC7>(addr,row, xls_content,this);
-            case 0xC8: return std::make_shared<OPCodeC8>(addr,row, xls_content,this);
-            case 0xC9: return std::make_shared<OPCodeC9>(addr,row, xls_content,this);
-            case 0xCA: return std::make_shared<OPCodeCA>(addr,row, xls_content,this);
-            case 0xCB: return std::make_shared<OPCodeCB>(addr,row, xls_content,this);
-            case 0xCC: return std::make_shared<OPCodeCC>(addr,row, xls_content,this);
-            case 0xCD: return std::make_shared<OPCodeCD>(addr,row, xls_content,this);
+        switch (OP) {
+            case 0x00:
+                return std::make_shared<OPCode0>(addr, row, xls_content, this);
+            case 0x01:
+                return std::make_shared<OPCode1>(addr, row, xls_content, this);
+            case 0x02:
+                return std::make_shared<OPCode2>(addr, row, xls_content, this);
+            case 0x03:
+                return std::make_shared<OPCode3>(addr, row, xls_content, this);
+            case 0x04:
+                return std::make_shared<OPCode4>(addr, row, xls_content, this);
+            case 0x05:
+                return std::make_shared<OPCode5>(addr, row, xls_content, this);
+            case 0x06:
+                return std::make_shared<OPCode6>(addr, row, xls_content, this);
+            case 0x07:
+                return std::make_shared<OPCode7>(addr, row, xls_content, this);
+            case 0x08:
+                return std::make_shared<OPCode8>(addr, row, xls_content, this);
+            case 0x0A:
+                return std::make_shared<OPCodeA>(addr, row, xls_content, this);
+            case 0x0C:
+                return std::make_shared<OPCodeC>(addr, row, xls_content, this);
+            case 0x0D:
+                return std::make_shared<OPCode0D>(addr, row, xls_content, this);
+            case 0x0E:
+                return std::make_shared<OPCodeE>(addr, row, xls_content, this);
+            case 0x10:
+                return std::make_shared<OPCode10>(addr, row, xls_content, this);
+            case 0x11:
+                return std::make_shared<OPCode11>(addr, row, xls_content, this);
+            case 0x12:
+                return std::make_shared<OPCode12>(addr, row, xls_content, this);
+            case 0x13:
+                return std::make_shared<OPCode13>(addr, row, xls_content, this);
+            case 0x14:
+                return std::make_shared<OPCode14>(addr, row, xls_content, this);
+            case 0x15:
+                return std::make_shared<OPCode15>(addr, row, xls_content, this);
+            case 0x16:
+                return std::make_shared<OPCode16>(addr, row, xls_content, this);
+            case 0x17:
+                return std::make_shared<OPCode17>(addr, row, xls_content, this);
+            case 0x18:
+                return std::make_shared<OPCode18>(addr, row, xls_content, this);
+            case 0x1A:
+                return std::make_shared<OPCode1A>(addr, row, xls_content, this);
+            case 0x1D:
+                return std::make_shared<OPCode1D>(addr, row, xls_content, this);
+            case 0x1E:
+                return std::make_shared<OPCode1E>(addr, row, xls_content, this);
+            case 0x1F:
+                return std::make_shared<OPCode1F>(addr, row, xls_content, this);
+            case 0x20:
+                return std::make_shared<OPCode20>(addr, row, xls_content, this);
+            case 0x21:
+                return std::make_shared<OPCode21>(addr, row, xls_content, this);
+            case 0x22:
+                return std::make_shared<OPCode22>(addr, row, xls_content, this);
+            case 0x23:
+                return std::make_shared<OPCode23>(addr, row, xls_content, this);
+            case 0x24:
+                return std::make_shared<OPCode24>(addr, row, xls_content, this);
+            case 0x25:
+                return std::make_shared<OPCode25>(addr, row, xls_content, this);
+            case 0x26:
+                return std::make_shared<OPCode26>(addr, row, xls_content, this);
+            case 0x27:
+                return std::make_shared<OPCode27>(addr, row, xls_content, this);
+            case 0x28:
+                return std::make_shared<OPCode28>(addr, row, xls_content, this);
+            case 0x29:
+                return std::make_shared<OPCode29>(addr, row, xls_content, this);
+            case 0x2A:
+                return std::make_shared<OPCode2A>(addr, row, xls_content, this);
+            case 0x2B:
+                return std::make_shared<OPCode2B>(addr, row, xls_content, this);
+            case 0x2C:
+                return std::make_shared<OPCode2C>(addr, row, xls_content, this);
+            case 0x2D:
+                return std::make_shared<OPCode2D>(addr, row, xls_content, this);
+            case 0x2E:
+                return std::make_shared<OPCode2E>(addr, row, xls_content, this);
+            case 0x2F:
+                return std::make_shared<OPCode2F>(addr, row, xls_content, this);
+            case 0x30:
+                return std::make_shared<OPCode30>(addr, row, xls_content, this);
+            case 0x31:
+                return std::make_shared<OPCode31>(addr, row, xls_content, this);
+            case 0x32:
+                return std::make_shared<OPCode32>(addr, row, xls_content, this);
+            case 0x33:
+                return std::make_shared<OPCode33>(addr, row, xls_content, this);
+            case 0x34:
+                return std::make_shared<OPCode34>(addr, row, xls_content, this);
+            case 0x35:
+                return std::make_shared<OPCode35>(addr, row, xls_content, this);
+            case 0x36:
+                return std::make_shared<OPCode36>(addr, row, xls_content, this);
+            case 0x37:
+                return std::make_shared<OPCode37>(addr, row, xls_content, this);
+            case 0x38:
+                return std::make_shared<OPCode38>(addr, row, xls_content, this);
+            case 0x39:
+                return std::make_shared<OPCode39>(addr, row, xls_content, this);
+            case 0x3A:
+                return std::make_shared<OPCode3A>(addr, row, xls_content, this);
+            case 0x3B:
+                return std::make_shared<OPCode3B>(addr, row, xls_content, this);
+            case 0x3C:
+                return std::make_shared<OPCode3C>(addr, row, xls_content, this);
+            case 0x3D:
+                return std::make_shared<OPCode3D>(addr, row, xls_content, this);
+            case 0x3E:
+                return std::make_shared<OPCode3E>(addr, row, xls_content, this);
+            case 0x3F:
+                return std::make_shared<OPCode3F>(addr, row, xls_content, this);
+            case 0x40:
+                return std::make_shared<OPCode40>(addr, row, xls_content, this);
+            case 0x41:
+                return std::make_shared<OPCode41>(addr, row, xls_content, this);
+            case 0x42:
+                return std::make_shared<OPCode42>(addr, row, xls_content, this);
+            case 0x43:
+                return std::make_shared<OPCode43>(addr, row, xls_content, this);
+            case 0x44:
+                return std::make_shared<OPCode44>(addr, row, xls_content, this);
+            case 0x45:
+                return std::make_shared<OPCode45>(addr, row, xls_content, this);
+            case 0x46:
+                return std::make_shared<OPCode46>(addr, row, xls_content, this);
+            case 0x47:
+                return std::make_shared<OPCode47>(addr, row, xls_content, this);
+            case 0x48:
+                return std::make_shared<OPCode48>(addr, row, xls_content, this);
+            case 0x49:
+                return std::make_shared<OPCode49>(addr, row, xls_content, this);
+            case 0x4A:
+                return std::make_shared<OPCode4A>(addr, row, xls_content, this);
+            case 0x4B:
+                return std::make_shared<OPCode4B>(addr, row, xls_content, this);
+            case 0x4C:
+                return std::make_shared<OPCode4C>(addr, row, xls_content, this);
+            case 0x4D:
+                return std::make_shared<OPCode4D>(addr, row, xls_content, this);
+            case 0x4E:
+                return std::make_shared<OPCode4E>(addr, row, xls_content, this);
+            case 0x4F:
+                return std::make_shared<OPCode4F>(addr, row, xls_content, this);
+            case 0x50:
+                return std::make_shared<OPCode50>(addr, row, xls_content, this);
+            case 0x51:
+                return std::make_shared<OPCode51>(addr, row, xls_content, this);
+            case 0x52:
+                return std::make_shared<OPCode52>(addr, row, xls_content, this);
+            case 0x53:
+                return std::make_shared<OPCode53>(addr, row, xls_content, this);
+            case 0x54:
+                return std::make_shared<OPCode54>(addr, row, xls_content, this);
+            case 0x55:
+                return std::make_shared<OPCode55>(addr, row, xls_content, this);
+            case 0x56:
+                return std::make_shared<OPCode56>(addr, row, xls_content, this);
+            case 0x57:
+                return std::make_shared<OPCode57>(addr, row, xls_content, this);
+            case 0x58:
+                return std::make_shared<OPCode58>(addr, row, xls_content, this);
+            case 0x5A:
+                return std::make_shared<OPCode5A>(addr, row, xls_content, this);
+            case 0x5B:
+                return std::make_shared<OPCode5B>(addr, row, xls_content, this);
+            case 0x5C:
+                return std::make_shared<OPCode5C>(addr, row, xls_content, this);
+            case 0x5D:
+                return std::make_shared<OPCode5D>(addr, row, xls_content, this);
+            case 0x5E:
+                return std::make_shared<OPCode5E>(addr, row, xls_content, this);
+            case 0x60:
+                return std::make_shared<OPCode60>(addr, row, xls_content, this);
+            case 0x61:
+                return std::make_shared<OPCode61>(addr, row, xls_content, this);
+            case 0x62:
+                return std::make_shared<OPCode62>(addr, row, xls_content, this);
+            case 0x63:
+                return std::make_shared<OPCode63>(addr, row, xls_content, this);
+            case 0x64:
+                return std::make_shared<OPCode64>(addr, row, xls_content, this);
+            case 0x65:
+                return std::make_shared<OPCode65>(addr, row, xls_content, this);
+            case 0x66:
+                return std::make_shared<OPCode66>(addr, row, xls_content, this);
+            case 0x67:
+                return std::make_shared<OPCode67>(addr, row, xls_content, this);
+            case 0x68:
+                return std::make_shared<OPCode68>(addr, row, xls_content, this);
+            case 0x69:
+                return std::make_shared<OPCode69>(addr, row, xls_content, this);
+            case 0x6A:
+                return std::make_shared<OPCode6A>(addr, row, xls_content, this);
+            case 0x6B:
+                return std::make_shared<OPCode6B>(addr, row, xls_content, this);
+            case 0x6C:
+                return std::make_shared<OPCode6C>(addr, row, xls_content, this);
+            case 0x6E:
+                return std::make_shared<OPCode6E>(addr, row, xls_content, this);
+            case 0x6F:
+                return std::make_shared<OPCode6F>(addr, row, xls_content, this);
+            case 0x70:
+                return std::make_shared<OPCode70>(addr, row, xls_content, this);
+            case 0x72:
+                return std::make_shared<OPCode72>(addr, row, xls_content, this);
+            case 0x73:
+                return std::make_shared<OPCode74>(addr, row, xls_content, this);
+            case 0x74:
+                return std::make_shared<OPCode74>(addr, row, xls_content, this);
+            case 0x75:
+                return std::make_shared<OPCode75>(addr, row, xls_content, this);
+            case 0x76:
+                return std::make_shared<OPCode76>(addr, row, xls_content, this);
+            case 0x77:
+                return std::make_shared<OPCode77>(addr, row, xls_content, this);
+            case 0x78:
+                return std::make_shared<OPCode78>(addr, row, xls_content, this);
+            case 0x79:
+                return std::make_shared<OPCode79>(addr, row, xls_content, this);
+            case 0x7A:
+                return std::make_shared<OPCode7A>(addr, row, xls_content, this);
+            case 0x7B:
+                return std::make_shared<OPCode7B>(addr, row, xls_content, this);
+            case 0x7C:
+                return std::make_shared<OPCode7C>(addr, row, xls_content, this);
+            case 0x7D:
+                return std::make_shared<OPCode7D>(addr, row, xls_content, this);
+            case 0x7E:
+                return std::make_shared<OPCode7E>(addr, row, xls_content, this);
+            case 0x80:
+                return std::make_shared<OPCode80>(addr, row, xls_content, this);
+            case 0x82:
+                return std::make_shared<OPCode82>(addr, row, xls_content, this);
+            case 0x83:
+                return std::make_shared<OPCode83>(addr, row, xls_content, this);
+            case 0x84:
+                return std::make_shared<OPCode84>(addr, row, xls_content, this);
+            case 0x86:
+                return std::make_shared<OPCode86>(addr, row, xls_content, this);
+            case 0x87:
+                return std::make_shared<OPCode87>(addr, row, xls_content, this);
+            case 0x88:
+                return std::make_shared<OPCode88>(addr, row, xls_content, this);
+            case 0x89:
+                return std::make_shared<OPCode89>(addr, row, xls_content, this);
+            case 0x8A:
+                return std::make_shared<OPCode8A>(addr, row, xls_content, this);
+            case 0x8B:
+                return std::make_shared<OPCode8B>(addr, row, xls_content, this);
+            case 0x8C:
+                return std::make_shared<OPCode8C>(addr, row, xls_content, this);
+            case 0x8D:
+                return std::make_shared<OPCode8D>(addr, row, xls_content, this);
+            case 0x8E:
+                return std::make_shared<OPCode8E>(addr, row, xls_content, this);
+            case 0x8F:
+                return std::make_shared<OPCode8F>(addr, row, xls_content, this);
+            case 0x90:
+                return std::make_shared<OPCode90>(addr, row, xls_content, this);
+            case 0x91:
+                return std::make_shared<OPCode91>(addr, row, xls_content, this);
+            case 0x92:
+                return std::make_shared<OPCode92>(addr, row, xls_content, this);
+            case 0x93:
+                return std::make_shared<OPCode93>(addr, row, xls_content, this);
+            case 0x94:
+                return std::make_shared<OPCode94>(addr, row, xls_content, this);
+            case 0x95:
+                return std::make_shared<OPCode95>(addr, row, xls_content, this);
+            case 0x97:
+                return std::make_shared<OPCode97>(addr, row, xls_content, this);
+            case 0x98:
+                return std::make_shared<OPCode98>(addr, row, xls_content, this);
+            case 0x99:
+                return std::make_shared<OPCode99>(addr, row, xls_content, this);
+            case 0x9A:
+                return std::make_shared<OPCode9A>(addr, row, xls_content, this);
+            case 0x9B:
+                return std::make_shared<OPCode9B>(addr, row, xls_content, this);
+            case 0x9C:
+                return std::make_shared<OPCode9C>(addr, row, xls_content, this);
+            case 0x9D:
+                return std::make_shared<OPCode9D>(addr, row, xls_content, this);
+            case 0x9E:
+                return std::make_shared<OPCode9E>(addr, row, xls_content, this);
+            case 0xA0:
+                return std::make_shared<OPCodeA0>(addr, row, xls_content, this);
+            case 0xA1:
+                return std::make_shared<OPCodeA1>(addr, row, xls_content, this);
+            case 0xA3:
+                return std::make_shared<OPCodeA3>(addr, row, xls_content, this);
+            case 0xA4:
+                return std::make_shared<OPCodeA4>(addr, row, xls_content, this);
+            case 0xA6:
+                return std::make_shared<OPCodeA6>(addr, row, xls_content, this);
+            case 0xA8:
+                return std::make_shared<OPCodeA8>(addr, row, xls_content, this);
+            case 0xA9:
+                return std::make_shared<OPCodeA9>(addr, row, xls_content, this);
+            case 0xAA:
+                return std::make_shared<OPCodeAA>(addr, row, xls_content, this);
+            case 0xAB:
+                return std::make_shared<OPCodeAB>(addr, row, xls_content, this);
+            case 0xAC:
+                return std::make_shared<OPCodeAC>(addr, row, xls_content, this);
+            case 0xAD:
+                return std::make_shared<OPCodeAD>(addr, row, xls_content, this);
+            case 0xAE:
+                return std::make_shared<OPCodeAE>(addr, row, xls_content, this);
+            case 0xAF:
+                return std::make_shared<OPCodeAF>(addr, row, xls_content, this);
+            case 0xB1:
+                return std::make_shared<OPCodeB1>(addr, row, xls_content, this);
+            case 0xB2:
+                return std::make_shared<OPCodeB2>(addr, row, xls_content, this);
+            case 0xB3:
+                return std::make_shared<OPCodeB3>(addr, row, xls_content, this);
+            case 0xB4:
+                return std::make_shared<OPCodeB4>(addr, row, xls_content, this);
+            case 0xB5:
+                return std::make_shared<OPCodeB5>(addr, row, xls_content, this);
+            case 0xB6:
+                return std::make_shared<OPCodeB6>(addr, row, xls_content, this);
+            case 0xB7:
+                return std::make_shared<OPCodeB7>(addr, row, xls_content, this);
+            case 0xB8:
+                return std::make_shared<OPCodeB8>(addr, row, xls_content, this);
+            case 0xB9:
+                return std::make_shared<OPCodeB9>(addr, row, xls_content, this);
+            case 0xBA:
+                return std::make_shared<OPCodeBA>(addr, row, xls_content, this);
+            case 0xBB:
+                return std::make_shared<OPCodeBB>(addr, row, xls_content, this);
+            case 0xBC:
+                return std::make_shared<OPCodeBC>(addr, row, xls_content, this);
+            case 0xBE:
+                return std::make_shared<OPCodeBE>(addr, row, xls_content, this);
+            case 0xC0:
+                return std::make_shared<OPCodeC0>(addr, row, xls_content, this);
+            case 0xC2:
+                return std::make_shared<OPCodeC2>(addr, row, xls_content, this);
+            case 0xC3:
+                return std::make_shared<OPCodeC3>(addr, row, xls_content, this);
+            case 0xC4:
+                return std::make_shared<OPCodeC4>(addr, row, xls_content, this);
+            case 0xC5:
+                return std::make_shared<OPCodeC5>(addr, row, xls_content, this);
+            case 0xC6:
+                return std::make_shared<OPCodeC6>(addr, row, xls_content, this);
+            case 0xC7:
+                return std::make_shared<OPCodeC7>(addr, row, xls_content, this);
+            case 0xC8:
+                return std::make_shared<OPCodeC8>(addr, row, xls_content, this);
+            case 0xC9:
+                return std::make_shared<OPCodeC9>(addr, row, xls_content, this);
+            case 0xCA:
+                return std::make_shared<OPCodeCA>(addr, row, xls_content, this);
+            case 0xCB:
+                return std::make_shared<OPCodeCB>(addr, row, xls_content, this);
+            case 0xCC:
+                return std::make_shared<OPCodeCC>(addr, row, xls_content, this);
+            case 0xCD:
+                return std::make_shared<OPCodeCD>(addr, row, xls_content, this);
 
-            case 256: return std::make_shared<CreateMonsters>(addr, row, xls_content,this);
-            case 257: return std::make_shared<EffectsInstr>(addr, row, xls_content,this);
-            case 258: return std::make_shared<ActionTable>(addr, row, xls_content,this);
-            case 259: return std::make_shared<AlgoTable>(addr, row, xls_content,this);
-            case 260: return std::make_shared<WeaponAttTable>(addr, row, xls_content,this);
-            case 261: return std::make_shared<BreakTable>(addr, row, xls_content,this);
-            case 262: return std::make_shared<SummonTable>(addr, row, xls_content,this);
-            case 263: return std::make_shared<ReactionTable>(addr, row, xls_content,this);
-            case 264: return std::make_shared<PartTable>(addr, row, xls_content,this);
-            case 265: return std::make_shared<AnimeClipTable>(addr, row, xls_content,this);
-            case 266: return std::make_shared<FieldMonsterData>(addr, row, xls_content,this);
-            case 267: return std::make_shared<FieldFollowData>(addr, row, xls_content,this);
-            case 268: return std::make_shared<FC_autoX>(addr, row, xls_content,this);
-            case 269: return std::make_shared<BookData99>(addr, row, xls_content,this);
-            case 270: return std::make_shared<BookDataX>(addr, row, xls_content,this);
-            case 273: return std::make_shared<AnimeClipData>(addr, row, xls_content,this);
+            case 256:
+                return std::make_shared<CreateMonsters>(addr, row, xls_content, this);
+            case 257:
+                return std::make_shared<EffectsInstr>(addr, row, xls_content, this);
+            case 258:
+                return std::make_shared<ActionTable>(addr, row, xls_content, this);
+            case 259:
+                return std::make_shared<AlgoTable>(addr, row, xls_content, this);
+            case 260:
+                return std::make_shared<WeaponAttTable>(addr, row, xls_content, this);
+            case 261:
+                return std::make_shared<BreakTable>(addr, row, xls_content, this);
+            case 262:
+                return std::make_shared<SummonTable>(addr, row, xls_content, this);
+            case 263:
+                return std::make_shared<ReactionTable>(addr, row, xls_content, this);
+            case 264:
+                return std::make_shared<PartTable>(addr, row, xls_content, this);
+            case 265:
+                return std::make_shared<AnimeClipTable>(addr, row, xls_content, this);
+            case 266:
+                return std::make_shared<FieldMonsterData>(addr, row, xls_content, this);
+            case 267:
+                return std::make_shared<FieldFollowData>(addr, row, xls_content, this);
+            case 268:
+                return std::make_shared<FC_autoX>(addr, row, xls_content, this);
+            case 269:
+                return std::make_shared<BookData99>(addr, row, xls_content, this);
+            case 270:
+                return std::make_shared<BookDataX>(addr, row, xls_content, this);
+            case 273:
+                return std::make_shared<AnimeClipData>(addr, row, xls_content, this);
             default:
                 std::stringstream stream;
                 stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << this->SceneName.toStdString();
@@ -6622,8 +7390,7 @@ class CS3Builder : public Builder
         }
     }
 
-
-    QByteArray CreateHeaderBytes(){
+    QByteArray CreateHeaderBytes() {
 
         QByteArray header;
 
@@ -6632,44 +7399,43 @@ class CS3Builder : public Builder
         int size_of_scene_name = scene_name_bytes.length();
         header.append(GetBytesFromInt(0x20));
         header.append(GetBytesFromInt(0x20));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name));
-        header.append(GetBytesFromInt(FunctionsParsed.size()*4));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name));
+        header.append(GetBytesFromInt(FunctionsParsed.size() * 4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4));
         header.append(GetBytesFromInt(FunctionsParsed.size()));
         int length_of_names_section = 0;
-        for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + length_of_names_section));
+        for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++)
+            length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
+        header.append(
+          GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + length_of_names_section));
         header.append(GetBytesFromInt(0xABCDEF00));
         header.append(scene_name_bytes);
-        if (FunctionsParsed.size()>0){
+        if (FunctionsParsed.size() > 0) {
             QByteArray position_names;
             QByteArray actual_names;
             int offset_names = 0;
-            for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) {
+            for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++) {
                 header.append(GetBytesFromInt(FunctionsParsed[idx_fun].actual_addr));
                 QByteArray name = FunctionsParsed[idx_fun].name.toUtf8();
                 name.append('\x0');
-                position_names.append(GetBytesFromShort(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + offset_names));
+                position_names.append(
+                  GetBytesFromShort(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + offset_names));
                 actual_names.append(name);
                 offset_names = offset_names + name.size();
-
-
             }
             header.append(position_names);
             header.append(actual_names);
             int multiple = 4;
             if (FunctionsParsed[0].name.startsWith("_")) multiple = 0x10;
-            int nb_byte_to_add = (((int) ceil((float)header.size()/multiple)))*multiple - header.size();
+            int nb_byte_to_add = (((int)ceil((float)header.size() / multiple))) * multiple - header.size();
             QByteArray remaining;
-            for (int i = 0; i < nb_byte_to_add;i++) {
+            for (int i = 0; i < nb_byte_to_add; i++) {
                 remaining.push_back('\x0');
             }
             header.append(remaining);
         }
         return header;
     }
-
 };
-
 
 #endif // CS3INSTRUCTIONSSET_H

--- a/headers/CS4InstructionsSet.h
+++ b/headers/CS4InstructionsSet.h
@@ -1,184 +1,170 @@
 #ifndef CS4INSTRUCTIONSSET_H
 #define CS4INSTRUCTIONSSET_H
-#include "headers/utilities.h"
 #include "headers/functions.h"
 #include "headers/translationfile.h"
+#include "headers/utilities.h"
 
 #include <QString>
 
-
-
-class CS4TranslationFile : public TranslationFile
-{
-    public:
-    CS4TranslationFile():TranslationFile(){}
-
+class CS4TranslationFile : public TranslationFile {
+  public:
+    CS4TranslationFile()
+      : TranslationFile() {}
 };
-class CS4Builder : public Builder
-{
-    public:
-    CS4Builder(){
-
-    }
-    int add_operandes(int &addr, QByteArray &content, Instruction * instr, int size){
+class CS4Builder : public Builder {
+  public:
+    CS4Builder() {}
+    int add_operandes(int& addr, QByteArray& content, Instruction* instr, int size) {
         int plVar15 = addr;
         int lVar5, lVar7;
         lVar7 = -1;
         do {
-          instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-          lVar5 = lVar7 + size;
-          lVar7 = lVar7 + 1;
-        } while (content[plVar15+lVar5] != '\0');
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            lVar5 = lVar7 + size;
+            lVar7 = lVar7 + 1;
+        } while (content[plVar15 + lVar5] != '\0');
         return lVar7;
-
-
     }
 
-    static void reading_dialog(int &addr, QByteArray &content, Instruction * instr){
+    static void reading_dialog(int& addr, QByteArray& content, Instruction* instr) {
 
         QByteArray current_op_value;
         int addr_ = addr;
 
         bool start_text = false;
         int cnt = 0;
-        do{
+        do {
             unsigned char current_byte = content[addr];
 
-            switch(current_byte){
+            switch (current_byte) {
                 case 0x00:
                     current_op_value.clear();
                     current_op_value[0] = 0;
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     addr++;
                     return;
                 case 0x01:
 
                     if (start_text)
                         current_op_value.push_back(current_byte);
-                    else{
+                    else {
 
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         current_op_value.clear();
                     }
                     addr++;
                     break;
                 case 0x02:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
                     break;
                 case 0x10:
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x17:
                 case 0x19:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x11:
                 case 0x12:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x23:
                     current_op_value.push_back(0x23);
                     addr_ = addr;
                     addr++;
                     current_byte = content[addr];
-                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) ||
-                           (current_byte == 0x42)||(current_byte == 0x48)||(current_byte == 0x56)||(current_byte == 0x4b) ||
-                            (current_byte == 0x6b) || (current_byte == 0x46)) {
+                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) || (current_byte == 0x42) ||
+                        (current_byte == 0x48) || (current_byte == 0x56) || (current_byte == 0x4b) || (current_byte == 0x6b) ||
+                        (current_byte == 0x46)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
+
+                        if (current_byte != 0x5f) {
+                            if (current_byte == 0x5b) {
+                                do {
+                                    current_op_value.push_back(current_byte);
+                                    addr++;
+                                    current_byte = content[addr];
+                                } while (current_byte != 0x5D);
+                                current_op_value.push_back(current_byte);
+                                addr++;
+                                current_byte = content[addr];
+                            }
+                            break;
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
-
-                              if (current_byte != 0x5f) {
-                                  if (current_byte == 0x5b) {
-                                      do{
-                                          current_op_value.push_back(current_byte);
-                                          addr++;
-                                          current_byte = content[addr];
-                                      }
-                                      while(current_byte!=0x5D);
-                                      current_op_value.push_back(current_byte);
-                                      addr++;
-                                      current_byte = content[addr];
-                                  }
-                                  break;
-                              }
-                              else{
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  break;
-                              }
-
-                           }
-                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
-                                 (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
-                                 (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
-                                 current_op_value.push_back(current_byte);
-                                 addr++;
-                                 current_byte = content[addr];
-                                 break;
+                            current_op_value.push_back(current_byte);
+                            addr++;
+                            current_byte = content[addr];
+                            break;
                         }
+
+                    } else if ((((current_byte + 0xb7) & 0xdf) == 0) || (current_byte == 0x50) || (current_byte == 0x54) ||
+                               (current_byte == 0x57) || (current_byte == 0x53) || (current_byte == 0x73) || (current_byte == 0x43) ||
+                               (current_byte == 99) || (current_byte == 0x78) || (current_byte == 0x79) || (current_byte == 0x47) ||
+                               (current_byte == 0x44) || (current_byte == 0x55) || (current_byte == 0x52)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
                         break;
+                    }
+                    break;
                 default:
-                    if (current_byte < 0x20){
-                        if (current_op_value.size()>0) {
-                            instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_byte < 0x20) {
+                        if (current_op_value.size() > 0) {
+                            instr->AddOperande(operande(addr_, "dialog", current_op_value));
                         }
                         start_text = false;
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         addr++;
                         current_op_value.clear();
-                    }
-                    else {
+                    } else {
                         if (!(start_text)) start_text = true;
 
-                        if ((current_byte < 0xE0)&&(current_byte >= 0xC0)){
+                        if ((current_byte < 0xE0) && (current_byte >= 0xC0)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte >= 0xE0)&&(current_byte <= 0xF7)){
+                        } else if ((current_byte >= 0xE0) && (current_byte <= 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
@@ -187,12 +173,10 @@ class CS4Builder : public Builder
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte > 0xF7)){
+                        } else if ((current_byte > 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else{
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                         }
@@ -200,3702 +184,3896 @@ class CS4Builder : public Builder
                     break;
             }
 
-
             cnt++;
-        }
-        while(cnt<9999);
-
+        } while (cnt < 9999);
     }
 
-
-    static void fun_1403c90e0(int &addr, QByteArray &content, Instruction * instr, int param){
+    static void fun_1403c90e0(int& addr, QByteArray& content, Instruction* instr, int param) {
         QByteArray control_byte3_arr = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte3_arr));
+        instr->AddOperande(operande(addr, "byte", control_byte3_arr));
         unsigned char control_byte3 = (unsigned char)control_byte3_arr[0];
-        if (control_byte3 == '\x55'){
-            instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+        if (control_byte3 == '\x55') {
+            instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-        if (control_byte3 == '\x11'){
-            instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+        if (control_byte3 == '\x11') {
+            instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-        }
-        else if (control_byte3 != '3'){
+        } else if (control_byte3 != '3') {
 
-            if (control_byte3 == '\"'){
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            if (control_byte3 == '\"') {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-            }
-            else if (control_byte3 != 0x44){
+            } else if (control_byte3 != 0x44) {
 
-                if (control_byte3 == 0xDD){
+                if (control_byte3 == 0xDD) {
 
-                    //there is a XOR,XOR EDI which causes a jump that ignores the strcpy
-                    if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                }
-                else if (control_byte3 == 0xFF){
-                    instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                }
-                else{
-                    if (control_byte3 != 0xEE){
+                    // there is a XOR,XOR EDI which causes a jump that ignores the strcpy
+                    if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                } else if (control_byte3 == 0xFF) {
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                } else {
+                    if (control_byte3 != 0xEE) {
 
-                    }
-                    else{
-                        instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    } else {
+                        instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     }
                 }
 
-
-            }
-            else{
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            } else {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
 
-        }
-        else{
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+        } else {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     }
-    static void sub05(int &addr, QByteArray &content, Instruction * instr){
+    static void sub05(int& addr, QByteArray& content, Instruction* instr) {
         QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte));
+        instr->AddOperande(operande(addr, "byte", control_byte));
 
-        while ((int)control_byte[0]!=1){
+        while ((int)control_byte[0] != 1) {
 
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x0:
-                    case 0x24:
-                        instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x24:
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-                    case 0x1c:{
-                        //the next byte is the OP code for a new instruction
+                case 0x1c: {
+                    // the next byte is the OP code for a new instruction
 
-                        std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content,0);
+                    std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content, 0);
 
-                        operande op = operande(addr,"instruction", instr2->getBytes());
-                        instr->AddOperande(op);
+                    operande op = operande(addr, "instruction", instr2->getBytes());
+                    instr->AddOperande(op);
 
-
-                        break;
-                    }
-                    case 0x1e:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x1f:
-                    case 0x20:
-                    case 0x23:
-
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x21:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x25:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    default:
-                        ;
+                    break;
                 }
+                case 0x1e:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x1f:
+                case 0x20:
+                case 0x23:
 
-                control_byte = ReadSubByteArray(content, addr, 1);
-
-                instr->AddOperande(operande(addr,"byte", control_byte));
-
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x21:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x25:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                default:;
             }
+
+            control_byte = ReadSubByteArray(content, addr, 1);
+
+            instr->AddOperande(operande(addr, "byte", control_byte));
+        }
     }
-    class CreateMonsters : public Instruction
-    {
-        public:
-        CreateMonsters():Instruction(-1,256,nullptr){}
-        CreateMonsters(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"CreateMonsters", 256,Maker){}
-        CreateMonsters(int addr, Builder *Maker):Instruction(addr,"CreateMonsters", 256, Maker){}
-        CreateMonsters(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"CreateMonsters", 256,Maker){
+    class CreateMonsters : public Instruction {
+      public:
+        CreateMonsters()
+          : Instruction(-1, 256, nullptr) {}
+        CreateMonsters(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int addr, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {
             int initial_addr = addr;
-            if (Maker->goal<addr+0x4C){
+            if (Maker->goal < addr + 0x4C) {
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            int check1 = ReadIntegerFromByteArray(addr,content);
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            int check1 = ReadIntegerFromByteArray(addr, content);
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            int check2 = ReadIntegerFromByteArray(addr,content);
-            if (check1 && check2 != 0){ //bad
+            int check2 = ReadIntegerFromByteArray(addr, content);
+            if (check1 && check2 != 0) { // bad
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2))); //RSI + 0x28
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RSI + 0x28
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4))); //0x2C
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4))); // 0x2C
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//0x30
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//0x32
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//0x34
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//0x36
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x30
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x32
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x34
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x36
 
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));//0x38
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4))); // 0x38
 
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));//0x3C
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));//0x40
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0x44
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0x48
-            //0x4C The first part is done
-            //from here, it's just a guess. There is a maximum of 8 enemies hardcoded in the function.
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 0x3C
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 0x40
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x44
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x48
+            // 0x4C The first part is done
+            // from here, it's just a guess. There is a maximum of 8 enemies hardcoded in the function.
 
             QByteArray array = ReadSubByteArray(content, addr, 4);
-            this->AddOperande(operande(addr,"int", array));
-            int first = ReadIntegerFromByteArray(0,array);
+            this->AddOperande(operande(addr, "int", array));
+            int first = ReadIntegerFromByteArray(0, array);
             int cnt = 0;
-            do{
+            do {
                 int counter = 0;
-                if (Maker->goal<initial_addr+0x4C + cnt * (0x90)){
+                if (Maker->goal < initial_addr + 0x4C + cnt * (0x90)) {
                     addr = initial_addr;
                     Maker->flag_monsters = false;
                     return;
                 }
-                do{
+                do {
                     counter++;
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10-monsters_name.size()-1);
-                    operande fill = operande(addr,"fill", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "fill", remaining);
                     fill.setBytesToFill(0x10);
                     this->AddOperande(fill);
 
-                }
-                while(counter < 0x8);
-                for (int idx_byte = 0; idx_byte < 8; idx_byte++) this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                if ((unsigned char) content[addr] == 0)this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 8))); //??
+                } while (counter < 0x8);
+                for (int idx_byte = 0; idx_byte < 8; idx_byte++)
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                if ((unsigned char)content[addr] == 0)
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 8))); //??
                 else {
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 12-monsters_name.size()-1);
-                    operande fill = operande(addr,"bytearray", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 12 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "bytearray", remaining);
                     fill.setBytesToFill(12);
                     this->AddOperande(fill);
-
-
                 }
 
-
                 QByteArray array = ReadSubByteArray(content, addr, 4);
-                this->AddOperande(operande(addr,"int", array));
-                first = ReadIntegerFromByteArray(0,array);
+                this->AddOperande(operande(addr, "int", array));
+                first = ReadIntegerFromByteArray(0, array);
                 cnt++;
-            }
-            while(first != -1);
+            } while (first != -1);
 
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x18))); //??
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x18))); //??
             Maker->flag_monsters = true;
         }
-
-
     };
-    class EffectsInstr : public Instruction
-    {
-        public:
-        EffectsInstr():Instruction(-1,257,nullptr){}
-        EffectsInstr(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"EffectsInstr", 257,Maker){}
-        EffectsInstr(int addr, Builder *Maker):Instruction(addr,"EffectsInstr", 257, Maker){}
-        EffectsInstr(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"EffectsInstr", 257,Maker){
+    class EffectsInstr : public Instruction {
+      public:
+        EffectsInstr()
+          : Instruction(-1, 257, nullptr) {}
+        EffectsInstr(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int addr, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {
 
             unsigned char current_byte = content[addr];
-            while (current_byte!=0x01){
+            while (current_byte != 0x01) {
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
+                this->AddOperande(operande(addr, "string", str));
 
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
 
-
-                operande fill = operande(addr,"fill", remaining);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 current_byte = content[addr];
-
             }
-
         }
-
-
     };
-    class AddCollision : public Instruction
-    {
-        public:
-        AddCollision():Instruction(-1,271,nullptr){}
-        AddCollision(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AddCollision", 271,Maker){}
-        AddCollision(int addr, Builder *Maker):Instruction(addr,"AddCollision", 271, Maker){}
-        AddCollision(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AddCollision", 271,Maker){
-
+    class AddCollision : public Instruction {
+      public:
+        AddCollision()
+          : Instruction(-1, 271, nullptr) {}
+        AddCollision(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AddCollision", 271, Maker) {}
+        AddCollision(int addr, Builder* Maker)
+          : Instruction(addr, "AddCollision", 271, Maker) {}
+        AddCollision(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AddCollision", 271, Maker) {
 
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            while (cnt < current_byte) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                 cnt++;
-          }
-
-
+            }
         }
-
-
     };
-    class ActionTable : public Instruction
-    {
-        public:
-        ActionTable():Instruction(-1,258,nullptr){}
-        ActionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ActionTable", 258,Maker){}
-        ActionTable(int addr, Builder *Maker):Instruction(addr,"ActionTable", 258, Maker){}
-        ActionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ActionTable", 258,Maker){
+    class ActionTable : public Instruction {
+      public:
+        ActionTable()
+          : Instruction(-1, 258, nullptr) {}
+        ActionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ActionTable", 258, Maker) {}
+        ActionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {}
+        ActionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {
             int cnt = 0;
             short shrt = 0;
-            do{
+            do {
 
                 shrt = ReadShortFromByteArray(addr, content);
                 if (shrt == -1) break;
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+                this->AddOperande(operande(addr, "short", short_bytes));
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1))); //57
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//58->5B
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//5C->5F
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//60->63
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//64
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//65
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//66
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//67
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//68
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//6A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//6C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//6E
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//70
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//74
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//78
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RSP+7C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-80
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-7C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-78
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-74
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-70
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-6C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-68
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-64
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-60
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-5C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-58
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //RBP-54
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //RBP-50
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 57
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 58->5B
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 5C->5F
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 60->63
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 64
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 65
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 66
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 67
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 68
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 6A
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 6C
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 6E
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 70
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 74
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 78
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RSP+7C
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-80
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-7C
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-78
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-74
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-70
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-6C
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-68
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-64
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-60
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-5C
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-58
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // RBP-54
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RBP-50
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 /*QByteArray current_byte = ReadSubByteArray(content, addr,1);
                 this->AddOperande(operande(addr,"byte", current_byte));*///Strange byte dealt in 14027dcf0
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
 
                 QByteArray str_ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str_));
-                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20-str_.size()-1);
-                operande fill_ = operande(addr,"fill", remaining_);
+                this->AddOperande(operande(addr, "string", str_));
+                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20 - str_.size() - 1);
+                operande fill_ = operande(addr, "fill", remaining_);
                 fill_.setBytesToFill(0x20);
                 this->AddOperande(fill_);
 
-                //The last string can be 0x20 long and the following 0x20 can terminate the string, I think
-                //it's their purpose here
+                // The last string can be 0x20 long and the following 0x20 can terminate the string, I think
+                // it's their purpose here
                 QByteArray str__ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str__));
-                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x40-str__.size()-1);
-                operande fill__ = operande(addr,"fill", remaining__);
+                this->AddOperande(operande(addr, "string", str__));
+                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x40 - str__.size() - 1);
+                operande fill__ = operande(addr, "fill", remaining__);
                 fill__.setBytesToFill(0x40);
                 this->AddOperande(fill__);
 
                 cnt++;
-          }
-            while(cnt < 0x40);
-            //also here, can't explain what is the purpose of those bytes
-            while (shrt==-1){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", short_bytes));
+            } while (cnt < 0x40);
+            // also here, can't explain what is the purpose of those bytes
+            while (shrt == -1) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+                this->AddOperande(operande(addr, "short", short_bytes));
                 QByteArray remaining___ = ReadSubByteArray(content, addr, 0xC1);
-                this->AddOperande(operande(addr,"bytearray", remaining___));
+                this->AddOperande(operande(addr, "bytearray", remaining___));
 
                 shrt = ReadShortFromByteArray(addr, content);
             }
-
-
-
         }
-
-
     };
-    class AlgoTable : public Instruction
-    {
-        public:
-        AlgoTable():Instruction(-1,259,nullptr){}
-        AlgoTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AlgoTable", 259,Maker){}
-        AlgoTable(int addr, Builder *Maker):Instruction(addr,"AlgoTable", 259, Maker){}
-        AlgoTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AlgoTable", 259,Maker){
+    class AlgoTable : public Instruction {
+      public:
+        AlgoTable()
+          : Instruction(-1, 259, nullptr) {}
+        AlgoTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AlgoTable", 259, Maker) {}
+        AlgoTable(int addr, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {}
+        AlgoTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {
             int cnt = 0;
 
-
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 short shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
 
                 if (shrt == 0) break;
 
-                this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
+                this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1E)));
 
                 cnt++;
-          }
-            while(cnt < 0x40);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-
+            } while (cnt < 0x40);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1E)));
         }
     };
-    class WeaponAttTable : public Instruction
-    {
-        public:
-        WeaponAttTable():Instruction(-1,260,nullptr){}
-        WeaponAttTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"WeaponAttTable", 260,Maker){}
-        WeaponAttTable(int addr, Builder *Maker):Instruction(addr,"WeaponAttTable", 260, Maker){}
-        WeaponAttTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"WeaponAttTable", 260,Maker){
+    class WeaponAttTable : public Instruction {
+      public:
+        WeaponAttTable()
+          : Instruction(-1, 260, nullptr) {}
+        WeaponAttTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int addr, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {
 
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class BreakTable : public Instruction
-    {
-        public:
-        BreakTable():Instruction(-1,261,nullptr){}
-        BreakTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BreakTable", 261,Maker){}
-        BreakTable(int addr, Builder *Maker):Instruction(addr,"BreakTable", 261, Maker){}
-        BreakTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BreakTable", 261,Maker){
+    class BreakTable : public Instruction {
+      public:
+        BreakTable()
+          : Instruction(-1, 261, nullptr) {}
+        BreakTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BreakTable", 261, Maker) {}
+        BreakTable(int addr, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {}
+        BreakTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {
             int cnt = 0;
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 short shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0) break;
-                QByteArray short_bytes2 = ReadSubByteArray(content, addr,2);
+                QByteArray short_bytes2 = ReadSubByteArray(content, addr, 2);
 
-                this->AddOperande(operande(addr,"short", short_bytes2)); //not sure if two single bytes
-                //or one short, guessing its one short
+                this->AddOperande(operande(addr, "short", short_bytes2)); // not sure if two single bytes
+                // or one short, guessing its one short
 
                 cnt++;
-            }
-            while(cnt < 0x40);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x2)));
+            } while (cnt < 0x40);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x2)));
         }
     };
-    class SummonTable : public Instruction //140142002
+    class SummonTable
+      : public Instruction // 140142002
     {
-        public:
-        SummonTable():Instruction(-1,262,nullptr){}
-        SummonTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"SummonTable", 262,Maker){}
-        SummonTable(int addr, Builder *Maker):Instruction(addr,"SummonTable", 262, Maker){}
-        SummonTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"SummonTable", 262,Maker){
+      public:
+        SummonTable()
+          : Instruction(-1, 262, nullptr) {}
+        SummonTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "SummonTable", 262, Maker) {}
+        SummonTable(int addr, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {}
+        SummonTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {
             int cnt = 0;
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 ushort shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0xFFFF) break;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
                 cnt++;
-            }
-            while(cnt < 0x40);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x24-2)));
+            } while (cnt < 0x40);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x24 - 2)));
         }
     };
-    class ReactionTable : public Instruction //140142002
+    class ReactionTable
+      : public Instruction // 140142002
     {
-        public:
-        ReactionTable():Instruction(-1,263,nullptr){}
-        ReactionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ReactionTable", 263,Maker){}
-        ReactionTable(int addr, Builder *Maker):Instruction(addr,"ReactionTable", 263, Maker){}
-        ReactionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ReactionTable", 263,Maker){
+      public:
+        ReactionTable()
+          : Instruction(-1, 263, nullptr) {}
+        ReactionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ReactionTable", 263, Maker) {}
+        ReactionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {}
+        ReactionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {
             int cnt = 0;
-            do{
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            do {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 ushort shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0x0) break;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                 cnt++;
-            }
-            while(cnt < 0x8);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x3A)));
+            } while (cnt < 0x8);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x3A)));
         }
     };
-    class PartTable : public Instruction //14019797c
+    class PartTable
+      : public Instruction // 14019797c
     {
-        public:
-        PartTable():Instruction(-1,264,nullptr){}
-        PartTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"PartTable", 264,Maker){}
-        PartTable(int addr, Builder *Maker):Instruction(addr,"PartTable", 264, Maker){}
-        PartTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"PartTable", 264,Maker){
+      public:
+        PartTable()
+          : Instruction(-1, 264, nullptr) {}
+        PartTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "PartTable", 264, Maker) {}
+        PartTable(int addr, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {}
+        PartTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {
             int cnt = 0;
-            do{
-                QByteArray int_bytes = ReadSubByteArray(content, addr,4);
+            do {
+                QByteArray int_bytes = ReadSubByteArray(content, addr, 4);
                 uint integer = ReadIntegerFromByteArray(0, int_bytes);
-                this->AddOperande(operande(addr,"int", int_bytes));
+                this->AddOperande(operande(addr, "int", int_bytes));
                 if (integer == 0xFF) break;
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 cnt++;
-            }
-            while(cnt < 0x4);
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x40)));
-
+            } while (cnt < 0x4);
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x40)));
         }
     };
 
-
-    class AnimeClipTable : public Instruction // from CS4
+    class AnimeClipTable
+      : public Instruction // from CS4
     {
-        public:
-        AnimeClipTable():Instruction(-1,265,nullptr){}
-        AnimeClipTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipTable", 265,Maker){}
-        AnimeClipTable(int addr, Builder *Maker):Instruction(addr,"AnimeClipTable", 265, Maker){}
-        AnimeClipTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipTable", 265,Maker){
+      public:
+        AnimeClipTable()
+          : Instruction(-1, 265, nullptr) {}
+        AnimeClipTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {
 
             int first_integer;
             first_integer = ReadIntegerFromByteArray(addr, content);
             std::vector<function>::iterator itt_current_fun = find_function_by_ID(Maker->FunctionsToParse, Maker->idx_current_fun);
-            while(first_integer != 0){
-                itt_current_fun->AddInstruction(std::make_shared<AnimeClipData>(addr, content,Maker));
+            while (first_integer != 0) {
+                itt_current_fun->AddInstruction(std::make_shared<AnimeClipData>(addr, content, Maker));
                 first_integer = ReadIntegerFromByteArray(addr, content);
-
             }
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            //I think this is some sort of a table with ID at the beginning and then two names
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            // I think this is some sort of a table with ID at the beginning and then two names
         }
     };
-    class AnimeClipData : public Instruction
-    {
-        public:
-        AnimeClipData():Instruction(-1,273,nullptr){}
-        AnimeClipData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipData", 273,Maker){}
-        AnimeClipData(int addr, Builder *Maker):Instruction(addr,"AnimeClipData", 273, Maker){}
-        AnimeClipData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipData", 273,Maker){
+    class AnimeClipData : public Instruction {
+      public:
+        AnimeClipData()
+          : Instruction(-1, 273, nullptr) {}
+        AnimeClipData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipData", 273, Maker) {}
+        AnimeClipData(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipData", 273, Maker) {}
+        AnimeClipData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipData", 273, Maker) {
 
-
-                QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-                this->AddOperande(operande(addr,"int", first_integer_bytes));
-                QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
-                fill.setBytesToFill((0x20));
-                this->AddOperande(fill);
-                str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                fill = operande(addr,"fill", remaining);
-                fill.setBytesToFill((0x20));
-                this->AddOperande(fill);
-
-
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            QByteArray str = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", str));
+            QByteArray remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+            operande fill = operande(addr, "fill", remaining);
+            fill.setBytesToFill((0x20));
+            this->AddOperande(fill);
+            str = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", str));
+            remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+            fill = operande(addr, "fill", remaining);
+            fill.setBytesToFill((0x20));
+            this->AddOperande(fill);
         }
     };
 
-
-    class FieldMonsterData : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
+    class FieldMonsterData
+      : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
     {
-        public:
-        FieldMonsterData():Instruction(-1,266,nullptr){}
-        FieldMonsterData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 266,Maker){}
-        FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
-        FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
+      public:
+        FieldMonsterData()
+          : Instruction(-1, 266, nullptr) {}
+        FieldMonsterData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {
 
-
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FieldFollowData : public Instruction //
+    class FieldFollowData
+      : public Instruction //
     {
-        public:
-        FieldFollowData():Instruction(-1,267,nullptr){}
-        FieldFollowData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 267,Maker){}
-        FieldFollowData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 267, Maker){}
-        FieldFollowData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 267,Maker){
+      public:
+        FieldFollowData()
+          : Instruction(-1, 267, nullptr) {}
+        FieldFollowData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FC_autoX : public Instruction //
+    class FC_autoX
+      : public Instruction //
     {
-        public:
-        FC_autoX():Instruction(-1,268,nullptr){}
-        FC_autoX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FC_autoX", 268,Maker){}
-        FC_autoX(int addr, Builder *Maker):Instruction(addr,"FC_autoX", 268, Maker){}
-        FC_autoX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FC_autoX", 268,Maker){
+      public:
+        FC_autoX()
+          : Instruction(-1, 268, nullptr) {}
+        FC_autoX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FC_autoX", 268, Maker) {}
+        FC_autoX(int addr, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {}
+        FC_autoX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {
 
             QByteArray things = ReadStringSubByteArray(content, addr);
-            this->AddOperande(operande(addr,"string", things));
+            this->AddOperande(operande(addr, "string", things));
         }
     };
-    class BookData99 : public Instruction //
+    class BookData99
+      : public Instruction //
     {
-        public:
-        BookData99():Instruction(-1,269,nullptr){}
-        BookData99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookData99", 269,Maker){}
-        BookData99(int addr, Builder *Maker):Instruction(addr,"BookData99", 269, Maker){}
-        BookData99(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookData99", 269,Maker){
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+      public:
+        BookData99()
+          : Instruction(-1, 269, nullptr) {}
+        BookData99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookData99", 269, Maker) {}
+        BookData99(int addr, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {}
+        BookData99(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class BookDataX: public Instruction //0000000140464549
+    class BookDataX
+      : public Instruction // 0000000140464549
     {
-        public:
-        BookDataX():Instruction(-1,270,nullptr){}
-        BookDataX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookDataX", 270,Maker){}
-        BookDataX(int addr, Builder *Maker):Instruction(addr,"BookDataX", 270, Maker){}
-        BookDataX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookDataX", 270,Maker){
+      public:
+        BookDataX()
+          : Instruction(-1, 270, nullptr) {}
+        BookDataX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookDataX", 270, Maker) {}
+        BookDataX(int addr, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {}
+        BookDataX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             short control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));//3
-            if (control>0){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", control_short)); // 3
+            if (control > 0) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 QByteArray title = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", title));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-title.size()-1);
-                operande fill = operande(addr,"bytearray", remaining);
+                this->AddOperande(operande(addr, "string", title));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - title.size() - 1);
+                operande fill = operande(addr, "bytearray", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x12
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x14
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x16
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x18
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1E
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x20
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x22
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x24
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            }
-            else
-            {
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x12
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x14
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x16
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x18
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1A
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1C
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1E
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x20
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x22
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x24
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            } else {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
         }
     };
-    class StyleName: public Instruction
-    {
-        public:
-        StyleName():Instruction(-1,274,nullptr){}
-        StyleName(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"StyleName", 274,Maker){}
-        StyleName(int addr, Builder *Maker):Instruction(addr,"StyleName", 274, Maker){}
-        StyleName(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"StyleName", 274,Maker){
+    class StyleName : public Instruction {
+      public:
+        StyleName()
+          : Instruction(-1, 274, nullptr) {}
+        StyleName(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "StyleName", 274, Maker) {}
+        StyleName(int addr, Builder* Maker)
+          : Instruction(addr, "StyleName", 274, Maker) {}
+        StyleName(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "StyleName", 274, Maker) {
 
             unsigned char current_byte = content[addr];
-            while (current_byte!=0x01){
-
+            while (current_byte != 0x01) {
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x40-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x40 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x40);
                 this->AddOperande(fill);
                 current_byte = content[addr];
-
-
             }
         }
     };
 
-
-    class OPCode0 : public Instruction
-    {
-        public:
-        OPCode0():Instruction(-1,0,nullptr){}
-        OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
-        OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
-            addr++;
-
-        }
-
-
-    };
-    class OPCode1 : public Instruction
-    {
-        public:
-        OPCode1():Instruction(-1,1,nullptr){}
-        OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
-        OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+    class OPCode0 : public Instruction {
+      public:
+        OPCode0()
+          : Instruction(-1, 0, nullptr) {}
+        OPCode0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Instruction 0", 0, Maker) {}
+        OPCode0(int addr, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {}
+        OPCode0(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {
             addr++;
         }
-
-
     };
-    class OPCode2 : public Instruction
-    {
-        public:
-        OPCode2():Instruction(-1,2,nullptr){}
-        OPCode2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Call", 2,Maker){}
-        OPCode2(int addr, Builder *Maker):Instruction(addr,"Call",2,Maker){}
-        OPCode2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"Call", 2,Maker){
-                addr++;
-
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                QByteArray function_name = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", function_name));
-                QByteArray control_byte2_arr = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte2_arr));
-
-                int control_byte2 = (int)control_byte2_arr[0];
-
-                if (control_byte2!=0){
-                    for (int i = 0; i < control_byte2; i++){
-                        fun_1403c90e0(addr, content, this, 0);
-                    }
-
-                }
-        }
-
-
-    };
-    class OPCode3 : public Instruction
-    {
-        public:
-        OPCode3():Instruction(-1,3,nullptr){}
-        OPCode3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 3,Maker){}
-        OPCode3(int addr, Builder *Maker):Instruction(addr,"???",3,Maker){}
-        OPCode3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 3,Maker){
+    class OPCode1 : public Instruction {
+      public:
+        OPCode1()
+          : Instruction(-1, 1, nullptr) {}
+        OPCode1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Return", 1, Maker) {}
+        OPCode1(int addr, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {}
+        OPCode1(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr, 4)));
-        }
-
-
-    };
-    class OPCode4 : public Instruction
-    {
-        public:
-        OPCode4():Instruction(-1,4,nullptr){}
-        OPCode4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 4,Maker){}
-        OPCode4(int addr, Builder *Maker):Instruction(addr,"???",4,Maker){}
-        OPCode4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 4,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
         }
     };
-    class OPCode5 : public Instruction
-    {
-        public:
-        OPCode5():Instruction(-1,5,nullptr){}
-        OPCode5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 5,Maker){}
-        OPCode5(int addr, Builder *Maker):Instruction(addr,"???",5,Maker){}
-        OPCode5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 5,Maker){
-                addr++;
-                sub05(addr, content, this);
-                this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr, 4))); // pointer
+    class OPCode2 : public Instruction {
+      public:
+        OPCode2()
+          : Instruction(-1, 2, nullptr) {}
+        OPCode2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Call", 2, Maker) {}
+        OPCode2(int addr, Builder* Maker)
+          : Instruction(addr, "Call", 2, Maker) {}
+        OPCode2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Call", 2, Maker) {
+            addr++;
 
-        }
-    };
-    class OPCode6 : public Instruction
-    {
-        public:
-        OPCode6():Instruction(-1,6,nullptr){}
-        OPCode6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 6,Maker){}
-        OPCode6(int addr, Builder *Maker):Instruction(addr,"???",6,Maker){}
-        OPCode6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 6,Maker){
-                addr++;
-                sub05(addr, content, this);
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            QByteArray function_name = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", function_name));
+            QByteArray control_byte2_arr = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte2_arr));
 
-                QByteArray ptr;
-                this->AddOperande(operande(addr,"byte", control_byte));
+            int control_byte2 = (int)control_byte2_arr[0];
 
-                for (int i = 0; i < (unsigned char) control_byte[0]; i++){
-                    QByteArray iVar3_arr = ReadSubByteArray(content, addr,4);
-                    this->AddOperande(operande(addr,"int", iVar3_arr));
-
-                    ptr = ReadSubByteArray(content, addr,4);
-                    this->AddOperande(operande(addr,"pointer",ptr));
-
+            if (control_byte2 != 0) {
+                for (int i = 0; i < control_byte2; i++) {
+                    fun_1403c90e0(addr, content, this, 0);
                 }
-
-                this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
+            }
         }
     };
-    class OPCode7 : public Instruction
-    {
-        public:
-        OPCode7():Instruction(-1,0x7,nullptr){}
-        OPCode7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 7,Maker){}
-        OPCode7(int addr, Builder *Maker):Instruction(addr,"???",0x7,Maker){}
-        OPCode7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        fun_1403c90e0(addr, content, this, 0);
-
-                        break;
-                    case 1:
-                        fun_1403c90e0(addr, content, this, 0);
-                        break;
-                    case 2:
-                        fun_1403c90e0(addr, content, this, 0);
-                        break;
-                    case 3:
-                        fun_1403c90e0(addr, content, this, 0);
-                        break;
-                }
-        }
-
-
-    };
-    class OPCode8 : public Instruction
-    {
-        public:
-        OPCode8():Instruction(-1,8,nullptr){}
-        OPCode8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 8,Maker){}
-        OPCode8(int addr, Builder *Maker):Instruction(addr,"???",8,Maker){}
-        OPCode8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 8,Maker){
-                addr++;
-                sub05(addr, content, this);
-
+    class OPCode3 : public Instruction {
+      public:
+        OPCode3()
+          : Instruction(-1, 3, nullptr) {}
+        OPCode3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 3, Maker) {}
+        OPCode3(int addr, Builder* Maker)
+          : Instruction(addr, "???", 3, Maker) {}
+        OPCode3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 3, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCodeA : public Instruction
-    {
-        public:
-        OPCodeA():Instruction(-1,0xA,nullptr){}
-        OPCodeA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA,Maker){}
-        OPCodeA(int addr, Builder *Maker):Instruction(addr,"???",0xA,Maker){}
-        OPCodeA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                sub05(addr, content, this);
+    class OPCode4 : public Instruction {
+      public:
+        OPCode4()
+          : Instruction(-1, 4, nullptr) {}
+        OPCode4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 4, Maker) {}
+        OPCode4(int addr, Builder* Maker)
+          : Instruction(addr, "???", 4, Maker) {}
+        OPCode4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 4, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    class OPCodeB : public Instruction
-    {
-        public:
-        OPCodeB():Instruction(-1,0xB,nullptr){}
-        OPCodeB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB,Maker){}
-        OPCodeB(int addr, Builder *Maker):Instruction(addr,"???",0xB,Maker){}
-        OPCodeB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                QByteArray control_byte2;
-                do{
-                    control_byte2 = ReadSubByteArray(content, addr, 1);
-                    this->AddOperande(operande(addr,"byte", control_byte2));
-                    switch((unsigned char)control_byte2[0]){
-                        case 1: return;
-                        case 2:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                            break;
-                        case 0x13:
-
-                            break;
-                        case 0x1C:
-
-                            break;
-
-                    }
-                }
-                while(true);
-
-
+    class OPCode5 : public Instruction {
+      public:
+        OPCode5()
+          : Instruction(-1, 5, nullptr) {}
+        OPCode5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 5, Maker) {}
+        OPCode5(int addr, Builder* Maker)
+          : Instruction(addr, "???", 5, Maker) {}
+        OPCode5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 5, Maker) {
+            addr++;
+            sub05(addr, content, this);
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4))); // pointer
         }
     };
-    class OPCodeC : public Instruction
-    {
-        public:
-        OPCodeC():Instruction(-1,0xC,nullptr){}
-        OPCodeC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC,Maker){}
-        OPCodeC(int addr, Builder *Maker):Instruction(addr,"???",0xC,Maker){}
-        OPCodeC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+    class OPCode6 : public Instruction {
+      public:
+        OPCode6()
+          : Instruction(-1, 6, nullptr) {}
+        OPCode6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 6, Maker) {}
+        OPCode6(int addr, Builder* Maker)
+          : Instruction(addr, "???", 6, Maker) {}
+        OPCode6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 6, Maker) {
+            addr++;
+            sub05(addr, content, this);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
 
+            QByteArray ptr;
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            for (int i = 0; i < (unsigned char)control_byte[0]; i++) {
+                QByteArray iVar3_arr = ReadSubByteArray(content, addr, 4);
+                this->AddOperande(operande(addr, "int", iVar3_arr));
+
+                ptr = ReadSubByteArray(content, addr, 4);
+                this->AddOperande(operande(addr, "pointer", ptr));
+            }
+
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode0D : public Instruction
-    {
-        public:
-        OPCode0D():Instruction(-1,0x0D,nullptr){}
-        OPCode0D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0D,Maker){}
-        OPCode0D(int addr, Builder *Maker):Instruction(addr,"???",0x0D,Maker){}
-        OPCode0D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0D,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        sub05(addr, content, this);
-                        break;
-                }
-        }
-
-
-    };
-    class OPCodeE : public Instruction
-    {
-        public:
-        OPCodeE():Instruction(-1,0xE,nullptr){}
-        OPCodeE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xE,Maker){}
-        OPCodeE(int addr, Builder *Maker):Instruction(addr,"???",0xE,Maker){}
-        OPCodeE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xE,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-
-        }
-    };
-    class OPCode10 : public Instruction
-    {
-        public:
-        OPCode10():Instruction(-1,0x10,nullptr){}
-        OPCode10(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x10,Maker){}
-        OPCode10(int addr, Builder *Maker):Instruction(addr,"???",0x10,Maker){}
-        OPCode10(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x10,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode11 : public Instruction
-    {
-        public:
-        OPCode11():Instruction(-1,0x11,nullptr){}
-        OPCode11(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x11,Maker){}
-        OPCode11(int addr, Builder *Maker):Instruction(addr,"???",0x11,Maker){}
-        OPCode11(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x11,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode12 : public Instruction
-    {
-        public:
-        OPCode12():Instruction(-1,0x12,nullptr){}
-        OPCode12(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x12,Maker){}
-        OPCode12(int addr, Builder *Maker):Instruction(addr,"???",0x12,Maker){}
-        OPCode12(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x12,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode13 : public Instruction
-    {
-        public:
-        OPCode13():Instruction(-1,0x13,nullptr){}
-        OPCode13(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x13,Maker){}
-        OPCode13(int addr, Builder *Maker):Instruction(addr,"???",0x13,Maker){}
-        OPCode13(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x13,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode14 : public Instruction
-    {
-        public:
-        OPCode14():Instruction(-1,0x14,nullptr){}
-        OPCode14(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x14,Maker){}
-        OPCode14(int addr, Builder *Maker):Instruction(addr,"???",0x14,Maker){}
-        OPCode14(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x14,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode15 : public Instruction
-    {
-        public:
-        OPCode15():Instruction(-1,0x15,nullptr){}
-        OPCode15(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x15,Maker){}
-        OPCode15(int addr, Builder *Maker):Instruction(addr,"???",0x15,Maker){}
-        OPCode15(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x15,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode16 : public Instruction
-    {
-        public:
-        OPCode16():Instruction(-1,0x16,nullptr){}
-        OPCode16(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x16,Maker){}
-        OPCode16(int addr, Builder *Maker):Instruction(addr,"???",0x16,Maker){}
-        OPCode16(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x16,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode17 : public Instruction
-    {
-        public:
-        OPCode17():Instruction(-1,0x17,nullptr){}
-        OPCode17(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x17,Maker){}
-        OPCode17(int addr, Builder *Maker):Instruction(addr,"???",0x17,Maker){}
-        OPCode17(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x17,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode18 : public Instruction
-    {
-        public:
-        OPCode18():Instruction(-1,0x18,nullptr){}
-        OPCode18(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x18,Maker){}
-        OPCode18(int addr, Builder *Maker):Instruction(addr,"???",0x18,Maker){}
-        OPCode18(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x18,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                sub05(addr, content, this);
-
-        }
-    };
-    class OPCode19 : public Instruction
-    {
-        public:
-        OPCode19():Instruction(-1,0x19,nullptr){}
-        OPCode19(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x19,Maker){}
-        OPCode19(int addr, Builder *Maker):Instruction(addr,"???",0x19,Maker){}
-        OPCode19(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x19,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode1A : public Instruction
-    {
-        public:
-        OPCode1A():Instruction(-1,0x1A,nullptr){}
-        OPCode1A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1A,Maker){}
-        OPCode1A(int addr, Builder *Maker):Instruction(addr,"???",0x1A,Maker){}
-        OPCode1A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1A,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode1D : public Instruction
-    {
-        public:
-        OPCode1D():Instruction(-1,0x1D,nullptr){}
-        OPCode1D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1D,Maker){}
-        OPCode1D(int addr, Builder *Maker):Instruction(addr,"???",0x1D,Maker){}
-        OPCode1D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//6
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//10
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//E
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x12
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x16
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x1A
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x1E
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0x22
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode1E : public Instruction
-    {
-        public:
-        OPCode1E():Instruction(-1,0x1E,nullptr){}
-        OPCode1E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1E,Maker){}
-        OPCode1E(int addr, Builder *Maker):Instruction(addr,"???",0x1E,Maker){}
-        OPCode1E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-        }
-    };
-    class OPCode1F : public Instruction
-    {
-        public:
-        OPCode1F():Instruction(-1,0x1F,nullptr){}
-        OPCode1F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1F,Maker){}
-        OPCode1F(int addr, Builder *Maker):Instruction(addr,"???",0x1F,Maker){}
-        OPCode1F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1F,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-
-        }
-    };
-    class OPCode20 : public Instruction
-    {
-        public:
-        OPCode20():Instruction(-1,0x20,nullptr){}
-        OPCode20(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x20,Maker){}
-        OPCode20(int addr, Builder *Maker):Instruction(addr,"???",0x20,Maker){}
-        OPCode20(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x20,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-        }
-
-
-    };
-    class OPCode21 : public Instruction
-    {
-        public:
-        OPCode21():Instruction(-1,0x21,nullptr){}
-        OPCode21(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x21,Maker){}
-        OPCode21(int addr, Builder *Maker):Instruction(addr,"???",0x21,Maker){}
-        OPCode21(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x21,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-
-    };
-    class OPCode22 : public Instruction
-    {
-        public:
-        OPCode22():Instruction(-1,0x22,nullptr){}
-        OPCode22(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x22,Maker){}
-        OPCode22(int addr, Builder *Maker):Instruction(addr,"???",0x22,Maker){}
-        OPCode22(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x22,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                reading_dialog(addr, content, this);
-        }
-
-
-    };
-    class OPCode23 : public Instruction
-    {
-        public:
-        OPCode23():Instruction(-1,0x23,nullptr){}
-        OPCode23(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x23,Maker){}
-        OPCode23(int addr, Builder *Maker):Instruction(addr,"???",0x23,Maker){}
-        OPCode23(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x23,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                }
-        }
-
-
-    };
-    class OPCode24 : public Instruction
-    {
-        public:
-        OPCode24():Instruction(-1,0x24,nullptr){}
-        OPCode24(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x24,Maker){}
-        OPCode24(int addr, Builder *Maker):Instruction(addr,"???",0x24,Maker){}
-        OPCode24(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x24,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                reading_dialog(addr, content, this);
-
-        }
-
-
-    };
-    class OPCode25 : public Instruction
-    {
-        public:
-        OPCode25():Instruction(-1,0x25,nullptr){}
-        OPCode25(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x25,Maker){}
-        OPCode25(int addr, Builder *Maker):Instruction(addr,"???",0x25,Maker){}
-        OPCode25(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x25,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-
-    };
-    class OPCode26 : public Instruction
-    {
-        public:
-        OPCode26():Instruction(-1,0x26,nullptr){}
-        OPCode26(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x26,Maker){}
-        OPCode26(int addr, Builder *Maker):Instruction(addr,"???",0x26,Maker){}
-        OPCode26(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
-                addr++;
-        }
-
-
-    };
-    class OPCode27 : public Instruction
-    {
-        public:
-        OPCode27():Instruction(-1,0x27,nullptr){}
-        OPCode27(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x27,Maker){}
-        OPCode27(int addr, Builder *Maker):Instruction(addr,"???",0x27,Maker){}
-        OPCode27(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x27,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-        }
-
-
-    };
-    class OPCode28 : public Instruction
-    {
-        public:
-        OPCode28():Instruction(-1,0x28,nullptr){}
-        OPCode28(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x28,Maker){}
-        OPCode28(int addr, Builder *Maker):Instruction(addr,"???",0x28,Maker){}
-        OPCode28(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x28,Maker){
-                addr++;
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-
-    };
-    class OPCode29 : public Instruction
-    {
-        public:
-        OPCode29():Instruction(-1,0x29,nullptr){}
-        OPCode29(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x29,Maker){}
-        OPCode29(int addr, Builder *Maker):Instruction(addr,"???",0x29,Maker){}
-        OPCode29(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x29,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", control_byte2));
-                if((unsigned char)control_byte2[0]<4){
-                    switch ((unsigned char)control_byte[0])  {
-                        case 0:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                        case 1:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                        case 2:
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                        case 4:
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                        case 5:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                        case 6:
-                        case 7:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                        case 8:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                            fun_1403c90e0(addr, content, this, 1);
-                            fun_1403c90e0(addr, content, this, 1);
-                        break;
-                        case 0x9:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            fun_1403c90e0(addr, content, this, 1);
-                        break;
-                        case 0xB:
-                            fun_1403c90e0(addr, content, this, 1);
-                        break;
-                        case 0xC:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                        case 0xD:
-                        case 0xE:
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                        case 0x11:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                        case 0x12:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    }
-                }
-
-        }
-
-
-    };
-    class OPCode2A : public Instruction
-    {
-        public:
-        OPCode2A():Instruction(-1,0x2A,nullptr){}
-        OPCode2A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2A,Maker){}
-        OPCode2A(int addr, Builder *Maker):Instruction(addr,"???",0x2A,Maker){}
-        OPCode2A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                    switch ((unsigned char)control_byte[0])  {
-                        case 0:
-                        case 1:
-                        case 2:
-                        case 3:
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-
-        }
-
-
-    };
-
-    class OPCode2B : public Instruction
-    {
-        public:
-        OPCode2B():Instruction(-1,0x2B,nullptr){}
-        OPCode2B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2B,Maker){}
-        OPCode2B(int addr, Builder *Maker):Instruction(addr,"???",0x2B,Maker){}
-        OPCode2B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2B,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                if ((unsigned char)control_byte[0] == 0){
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                }
-                if ((unsigned char)control_byte[0] == 1){
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                }
-
-
-        }
-
-
-    };
-    class OPCode2C : public Instruction
-    {
-        public:
-        OPCode2C():Instruction(-1,0x2C,nullptr){}
-        OPCode2C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2C,Maker){}
-        OPCode2C(int addr, Builder *Maker):Instruction(addr,"???",0x2C,Maker){}
-        OPCode2C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-        }
-
-
-    };
-    class OPCode2D : public Instruction
-    {
-        public:
-        OPCode2D():Instruction(-1,0x2D,nullptr){}
-        OPCode2D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2D,Maker){}
-        OPCode2D(int addr, Builder *Maker):Instruction(addr,"???",0x2D,Maker){}
-        OPCode2D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-
-
-    };
-    class OPCode2E : public Instruction
-    {
-        public:
-        OPCode2E():Instruction(-1,0x2E,nullptr){}
-        OPCode2E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2E,Maker){}
-        OPCode2E(int addr, Builder *Maker):Instruction(addr,"???",0x2E,Maker){}
-        OPCode2E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2E,Maker){
+    class OPCode7 : public Instruction {
+      public:
+        OPCode7()
+          : Instruction(-1, 0x7, nullptr) {}
+        OPCode7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 7, Maker) {}
+        OPCode7(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7, Maker) {}
+        OPCode7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-            switch ((unsigned char)control_byte[0])  {
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    fun_1403c90e0(addr, content, this, 0);
+
+                    break;
+                case 1:
+                    fun_1403c90e0(addr, content, this, 0);
+                    break;
+                case 2:
+                    fun_1403c90e0(addr, content, this, 0);
+                    break;
+                case 3:
+                    fun_1403c90e0(addr, content, this, 0);
+                    break;
+            }
+        }
+    };
+    class OPCode8 : public Instruction {
+      public:
+        OPCode8()
+          : Instruction(-1, 8, nullptr) {}
+        OPCode8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 8, Maker) {}
+        OPCode8(int addr, Builder* Maker)
+          : Instruction(addr, "???", 8, Maker) {}
+        OPCode8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 8, Maker) {
+            addr++;
+            sub05(addr, content, this);
+        }
+    };
+    class OPCodeA : public Instruction {
+      public:
+        OPCodeA()
+          : Instruction(-1, 0xA, nullptr) {}
+        OPCodeA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA, Maker) {}
+        OPCodeA(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA, Maker) {}
+        OPCodeA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            sub05(addr, content, this);
+        }
+    };
+    class OPCodeB : public Instruction {
+      public:
+        OPCodeB()
+          : Instruction(-1, 0xB, nullptr) {}
+        OPCodeB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB, Maker) {}
+        OPCodeB(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB, Maker) {}
+        OPCodeB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            QByteArray control_byte2;
+            do {
+                control_byte2 = ReadSubByteArray(content, addr, 1);
+                this->AddOperande(operande(addr, "byte", control_byte2));
+                switch ((unsigned char)control_byte2[0]) {
+                    case 1:
+                        return;
+                    case 2:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                        break;
+                    case 0x13:
+
+                        break;
+                    case 0x1C:
+
+                        break;
+                }
+            } while (true);
+        }
+    };
+    class OPCodeC : public Instruction {
+      public:
+        OPCodeC()
+          : Instruction(-1, 0xC, nullptr) {}
+        OPCodeC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC, Maker) {}
+        OPCodeC(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC, Maker) {}
+        OPCodeC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode0D : public Instruction {
+      public:
+        OPCode0D()
+          : Instruction(-1, 0x0D, nullptr) {}
+        OPCode0D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0D, Maker) {}
+        OPCode0D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {}
+        OPCode0D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    sub05(addr, content, this);
+                    break;
+            }
+        }
+    };
+    class OPCodeE : public Instruction {
+      public:
+        OPCodeE()
+          : Instruction(-1, 0xE, nullptr) {}
+        OPCodeE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xE, Maker) {}
+        OPCodeE(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xE, Maker) {}
+        OPCodeE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xE, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode10 : public Instruction {
+      public:
+        OPCode10()
+          : Instruction(-1, 0x10, nullptr) {}
+        OPCode10(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x10, Maker) {}
+        OPCode10(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {}
+        OPCode10(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode11 : public Instruction {
+      public:
+        OPCode11()
+          : Instruction(-1, 0x11, nullptr) {}
+        OPCode11(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x11, Maker) {}
+        OPCode11(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {}
+        OPCode11(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode12 : public Instruction {
+      public:
+        OPCode12()
+          : Instruction(-1, 0x12, nullptr) {}
+        OPCode12(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x12, Maker) {}
+        OPCode12(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {}
+        OPCode12(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode13 : public Instruction {
+      public:
+        OPCode13()
+          : Instruction(-1, 0x13, nullptr) {}
+        OPCode13(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x13, Maker) {}
+        OPCode13(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {}
+        OPCode13(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode14 : public Instruction {
+      public:
+        OPCode14()
+          : Instruction(-1, 0x14, nullptr) {}
+        OPCode14(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x14, Maker) {}
+        OPCode14(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {}
+        OPCode14(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode15 : public Instruction {
+      public:
+        OPCode15()
+          : Instruction(-1, 0x15, nullptr) {}
+        OPCode15(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x15, Maker) {}
+        OPCode15(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {}
+        OPCode15(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode16 : public Instruction {
+      public:
+        OPCode16()
+          : Instruction(-1, 0x16, nullptr) {}
+        OPCode16(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x16, Maker) {}
+        OPCode16(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {}
+        OPCode16(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode17 : public Instruction {
+      public:
+        OPCode17()
+          : Instruction(-1, 0x17, nullptr) {}
+        OPCode17(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x17, Maker) {}
+        OPCode17(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {}
+        OPCode17(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode18 : public Instruction {
+      public:
+        OPCode18()
+          : Instruction(-1, 0x18, nullptr) {}
+        OPCode18(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x18, Maker) {}
+        OPCode18(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {}
+        OPCode18(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            sub05(addr, content, this);
+        }
+    };
+    class OPCode19 : public Instruction {
+      public:
+        OPCode19()
+          : Instruction(-1, 0x19, nullptr) {}
+        OPCode19(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x19, Maker) {}
+        OPCode19(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x19, Maker) {}
+        OPCode19(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x19, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode1A : public Instruction {
+      public:
+        OPCode1A()
+          : Instruction(-1, 0x1A, nullptr) {}
+        OPCode1A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1A, Maker) {}
+        OPCode1A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {}
+        OPCode1A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode1D : public Instruction {
+      public:
+        OPCode1D()
+          : Instruction(-1, 0x1D, nullptr) {}
+        OPCode1D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1D, Maker) {}
+        OPCode1D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {}
+        OPCode1D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 6
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // E
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x12
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x16
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x1A
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x1E
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0x22
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode1E : public Instruction {
+      public:
+        OPCode1E()
+          : Instruction(-1, 0x1E, nullptr) {}
+        OPCode1E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1E, Maker) {}
+        OPCode1E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {}
+        OPCode1E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    class OPCode1F : public Instruction {
+      public:
+        OPCode1F()
+          : Instruction(-1, 0x1F, nullptr) {}
+        OPCode1F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1F, Maker) {}
+        OPCode1F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {}
+        OPCode1F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    class OPCode20 : public Instruction {
+      public:
+        OPCode20()
+          : Instruction(-1, 0x20, nullptr) {}
+        OPCode20(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x20, Maker) {}
+        OPCode20(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {}
+        OPCode20(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+        }
+    };
+    class OPCode21 : public Instruction {
+      public:
+        OPCode21()
+          : Instruction(-1, 0x21, nullptr) {}
+        OPCode21(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x21, Maker) {}
+        OPCode21(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {}
+        OPCode21(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode22 : public Instruction {
+      public:
+        OPCode22()
+          : Instruction(-1, 0x22, nullptr) {}
+        OPCode22(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x22, Maker) {}
+        OPCode22(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {}
+        OPCode22(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            reading_dialog(addr, content, this);
+        }
+    };
+    class OPCode23 : public Instruction {
+      public:
+        OPCode23()
+          : Instruction(-1, 0x23, nullptr) {}
+        OPCode23(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x23, Maker) {}
+        OPCode23(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {}
+        OPCode23(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode24 : public Instruction {
+      public:
+        OPCode24()
+          : Instruction(-1, 0x24, nullptr) {}
+        OPCode24(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x24, Maker) {}
+        OPCode24(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {}
+        OPCode24(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            reading_dialog(addr, content, this);
+        }
+    };
+    class OPCode25 : public Instruction {
+      public:
+        OPCode25()
+          : Instruction(-1, 0x25, nullptr) {}
+        OPCode25(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x25, Maker) {}
+        OPCode25(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {}
+        OPCode25(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode26 : public Instruction {
+      public:
+        OPCode26()
+          : Instruction(-1, 0x26, nullptr) {}
+        OPCode26(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x26, Maker) {}
+        OPCode26(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {}
+        OPCode26(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {
+            addr++;
+        }
+    };
+    class OPCode27 : public Instruction {
+      public:
+        OPCode27()
+          : Instruction(-1, 0x27, nullptr) {}
+        OPCode27(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x27, Maker) {}
+        OPCode27(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {}
+        OPCode27(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode28 : public Instruction {
+      public:
+        OPCode28()
+          : Instruction(-1, 0x28, nullptr) {}
+        OPCode28(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x28, Maker) {}
+        OPCode28(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {}
+        OPCode28(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {
+            addr++;
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode29 : public Instruction {
+      public:
+        OPCode29()
+          : Instruction(-1, 0x29, nullptr) {}
+        OPCode29(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x29, Maker) {}
+        OPCode29(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {}
+        OPCode29(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte2));
+            if ((unsigned char)control_byte2[0] < 4) {
+                switch ((unsigned char)control_byte[0]) {
+                    case 0:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 1:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 2:
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    case 4:
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    case 5:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                        break;
+                    case 6:
+                    case 7:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    case 8:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        fun_1403c90e0(addr, content, this, 1);
+                        fun_1403c90e0(addr, content, this, 1);
+                        break;
+                    case 0x9:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        fun_1403c90e0(addr, content, this, 1);
+                        break;
+                    case 0xB:
+                        fun_1403c90e0(addr, content, this, 1);
+                        break;
+                    case 0xC:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    case 0xD:
+                    case 0xE:
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 0x11:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 0x12:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                }
+            }
+        }
+    };
+    class OPCode2A : public Instruction {
+      public:
+        OPCode2A()
+          : Instruction(-1, 0x2A, nullptr) {}
+        OPCode2A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2A, Maker) {}
+        OPCode2A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {}
+        OPCode2A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                case 2:
+                case 3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+
+    class OPCode2B : public Instruction {
+      public:
+        OPCode2B()
+          : Instruction(-1, 0x2B, nullptr) {}
+        OPCode2B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2B, Maker) {}
+        OPCode2B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {}
+        OPCode2B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+            if ((unsigned char)control_byte[0] == 0) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            }
+            if ((unsigned char)control_byte[0] == 1) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            }
+        }
+    };
+    class OPCode2C : public Instruction {
+      public:
+        OPCode2C()
+          : Instruction(-1, 0x2C, nullptr) {}
+        OPCode2C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2C, Maker) {}
+        OPCode2C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {}
+        OPCode2C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode2D : public Instruction {
+      public:
+        OPCode2D()
+          : Instruction(-1, 0x2D, nullptr) {}
+        OPCode2D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2D, Maker) {}
+        OPCode2D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {}
+        OPCode2D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode2E : public Instruction {
+      public:
+        OPCode2E()
+          : Instruction(-1, 0x2E, nullptr) {}
+        OPCode2E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2E, Maker) {}
+        OPCode2E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {}
+        OPCode2E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte2));
+
+            switch ((unsigned char)control_byte[0]) {
                 case 0x01:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//5->8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//9->C
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));//D
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 5->8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 9->C
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // D
 
                     break;
                 case 0x03:
                 case 0x02:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));//5
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // 5
                     break;
             }
         }
-
-
     };
-    class OPCode2F : public Instruction
-    {
-        public:
-        OPCode2F():Instruction(-1,0x2F,nullptr){}
-        OPCode2F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2F,Maker){}
-        OPCode2F(int addr, Builder *Maker):Instruction(addr,"???",0x2F,Maker){}
-        OPCode2F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2F,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                switch ((unsigned char)control_byte[0])  {
+    class OPCode2F : public Instruction {
+      public:
+        OPCode2F()
+          : Instruction(-1, 0x2F, nullptr) {}
+        OPCode2F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2F, Maker) {}
+        OPCode2F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {}
+        OPCode2F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 1:
                 case 0:
                 case 2:
                 case 4:
                 case 5:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 6:
                 case 7:
 
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 8:
 
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));//16
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr))); // 16
                     break;
                 case 9:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0xA:
                 case 0xB:
                 case 0xC:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0xE:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0xF:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x10:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
-                }
-
+            }
         }
-
-
     };
-    class OPCode30 : public Instruction
-    {
-        public:
-        OPCode30():Instruction(-1,0x30,nullptr){}
-        OPCode30(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x30,Maker){}
-        OPCode30(int addr, Builder *Maker):Instruction(addr,"???",0x30,Maker){}
-        OPCode30(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x30,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
+    class OPCode30 : public Instruction {
+      public:
+        OPCode30()
+          : Instruction(-1, 0x30, nullptr) {}
+        OPCode30(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x30, Maker) {}
+        OPCode30(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {}
+        OPCode30(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    class OPCode31 : public Instruction
-    {
-        public:
-        OPCode31():Instruction(-1,0x31,nullptr){}
-        OPCode31(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x31,Maker){}
-        OPCode31(int addr, Builder *Maker):Instruction(addr,"???",0x31,Maker){}
-        OPCode31(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x31,Maker){
-                addr++;
+    class OPCode31 : public Instruction {
+      public:
+        OPCode31()
+          : Instruction(-1, 0x31, nullptr) {}
+        OPCode31(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x31, Maker) {}
+        OPCode31(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {}
+        OPCode31(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {
+            addr++;
 
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char) control_byte[0]){
-                    case 0:
-                    case 1:
-                    case 2:
-                    case 3:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                case 2:
+                case 3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
-                }
-
-
+            }
         }
-
-
     };
-    class OPCode32 : public Instruction
-    {
-        public:
-        OPCode32():Instruction(-1,0x32,nullptr){}
-        OPCode32(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x32,Maker){}
-        OPCode32(int addr, Builder *Maker):Instruction(addr,"???",0x32,Maker){}
-        OPCode32(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x32,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
+    class OPCode32 : public Instruction {
+      public:
+        OPCode32()
+          : Instruction(-1, 0x32, nullptr) {}
+        OPCode32(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x32, Maker) {}
+        OPCode32(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {}
+        OPCode32(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-                switch ((unsigned char)control_byte[0])  {
+            switch ((unsigned char)control_byte[0]) {
                 case '\n':
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     return;
 
-
                 case '\v':
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     return;
 
                 case '\f':
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    fun_1403c90e0(addr,content,this, 1);
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);//0xFF
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);
-                    fun_1403c90e0(addr,content,this, 0);
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0); // 0xFF
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0);
+                    fun_1403c90e0(addr, content, this, 0);
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     return;
-                }
-                if (((unsigned char)control_byte[0] - 0xD) < 2) {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                }
-                else if (1 < (control_byte[0] - 0xfU)){
-                    switch((unsigned char)control_byte[0]){
+            }
+            if (((unsigned char)control_byte[0] - 0xD) < 2) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            } else if (1 < (control_byte[0] - 0xfU)) {
+                switch ((unsigned char)control_byte[0]) {
                     case '\x11':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                         break;
                     case '\x12':
 
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                         break;
                     case '\x13':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                         break;
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
 
                     default:
-                        if ((unsigned char)(control_byte[0] - 0x14U) < 2){
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//3
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//F
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                        if ((unsigned char)(control_byte[0] - 0x14U) < 2) {
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 3
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // F
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                         }
                         break;
-
-                    }
-
                 }
-                else{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
 
-                }
-                switch((unsigned char)control_byte[0]){
-                    case '\x16':
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case '\x17':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case '\x18':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case '\x19':
+            } else {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            }
+            switch ((unsigned char)control_byte[0]) {
+                case '\x16':
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case '\x17':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case '\x18':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case '\x19':
 
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                        break;
-                    case '\x1A':
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case '\x1B':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case '\x1C':
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case '\x1A':
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case '\x1B':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case '\x1C':
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                        break;
-                    case '\x1D':
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case '\x1E':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case '\x1F':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x21:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x22:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    }
-
-              }
-
-
-
+                    break;
+                case '\x1D':
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case '\x1E':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case '\x1F':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x21:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x22:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+            }
+        }
     };
     class OPCode33 : public Instruction {
-        public:
-        OPCode33():Instruction(-1,0x33,nullptr){}
-        OPCode33(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x33,Maker){}
-        OPCode33(int addr, Builder *Maker):Instruction(addr,"???",0x33,Maker){}
-        OPCode33(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x33,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x00:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x01:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x02:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x03:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x04:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x07:
-                    case 0x05:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x06:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x08:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x09:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x0A:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x0C:
-                    case 0x0B:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x0D:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x0E:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x0F:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-                    case 0x10:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x11:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x12:
-                        {QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", control_byte2));
-                        switch((uint) control_byte2[0]){
-                            case 0:
-                                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                                break;
-                            case 2:
-                            case 1:
-                                break;
-                            default:
-                                qFatal("not analyzed");
-                                break;
-                        }
-
-
-                        break;
-                    }
-                    case 0x13:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x14:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-                    case 0x15:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x16:
-
-                        break;
-                    case 0x17:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x18:
-
-                        break;
-                    case 0x1E:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x19:
-                    case 0x1A:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x1B:
-
-                        break;
-                    case 0x20:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x21:
-                    case 0x22:
-                    case 0x23:
-                    case 0x24:
-                        break;
-                    case 0x26:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x27:
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-
-                    case 0x2C:{
-
-                        break;}
-                    case 0x2D:{
-                        //this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x2E:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x2F:{ //warning on this one, not sure if two or one short
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x1f:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x31:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x30:
-                        break;
-                    case 0x32:
-
-                        break;
-                    case 0x34:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x35:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x36:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x37:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x38:
-
-                        break;
-                    case 0x39:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x3A:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x3B:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x3C:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-                    case 0x4C:
-
-                        break;
-                    case 0x3D:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x3E:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x3F:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x40:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x41:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x42:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x4B:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x67:
-                    case 0x68:
-                        break;
-                    case 0x48:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x6C:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x46:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    case 0x47:
-                        break;
-                    case 0x4A:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-
-
-                    case 0x6B:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x33:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                        break;
-                    case 0x76:
-                    case 0x29:
-                        break;
-                    case 0x77:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x25:
-
-                        break;
-                    case 0xB5:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-
-                    case 0x62:
-                        {this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        QByteArray byte = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", byte));
-
-                        break;
-                    }
-                    case 0x52:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                        break;}
-                    case 0x53:{
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;}
-                    case 0x5A:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-                        break;}
-                    case 0x5B:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-                        break;}
-                    case 0x5C:{
-                        QByteArray byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", byte2));
-
-
-                        break;}
-                    case 0x61:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0x63:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x64:{
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;}
-                    case 0x65:
-                    case 0x66:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x6E:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                    }
-                    case 0x6F:{
-                        break;}
-                    case 0x70:{
-                        break;}
-                    case 0x73:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x74:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x78:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x7B:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x7D:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0x7E:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                        break;}
-                    case 0x7F:{
-
-                        break;}
-                    case 0x81:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x82:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;}
-                    case 0x87:{
-                        break;
-                    }
-                    case 0x83:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x85:{
-
-                        break;}
-                    case 0x86:{
-
-                        break;}
-                    case 0x88:{
-
-                        break;}
-                    case 0x89:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0x8A:{
-
-                        break;}
-                    case 0x8E:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x8F:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;}
-                    case 0x90:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    }
-                    case 0x91:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0x92:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    }
-                    case 0x94:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0x97:{
-
-                        break;
-                    }
-                    case 0x98:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0x9E:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    }
-                    case 0xA6:{
-                        break;
-                    }
-                    case 0xA7:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    }
-                    case 0xA8:{
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    }
-                    case 0xA9:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    }
-                    case 0xAA:{
-                        break;
-                    }
-                    case 0xAB:{
-                        break;
-                    }
-                    case 0xAD:{
-                        break;
-                    }
-                    case 0xAE:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0xAF:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    }
-                    case 0xB0:{
-                        break;}
-                    case 0xB1:{
-                        break;}
-                    case 0xB2:{
-                        break;}
-                    case 0xB3:{
-
-                        break;}
-                    case 0xB4:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        break;}
-                    case 0xB6:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;}
-                    case 0xB7:{
-                        QByteArray byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", byte2));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0xB8:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0xBA:
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0xBB:
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-
-                        break;
-                    case 0xBC:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-
-                    case 0xBD:
-
-                        break;
-                    case 0xBE:{
-
-                        break;}
-                    case 0xBF:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0xC0:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0xC1:{
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;}
-                    case 0xC2:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0xC3:{
-
-                        break;}
-                    case 0xC4:{
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;}
-                    case 0xC5:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;}
-                    case 0xC6:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0xC8:
-                    case 0xC7:{
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;}
-                    case 0xCB:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;}
-                    case 0xCC:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;}
-                    case 0xC9:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-
-                        break;}
-                    case 0xCA:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-
-                        break;}
-                    case 0xCD:{
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-
-                        break;}
-                    case 0xCE:{
-
-                        break;}
-                    case 0xD2:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-
-                        break;}
-                        default:
-                    qFatal("Byte not analyzed yet");
-                }
-
-        }
-
-
-    };
-    class OPCode34 : public Instruction
-    {
-        public:
-        OPCode34():Instruction(-1,0x34,nullptr){}
-        OPCode34(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x34,Maker){}
-        OPCode34(int addr, Builder *Maker):Instruction(addr,"???",0x34,Maker){}
-        OPCode34(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x34,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode35 : public Instruction
-    {
-        public:
-        OPCode35():Instruction(-1,0x35,nullptr){}
-        OPCode35(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x35,Maker){}
-        OPCode35(int addr, Builder *Maker):Instruction(addr,"???",0x35,Maker){}
-        OPCode35(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x35,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode36 : public Instruction
-    {
-        public:
-        OPCode36():Instruction(-1,0x36,nullptr){}
-        OPCode36(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x36,Maker){}
-        OPCode36(int addr, Builder *Maker):Instruction(addr,"???",0x36,Maker){}
-        OPCode36(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x36,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 3:
-                    case 0x14:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x5:
-                    case 0x16:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x6:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                    case 0x7:
-                    case 0x17:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x8:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x9:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0xA:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//0
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//4
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//8->c
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//c->E
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//E->10
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//10->12
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//12->14
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//14->16
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0xB:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xC:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xD:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xE:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xF:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    case 0x11:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x12:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x13:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;}
-                    case 0x15:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x1f:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;}
-                    case 0x19:
-                    case 0x18:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;}
-                    case 0x1A:{
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;}
-                    case 0x1B:{
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;}
-                    case 0x21:{
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;}
-                    case 0x28:
-                    case 0x29:{
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;}
-                    case 0x2A:
-                    case 0x2B:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;}
-                    case 0x2C:
-                    case 0x2D:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;}
-                    case 0x2E:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;}
-                }
-        }
-    };
-    class OPCode37 : public Instruction
-    {
-        public:
-        OPCode37():Instruction(-1,0x37,nullptr){}
-        OPCode37(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x37,Maker){}
-        OPCode37(int addr, Builder *Maker):Instruction(addr,"???",0x37,Maker){}
-        OPCode37(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x37,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class OPCode38 : public Instruction
-    {
-        public:
-        OPCode38():Instruction(-1,0x38,nullptr){}
-        OPCode38(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x38,Maker){}
-        OPCode38(int addr, Builder *Maker):Instruction(addr,"???",0x38,Maker){}
-        OPCode38(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x38,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-
-    class OPCode39 : public Instruction
-    {
-        public:
-        OPCode39():Instruction(-1,0x39,nullptr){}
-        OPCode39(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x39,Maker){}
-        OPCode39(int addr, Builder *Maker):Instruction(addr,"???",0x39,Maker){}
-        OPCode39(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x39,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-    };
-
-    class OPCode3A : public Instruction
-    {
-        public:
-        OPCode3A():Instruction(-1,0x3A,nullptr){}
-        OPCode3A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3A,Maker){}
-        OPCode3A(int addr, Builder *Maker):Instruction(addr,"???",0x3A,Maker){}
-        OPCode3A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x0:
-                    case 0x4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x7:
-
-                        break;
-                    case 0x8:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x9:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-
-
-        }
-    };
-    class OPCode3B : public Instruction
-    {
-        public:
-        OPCode3B():Instruction(-1,0x3B,nullptr){}
-        OPCode3B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3B,Maker){}
-        OPCode3B(int addr, Builder *Maker):Instruction(addr,"???",0x3B,Maker){}
-        OPCode3B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3B,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0xFB:
-                    case 0xFD:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0xFE:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0xFF:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0:
-                    case 0x32:
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//8->A
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));//A->C
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));//x
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                    case 1:
-                    case 0x33:
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        break;
-                    case 2:
-                    case 0x34:
-                        fun_1403c90e0(addr, content, this, 1);
-
-                        break;
-                    case 3:
-                    case 0x35:
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 4:
-                    case 0x36:
-                        fun_1403c90e0(addr, content, this, 1);
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 5:
-                    case 0x37:
-
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                    case 6:
-                    case 7:
-                    case 8:
-                    case 9:
-                    case 10:
-                    case 0xb:
-                    case 0xc:
-                    case 0xd:
-                    case 0xe:
-                    case 0xf:
-                    case 0x10:
-                    case 0x11:
-                    case 0x12:
-                    case 0x13:
-                    case 0x14:
-                    case 0x15:
-                    case 0x16:
-                    case 0x17:
-                    case 0x18:
-                    case 0x19:
-                    case 0x1a:
-                    case 0x1b:
-                    case 0x1c:
-                    case 0x1d:
-                    case 0x1e:
-                    case 0x1f:
-                    case 0x20:
-                    case 0x21:
-                    case 0x22:
-                    case 0x23:
-                    case 0x24:
-                    case 0x25:
-                    case 0x26:
-                    case 0x27:
-                    case 0x28:
-                    case 0x29:
-                    case 0x2a:
-                    case 0x2b:
-                    case 0x2c:
-                    case 0x2d:
-                    case 0x2e:
-                    case 0x2f:
-                    case 0x30:
-                    case 0x31:
-                    case 0x38:
-                    case 0x40:
-                    case 0x41:
-                    case 0x42:
-                    case 0x43:
-                    case 0x44:
-                    case 0x45:
-                    case 0x46:
-                    case 0x47:
-                    case 0x48:
-                    case 0x49:
-                    case 0x4a:
-                    case 0x4b:
-                    case 0x4c:
-                    case 0x4d:
-                    case 0x4e:
-                    case 0x4f:
-                    case 0x50:
-                    case 0x51:
-                    case 0x52:
-                    case 0x53:
-                    case 0x54:
-                    case 0x55:
-                    case 0x56:
-                    case 0x57:
-                    case 0x58:
-                    case 0x59:
-                    case 0x5a:
-                    case 0x5b:
-                    case 0x5c:
-                    case 0x5d:
-                    case 0x5e:
-                    case 0x5f:
-                    case 0x60:
-                    case 0x61:
-                    case 0x62:
-                    case 99:
-                    case 0x66:
-                    case 0x67:
-                    case 0x68:
-                    case 0x69:
-                    case 0x6a:
-                    case 0x6b:
-                    case 0x6c:
-                    case 0x6d:
-                    case 0x6e:
-                    case 0x6f:
-                    case 0x70:
-                    case 0x71:
-                    case 0x72:
-                    case 0x73:
-                    case 0x74:
-                    case 0x75:
-                    case 0x76:
-                    case 0x77:
-                    case 0x78:
-                    case 0x79:
-                    case 0x7a:
-                    case 0x7b:
-                    case 0x7c:
-                    case 0x7d:
-                    case 0x7e:
-                    case 0x7f:
-                    case 0x80:
-                    case 0x81:
-                    case 0x82:
-                    case 0x83:
-                    case 0x84:
-                    case 0x85:
-                    case 0x86:
-                    case 0x87:
-                    case 0x88:
-                    case 0x89:
-                    case 0x8a:
-                    case 0x8b:
-                    case 0x8c:
-                    case 0x8d:
-                    case 0x8e:
-                    case 0x8f:
-                    case 0x90:
-                    case 0x91:
-                    case 0x92:
-                    case 0x93:
-                    case 0x94:
-                    case 0x95:
-                      break;
-                    case 0x39:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x3A:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        fun_1403c90e0(addr, content, this, 1);
-                        break;
-                    case 0x3B:
-                    case 0x3C:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x3E:
-                    case 0x3F:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 100:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x65:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//0->4
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//4->8
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//8->C
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//C->10
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//10->14
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//14->18
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//18->1C
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//1C->20
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//20->24
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//24->28
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//28->2C
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//2C->30
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//30->34
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//34->38
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//38->3C
-                        break;
-                    case 0x3D:
-                        break;
-
-                    case 0x96:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    default:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                }
-
-
-        }
-    };
-    class OPCode3C : public Instruction
-    {
-        public:
-        OPCode3C():Instruction(-1,0x3C,nullptr){}
-        OPCode3C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3C,Maker){}
-        OPCode3C(int addr, Builder *Maker):Instruction(addr,"???",0x3C,Maker){}
-        OPCode3C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3C,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x1:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+      public:
+        OPCode33()
+          : Instruction(-1, 0x33, nullptr) {}
+        OPCode33(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x33, Maker) {}
+        OPCode33(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {}
+        OPCode33(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 0x5:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
+                case 0x01:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x02:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x03:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x04:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x07:
+                case 0x05:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x06:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x08:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x09:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x0A:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x0C:
+                case 0x0B:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x0D:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x0E:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x0F:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
+                    break;
+                case 0x10:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x11:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x12: {
+                    QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", control_byte2));
+                    switch ((uint)control_byte2[0]) {
+                        case 0:
+                            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            break;
+                        case 2:
+                        case 1:
+                            break;
+                        default:
+                            qFatal("not analyzed");
+                            break;
+                    }
+
+                    break;
                 }
+                case 0x13:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x14:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
+                    break;
+                case 0x15:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x16:
 
-        }
-    };
-    class OPCode3D : public Instruction
-    {
-        public:
-        OPCode3D():Instruction(-1,0x3D,nullptr){}
-        OPCode3D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3D,Maker){}
-        OPCode3D(int addr, Builder *Maker):Instruction(addr,"???",0x3D,Maker){}
-        OPCode3D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3D,Maker){
-                addr++;
+                    break;
+                case 0x17:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x18:
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    break;
+                case 0x1E:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x19:
+                case 0x1A:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x1B:
 
-        }
-    };
-    class OPCode3E : public Instruction
-    {
-        public:
-        OPCode3E():Instruction(-1,0x3E,nullptr){}
-        OPCode3E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3E,Maker){}
-        OPCode3E(int addr, Builder *Maker):Instruction(addr,"???",0x3E,Maker){}
-        OPCode3E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode3F : public Instruction
-    {
-        public:
-        OPCode3F():Instruction(-1,0x3F,nullptr){}
-        OPCode3F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3F,Maker){}
-        OPCode3F(int addr, Builder *Maker):Instruction(addr,"???",0x3F,Maker){}
-        OPCode3F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3F,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode40 : public Instruction
-    {
-        public:
-        OPCode40():Instruction(-1,0x40,nullptr){}
-        OPCode40(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x40,Maker){}
-        OPCode40(int addr, Builder *Maker):Instruction(addr,"???",0x40,Maker){}
-        OPCode40(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x40,Maker){
-                addr++;
+                    break;
+                case 0x20:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x21:
+                case 0x22:
+                case 0x23:
+                case 0x24:
+                    break;
+                case 0x26:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x27:
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//1
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                short control = ReadShortFromByteArray(0, control_short);
-                this->AddOperande(operande(addr,"short", control_short));//3
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//5
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//9
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//D
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-                if ((ushort)(control + 0x1feU) < 3){
+                case 0x2C: {
 
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//11 -> 15
+                    break;
                 }
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//4
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));//5
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//7
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//b
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//f
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//10
-                if ((ushort)control == 0xFE05) {
-                  while (content[addr] != '\0'){
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                  }
+                case 0x2D: {
+                    // this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 }
-
-        }
-    };
-    class OPCode41 : public Instruction
-    {
-        public:
-        OPCode41():Instruction(-1,0x41,nullptr){}
-        OPCode41(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x41", 0x41,Maker){}
-        OPCode41(int addr, Builder *Maker):Instruction(addr,"0x41",0x41,Maker){}
-        OPCode41(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x41", 0x41,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));//1
-                if ((unsigned char)control_byte[0] == 0x04){
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x2E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 }
-
-        }
-    };
-    class OPCode42 : public Instruction
-    {
-        public:
-        OPCode42():Instruction(-1,0x42,nullptr){}
-        OPCode42(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x42,Maker){}
-        OPCode42(int addr, Builder *Maker):Instruction(addr,"???",0x42,Maker){}
-        OPCode42(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x42,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));//1
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-
-
-        }
-    };
-    class OPCode43 : public Instruction
-    {
-        public:
-        OPCode43():Instruction(-1,0x43,nullptr){}
-        OPCode43(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x43,Maker){}
-        OPCode43(int addr, Builder *Maker):Instruction(addr,"???",0x43,Maker){}
-        OPCode43(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x43,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0xFF:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xFE:
-                    case 0x05:
-                    case 0x69:
-                    case 0x06:
-                    case 0x6A:
-                    case 0x6B:
-                    case 0x0A:
-                    case 0x0B:
-                    case 0x0C:
-
-                        break;
-                    default:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-
+                case 0x2F: { // warning on this one, not sure if two or one short
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 }
+                case 0x1f:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x31:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x30:
+                    break;
+                case 0x32:
 
-        }
-    };
-    class OPCode44 : public Instruction
-    {
-        public:
-        OPCode44():Instruction(-1,0x44,nullptr){}
-        OPCode44(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x44", 0x44,Maker){}
-        OPCode44(int addr, Builder *Maker):Instruction(addr,"0x44",0x44,Maker){}
-        OPCode44(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x44", 0x44,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class OPCode45 : public Instruction
-    {
-        public:
-        OPCode45():Instruction(-1,0x45,nullptr){}
-        OPCode45(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x45", 0x45,Maker){}
-        OPCode45(int addr, Builder *Maker):Instruction(addr,"0x45",0x45,Maker){}
-        OPCode45(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x45", 0x45,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode46 : public Instruction
-    {
-        public:
-        OPCode46():Instruction(-1,0x46,nullptr){}
-        OPCode46(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x46", 0x46,Maker){}
-        OPCode46(int addr, Builder *Maker):Instruction(addr,"0x46",0x46,Maker){}
-        OPCode46(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x46", 0x46,Maker){
+                    break;
+                case 0x34:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x35:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x36:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x37:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x38:
 
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch ((unsigned char)control_byte[0])  {
-                    case 3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
+                    break;
+                case 0x39:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x3A:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x3B:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x3C:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0x4C:
+
+                    break;
+                case 0x3D:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x3E:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x3F:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x40:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x41:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x42:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x4B:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x67:
+                case 0x68:
+                    break;
+                case 0x48:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x6C:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x46:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                case 0x47:
+                    break;
+                case 0x4A:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+
+                case 0x6B:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x33:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                case 0x76:
+                case 0x29:
+                    break;
+                case 0x77:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x25:
+
+                    break;
+                case 0xB5:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+
+                case 0x62: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    QByteArray byte = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", byte));
+
+                    break;
                 }
-        }
-    };
+                case 0x52: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-    class OPCode47 : public Instruction
-    {
-        public:
-        OPCode47():Instruction(-1,0x47,nullptr){}
-        OPCode47(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x47,Maker){}
-        OPCode47(int addr, Builder *Maker):Instruction(addr,"???",0x47,Maker){}
-        OPCode47(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x47,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode48 : public Instruction
-    {
-        public:
-        OPCode48():Instruction(-1,0x48,nullptr){}
-        OPCode48(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x48,Maker){}
-        OPCode48(int addr, Builder *Maker):Instruction(addr,"???",0x48,Maker){}
-        OPCode48(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x48,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 1:
-
-                        break;
+                    break;
                 }
-
-        }
-    };
-    class OPCode49 : public Instruction
-    {
-        public:
-        OPCode49():Instruction(-1,0x49,nullptr){}
-        OPCode49(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x49", 0x49,Maker){}
-        OPCode49(int addr, Builder *Maker):Instruction(addr,"0x49",0x49,Maker){}
-        OPCode49(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x49", 0x49,Maker){
-
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-
-                switch ((unsigned char)control_byte[0])  {
-
-                    case 0:
-                    case 1:
-                    case 4:
-                    case 5:
-                    case 6:
-                    case 0x11:
-                    case 9:
-
-                    case '\n':
-                    case '\v':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-
-                    case 8:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0xc:
-
-                    case 0x16:
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0x17:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 0xd:
-
-                        for (int i = 0; i < 0x18; i++) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case '\x0e':
-                    case '\x0f':
-                    case 0x12:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-
-                    case 0x1D:
-                    case 0x1C:
-                    case 0x1B:
-                    case 2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x14:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                        case 0x15:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                        case 0x1E:
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
+                case 0x53: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
                 }
-        }
-    };
-    class OPCode4A : public Instruction
-    {
-        public:
-        OPCode4A():Instruction(-1,0x4A,nullptr){}
-        OPCode4A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4A", 0x4A,Maker){}
-        OPCode4A(int addr, Builder *Maker):Instruction(addr,"0x4A",0x4A,Maker){}
-        OPCode4A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4A", 0x4A,Maker){
+                case 0x5A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-        }
-    };
-    class OPCode4B : public Instruction
-    {
-        public:
-        OPCode4B():Instruction(-1,0x4B,nullptr){}
-        OPCode4B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4B", 0x4B,Maker){}
-        OPCode4B(int addr, Builder *Maker):Instruction(addr,"0x4B",0x4B,Maker){}
-        OPCode4B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4B", 0x4B,Maker){
-
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                this->AddOperande(operande(addr,"short", control_short));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                /*switch (control_shrt)  {
-                    case 0xfff8:
-
-                        break;
-                    case 0xfff9:
-
-                        break;
-
-                }*/
-        }
-    };
-    class OPCode4C : public Instruction
-    {
-        public:
-        OPCode4C():Instruction(-1,0x4C,nullptr){}
-        OPCode4C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4C", 0x4C,Maker){}
-        OPCode4C(int addr, Builder *Maker):Instruction(addr,"0x4C",0x4C,Maker){}
-        OPCode4C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4C", 0x4C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode4D : public Instruction
-    {
-        public:
-        OPCode4D():Instruction(-1,0x4D,nullptr){}
-        OPCode4D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4D", 0x4D,Maker){}
-        OPCode4D(int addr, Builder *Maker):Instruction(addr,"0x4D",0x4D,Maker){}
-        OPCode4D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4D", 0x4D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode4E : public Instruction
-    {
-        public:
-        OPCode4E():Instruction(-1,0x4E,nullptr){}
-        OPCode4E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4E", 0x4E,Maker){}
-        OPCode4E(int addr, Builder *Maker):Instruction(addr,"0x4E",0x4E,Maker){}
-        OPCode4E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4E", 0x4E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        }
-    };
-    class OPCode4F : public Instruction
-    {
-        public:
-        OPCode4F():Instruction(-1,0x4F,nullptr){}
-        OPCode4F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x4F", 0x4F,Maker){}
-        OPCode4F(int addr, Builder *Maker):Instruction(addr,"0x4F",0x4F,Maker){}
-        OPCode4F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x4F", 0x4F,Maker){
-
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-
-                    case 3:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-
+                    break;
                 }
+                case 0x5B: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x5C: {
+                    QByteArray byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", byte2));
+
+                    break;
+                }
+                case 0x61: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x63: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x64: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x65:
+                case 0x66: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x6E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x6F: {
+                    break;
+                }
+                case 0x70: {
+                    break;
+                }
+                case 0x73: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x74: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x78: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x7B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x7D: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x7E: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x7F: {
+
+                    break;
+                }
+                case 0x81: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x82: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x87: {
+                    break;
+                }
+                case 0x83: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x85: {
+
+                    break;
+                }
+                case 0x86: {
+
+                    break;
+                }
+                case 0x88: {
+
+                    break;
+                }
+                case 0x89: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x8A: {
+
+                    break;
+                }
+                case 0x8E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x8F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x90: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x91: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x92: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x94: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x97: {
+
+                    break;
+                }
+                case 0x98: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x9E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0xA6: {
+                    break;
+                }
+                case 0xA7: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0xA8: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xA9: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xAA: {
+                    break;
+                }
+                case 0xAB: {
+                    break;
+                }
+                case 0xAD: {
+                    break;
+                }
+                case 0xAE: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xAF: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xB0: {
+                    break;
+                }
+                case 0xB1: {
+                    break;
+                }
+                case 0xB2: {
+                    break;
+                }
+                case 0xB3: {
+
+                    break;
+                }
+                case 0xB4: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    break;
+                }
+                case 0xB6: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xB7: {
+                    QByteArray byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", byte2));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0xB8: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0xBA:
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0xBB:
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+
+                    break;
+                case 0xBC:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+
+                case 0xBD:
+
+                    break;
+                case 0xBE: {
+
+                    break;
+                }
+                case 0xBF: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xC0: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0xC1: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xC2: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xC3: {
+
+                    break;
+                }
+                case 0xC4: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0xC5: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xC6: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xC8:
+                case 0xC7: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xCB: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0xCC: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xC9: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+
+                    break;
+                }
+                case 0xCA: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0xCD: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0xCE: {
+
+                    break;
+                }
+                case 0xD2: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                default:
+                    qFatal("Byte not analyzed yet");
+            }
         }
     };
-    class OPCode50 : public Instruction
-    {
-        public:
-        OPCode50():Instruction(-1,0x50,nullptr){}
-        OPCode50(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x50", 0x50,Maker){}
-        OPCode50(int addr, Builder *Maker):Instruction(addr,"0x50",0x50,Maker){}
-        OPCode50(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x50", 0x50,Maker){
-                addr++;
-                fun_1403c90e0(addr, content, this, 1);
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+    class OPCode34 : public Instruction {
+      public:
+        OPCode34()
+          : Instruction(-1, 0x34, nullptr) {}
+        OPCode34(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x34, Maker) {}
+        OPCode34(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {}
+        OPCode34(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode51 : public Instruction
-    {
-        public:
-        OPCode51():Instruction(-1,0x51,nullptr){}
-        OPCode51(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x51", 0x51,Maker){}
-        OPCode51(int addr, Builder *Maker):Instruction(addr,"0x51",0x51,Maker){}
-        OPCode51(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x51", 0x51,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
+    class OPCode35 : public Instruction {
+      public:
+        OPCode35()
+          : Instruction(-1, 0x35, nullptr) {}
+        OPCode35(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x35, Maker) {}
+        OPCode35(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {}
+        OPCode35(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode52 : public Instruction
-    {
-        public:
-        OPCode52():Instruction(-1,0x52,nullptr){}
-        OPCode52(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x52", 0x52,Maker){}
-        OPCode52(int addr, Builder *Maker):Instruction(addr,"0x52",0x52,Maker){}
-        OPCode52(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x52", 0x52,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+    class OPCode36 : public Instruction {
+      public:
+        OPCode36()
+          : Instruction(-1, 0x36, nullptr) {}
+        OPCode36(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x36, Maker) {}
+        OPCode36(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {}
+        OPCode36(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 3:
+                case 0x14:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x5:
+                case 0x16:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
+                    break;
+                case 0x6:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                case 0x7:
+                case 0x17:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0x8:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0x9:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0xA:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8->c
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // c->E
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // E->10
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 10->12
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 12->14
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 14->16
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xB:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xC:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xD:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xE:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xF:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                case 0x11:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x12:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x13: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x15:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x1f: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x19:
+                case 0x18: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x1A: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x1B: {
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x21: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x28:
+                case 0x29: {
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2A:
+                case 0x2B: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x2C:
+                case 0x2D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x2E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+            }
         }
     };
-    class OPCode53 : public Instruction
-    {
-        public:
-        OPCode53():Instruction(-1,0x53,nullptr){}
-        OPCode53(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x53", 0x53,Maker){}
-        OPCode53(int addr, Builder *Maker):Instruction(addr,"0x53",0x53,Maker){}
-        OPCode53(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x53", 0x53,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-
+    class OPCode37 : public Instruction {
+      public:
+        OPCode37()
+          : Instruction(-1, 0x37, nullptr) {}
+        OPCode37(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x37, Maker) {}
+        OPCode37(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {}
+        OPCode37(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode54 : public Instruction
-    {
-        public:
-        OPCode54():Instruction(-1,0x54,nullptr){}
-        OPCode54(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x54,Maker){}
-        OPCode54(int addr, Builder *Maker):Instruction(addr,"???",0x54,Maker){}
-        OPCode54(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x54,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                QByteArray control_byte2;
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch ((unsigned char)control_byte[0])  {
+    class OPCode38 : public Instruction {
+      public:
+        OPCode38()
+          : Instruction(-1, 0x38, nullptr) {}
+        OPCode38(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x38, Maker) {}
+        OPCode38(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {}
+        OPCode38(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
 
+    class OPCode39 : public Instruction {
+      public:
+        OPCode39()
+          : Instruction(-1, 0x39, nullptr) {}
+        OPCode39(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x39, Maker) {}
+        OPCode39(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {}
+        OPCode39(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+
+    class OPCode3A : public Instruction {
+      public:
+        OPCode3A()
+          : Instruction(-1, 0x3A, nullptr) {}
+        OPCode3A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3A, Maker) {}
+        OPCode3A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {}
+        OPCode3A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x4:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0x7:
+
+                    break;
+                case 0x8:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x9:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode3B : public Instruction {
+      public:
+        OPCode3B()
+          : Instruction(-1, 0x3B, nullptr) {}
+        OPCode3B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3B, Maker) {}
+        OPCode3B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {}
+        OPCode3B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0xFB:
+                case 0xFD:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xFE:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0xFF:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0:
+                case 0x32:
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 8->A
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // A->C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr))); // x
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                case 1:
+                case 0x33:
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    break;
+                case 2:
+                case 0x34:
+                    fun_1403c90e0(addr, content, this, 1);
+
+                    break;
+                case 3:
+                case 0x35:
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 4:
+                case 0x36:
+                    fun_1403c90e0(addr, content, this, 1);
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 5:
+                case 0x37:
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 0xb:
+                case 0xc:
+                case 0xd:
+                case 0xe:
+                case 0xf:
+                case 0x10:
+                case 0x11:
+                case 0x12:
+                case 0x13:
+                case 0x14:
+                case 0x15:
+                case 0x16:
+                case 0x17:
+                case 0x18:
+                case 0x19:
+                case 0x1a:
+                case 0x1b:
+                case 0x1c:
+                case 0x1d:
+                case 0x1e:
+                case 0x1f:
+                case 0x20:
+                case 0x21:
+                case 0x22:
+                case 0x23:
+                case 0x24:
+                case 0x25:
+                case 0x26:
+                case 0x27:
+                case 0x28:
+                case 0x29:
+                case 0x2a:
+                case 0x2b:
+                case 0x2c:
+                case 0x2d:
+                case 0x2e:
+                case 0x2f:
+                case 0x30:
+                case 0x31:
+                case 0x38:
+                case 0x40:
+                case 0x41:
+                case 0x42:
+                case 0x43:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x47:
+                case 0x48:
+                case 0x49:
+                case 0x4a:
+                case 0x4b:
+                case 0x4c:
+                case 0x4d:
+                case 0x4e:
+                case 0x4f:
+                case 0x50:
+                case 0x51:
+                case 0x52:
+                case 0x53:
+                case 0x54:
+                case 0x55:
+                case 0x56:
+                case 0x57:
+                case 0x58:
+                case 0x59:
+                case 0x5a:
+                case 0x5b:
+                case 0x5c:
+                case 0x5d:
+                case 0x5e:
+                case 0x5f:
+                case 0x60:
+                case 0x61:
+                case 0x62:
+                case 99:
+                case 0x66:
+                case 0x67:
+                case 0x68:
+                case 0x69:
+                case 0x6a:
+                case 0x6b:
+                case 0x6c:
+                case 0x6d:
+                case 0x6e:
+                case 0x6f:
+                case 0x70:
+                case 0x71:
+                case 0x72:
+                case 0x73:
+                case 0x74:
+                case 0x75:
+                case 0x76:
+                case 0x77:
+                case 0x78:
+                case 0x79:
+                case 0x7a:
+                case 0x7b:
+                case 0x7c:
+                case 0x7d:
+                case 0x7e:
+                case 0x7f:
+                case 0x80:
+                case 0x81:
+                case 0x82:
+                case 0x83:
+                case 0x84:
+                case 0x85:
+                case 0x86:
+                case 0x87:
+                case 0x88:
+                case 0x89:
+                case 0x8a:
+                case 0x8b:
+                case 0x8c:
+                case 0x8d:
+                case 0x8e:
+                case 0x8f:
+                case 0x90:
+                case 0x91:
+                case 0x92:
+                case 0x93:
+                case 0x94:
+                case 0x95:
+                    break;
+                case 0x39:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x3A:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    fun_1403c90e0(addr, content, this, 1);
+                    break;
+                case 0x3B:
+                case 0x3C:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x3E:
+                case 0x3F:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 100:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x65:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 0->4
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 4->8
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 8->C
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // C->10
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 10->14
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 14->18
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 18->1C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 1C->20
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 20->24
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 24->28
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 28->2C
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 2C->30
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 30->34
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 34->38
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 38->3C
+                    break;
+                case 0x3D:
+                    break;
+
+                case 0x96:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                default:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode3C : public Instruction {
+      public:
+        OPCode3C()
+          : Instruction(-1, 0x3C, nullptr) {}
+        OPCode3C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3C, Maker) {}
+        OPCode3C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {}
+        OPCode3C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x1:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 0x5:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+            }
+        }
+    };
+    class OPCode3D : public Instruction {
+      public:
+        OPCode3D()
+          : Instruction(-1, 0x3D, nullptr) {}
+        OPCode3D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3D, Maker) {}
+        OPCode3D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {}
+        OPCode3D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode3E : public Instruction {
+      public:
+        OPCode3E()
+          : Instruction(-1, 0x3E, nullptr) {}
+        OPCode3E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3E, Maker) {}
+        OPCode3E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {}
+        OPCode3E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode3F : public Instruction {
+      public:
+        OPCode3F()
+          : Instruction(-1, 0x3F, nullptr) {}
+        OPCode3F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3F, Maker) {}
+        OPCode3F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {}
+        OPCode3F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode40 : public Instruction {
+      public:
+        OPCode40()
+          : Instruction(-1, 0x40, nullptr) {}
+        OPCode40(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x40, Maker) {}
+        OPCode40(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {}
+        OPCode40(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {
+            addr++;
+
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 1
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            short control = ReadShortFromByteArray(0, control_short);
+            this->AddOperande(operande(addr, "short", control_short));                      // 3
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 5
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 9
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // D
+
+            if ((ushort)(control + 0x1feU) < 3) {
+
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 11 -> 15
+            }
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 5
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 7
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // b
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // f
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 10
+            if ((ushort)control == 0xFE05) {
+                while (content[addr] != '\0') {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                }
+            }
+        }
+    };
+    class OPCode41 : public Instruction {
+      public:
+        OPCode41()
+          : Instruction(-1, 0x41, nullptr) {}
+        OPCode41(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x41", 0x41, Maker) {}
+        OPCode41(int addr, Builder* Maker)
+          : Instruction(addr, "0x41", 0x41, Maker) {}
+        OPCode41(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x41", 0x41, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte)); // 1
+            if ((unsigned char)control_byte[0] == 0x04) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            }
+        }
+    };
+    class OPCode42 : public Instruction {
+      public:
+        OPCode42()
+          : Instruction(-1, 0x42, nullptr) {}
+        OPCode42(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x42, Maker) {}
+        OPCode42(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {}
+        OPCode42(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte)); // 1
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode43 : public Instruction {
+      public:
+        OPCode43()
+          : Instruction(-1, 0x43, nullptr) {}
+        OPCode43(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x43, Maker) {}
+        OPCode43(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {}
+        OPCode43(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0xFF:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xFE:
+                case 0x05:
+                case 0x69:
+                case 0x06:
+                case 0x6A:
+                case 0x6B:
+                case 0x0A:
+                case 0x0B:
+                case 0x0C:
+
+                    break;
+                default:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode44 : public Instruction {
+      public:
+        OPCode44()
+          : Instruction(-1, 0x44, nullptr) {}
+        OPCode44(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x44", 0x44, Maker) {}
+        OPCode44(int addr, Builder* Maker)
+          : Instruction(addr, "0x44", 0x44, Maker) {}
+        OPCode44(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x44", 0x44, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode45 : public Instruction {
+      public:
+        OPCode45()
+          : Instruction(-1, 0x45, nullptr) {}
+        OPCode45(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x45", 0x45, Maker) {}
+        OPCode45(int addr, Builder* Maker)
+          : Instruction(addr, "0x45", 0x45, Maker) {}
+        OPCode45(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x45", 0x45, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode46 : public Instruction {
+      public:
+        OPCode46()
+          : Instruction(-1, 0x46, nullptr) {}
+        OPCode46(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x46", 0x46, Maker) {}
+        OPCode46(int addr, Builder* Maker)
+          : Instruction(addr, "0x46", 0x46, Maker) {}
+        OPCode46(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x46", 0x46, Maker) {
+
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+
+    class OPCode47 : public Instruction {
+      public:
+        OPCode47()
+          : Instruction(-1, 0x47, nullptr) {}
+        OPCode47(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x47, Maker) {}
+        OPCode47(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {}
+        OPCode47(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode48 : public Instruction {
+      public:
+        OPCode48()
+          : Instruction(-1, 0x48, nullptr) {}
+        OPCode48(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x48, Maker) {}
+        OPCode48(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {}
+        OPCode48(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 1:
+
+                    break;
+            }
+        }
+    };
+    class OPCode49 : public Instruction {
+      public:
+        OPCode49()
+          : Instruction(-1, 0x49, nullptr) {}
+        OPCode49(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x49", 0x49, Maker) {}
+        OPCode49(int addr, Builder* Maker)
+          : Instruction(addr, "0x49", 0x49, Maker) {}
+        OPCode49(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x49", 0x49, Maker) {
+
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 0:
+                case 1:
+                case 4:
+                case 5:
+                case 6:
+                case 0x11:
+                case 9:
+
+                case '\n':
+                case '\v':
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+
+                case 8:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0xc:
+
+                case 0x16:
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0x17:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0xd:
+
+                    for (int i = 0; i < 0x18; i++)
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case '\x0e':
+                case '\x0f':
+                case 0x12:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+
+                case 0x1D:
+                case 0x1C:
+                case 0x1B:
+                case 2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x14:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 0x15:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x1E:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode4A : public Instruction {
+      public:
+        OPCode4A()
+          : Instruction(-1, 0x4A, nullptr) {}
+        OPCode4A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4A", 0x4A, Maker) {}
+        OPCode4A(int addr, Builder* Maker)
+          : Instruction(addr, "0x4A", 0x4A, Maker) {}
+        OPCode4A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4A", 0x4A, Maker) {
+
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode4B : public Instruction {
+      public:
+        OPCode4B()
+          : Instruction(-1, 0x4B, nullptr) {}
+        OPCode4B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4B", 0x4B, Maker) {}
+        OPCode4B(int addr, Builder* Maker)
+          : Instruction(addr, "0x4B", 0x4B, Maker) {}
+        OPCode4B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4B", 0x4B, Maker) {
+
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            this->AddOperande(operande(addr, "short", control_short));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            /*switch (control_shrt)  {
+                case 0xfff8:
+
+                    break;
+                case 0xfff9:
+
+                    break;
+
+            }*/
+        }
+    };
+    class OPCode4C : public Instruction {
+      public:
+        OPCode4C()
+          : Instruction(-1, 0x4C, nullptr) {}
+        OPCode4C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4C", 0x4C, Maker) {}
+        OPCode4C(int addr, Builder* Maker)
+          : Instruction(addr, "0x4C", 0x4C, Maker) {}
+        OPCode4C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4C", 0x4C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode4D : public Instruction {
+      public:
+        OPCode4D()
+          : Instruction(-1, 0x4D, nullptr) {}
+        OPCode4D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4D", 0x4D, Maker) {}
+        OPCode4D(int addr, Builder* Maker)
+          : Instruction(addr, "0x4D", 0x4D, Maker) {}
+        OPCode4D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4D", 0x4D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode4E : public Instruction {
+      public:
+        OPCode4E()
+          : Instruction(-1, 0x4E, nullptr) {}
+        OPCode4E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4E", 0x4E, Maker) {}
+        OPCode4E(int addr, Builder* Maker)
+          : Instruction(addr, "0x4E", 0x4E, Maker) {}
+        OPCode4E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4E", 0x4E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode4F : public Instruction {
+      public:
+        OPCode4F()
+          : Instruction(-1, 0x4F, nullptr) {}
+        OPCode4F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x4F", 0x4F, Maker) {}
+        OPCode4F(int addr, Builder* Maker)
+          : Instruction(addr, "0x4F", 0x4F, Maker) {}
+        OPCode4F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x4F", 0x4F, Maker) {
+
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+
+                case 3:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 4:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+            }
+        }
+    };
+    class OPCode50 : public Instruction {
+      public:
+        OPCode50()
+          : Instruction(-1, 0x50, nullptr) {}
+        OPCode50(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x50", 0x50, Maker) {}
+        OPCode50(int addr, Builder* Maker)
+          : Instruction(addr, "0x50", 0x50, Maker) {}
+        OPCode50(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x50", 0x50, Maker) {
+            addr++;
+            fun_1403c90e0(addr, content, this, 1);
+
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode51 : public Instruction {
+      public:
+        OPCode51()
+          : Instruction(-1, 0x51, nullptr) {}
+        OPCode51(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x51", 0x51, Maker) {}
+        OPCode51(int addr, Builder* Maker)
+          : Instruction(addr, "0x51", 0x51, Maker) {}
+        OPCode51(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x51", 0x51, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode52 : public Instruction {
+      public:
+        OPCode52()
+          : Instruction(-1, 0x52, nullptr) {}
+        OPCode52(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x52", 0x52, Maker) {}
+        OPCode52(int addr, Builder* Maker)
+          : Instruction(addr, "0x52", 0x52, Maker) {}
+        OPCode52(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x52", 0x52, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode53 : public Instruction {
+      public:
+        OPCode53()
+          : Instruction(-1, 0x53, nullptr) {}
+        OPCode53(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x53", 0x53, Maker) {}
+        OPCode53(int addr, Builder* Maker)
+          : Instruction(addr, "0x53", 0x53, Maker) {}
+        OPCode53(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x53", 0x53, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode54 : public Instruction {
+      public:
+        OPCode54()
+          : Instruction(-1, 0x54, nullptr) {}
+        OPCode54(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x54, Maker) {}
+        OPCode54(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x54, Maker) {}
+        OPCode54(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x54, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            QByteArray control_byte2;
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
                 case 10:
                 case 0xE:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0xB:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x18:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0xD:
 
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 case 0x14:
 
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 case 0x15:
 
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 case 0x17:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x30:
@@ -3905,236 +4083,234 @@ class CS4Builder : public Builder
                 case 0x22:
 
                 case 0x28:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x19:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0x1C:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 case 0x21:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x23:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x26:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
 
                 case 0x29:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x2B:
                     control_byte2 = ReadSubByteArray(content, addr, 1);
-                    this->AddOperande(operande(addr,"byte", control_byte2));
-                    if ((int)control_byte2[0]==0){
+                    this->AddOperande(operande(addr, "byte", control_byte2));
+                    if ((int)control_byte2[0] == 0) {
                         qFatal("NOOOOT SURE.");
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));}
-                    else if ((int)control_byte2[0]==1){
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    } else if ((int)control_byte2[0] == 1) {
                         qFatal("NOOOOT SURE TOO.");
                     }
                     break;
                 case 0x2C:
 
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x31:
                     control_byte2 = ReadSubByteArray(content, addr, 1);
-                    this->AddOperande(operande(addr,"byte", control_byte2));
-                    if ((int)control_byte2[0]==0){
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "byte", control_byte2));
+                    if ((int)control_byte2[0] == 0) {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    }
-                    else if ((int)control_byte2[0]==1){
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    } else if ((int)control_byte2[0] == 1) {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     }
                     break;
                 case 0x34:
 
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x35:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 case 0x37:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x38:
 
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x39:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x3A:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //0
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //2
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//C
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//10
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1))); //0x14
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 2
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 0x14
 
                     break;
                 case 0x3B:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //0
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //2
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));//8
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 2
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
                     break;
 
                 case 0x3C:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x3E:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
 
                 case 0x40:
                 case 0x4B:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x42:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x44:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x45:
                 case 0x46:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x47:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x48:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x49:
                 case 0x4A:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x4C:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x4D:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x4E:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x4F:
                     control_byte2 = ReadSubByteArray(content, addr, 1);
-                    this->AddOperande(operande(addr,"byte", control_byte2)); //1
-                    switch((int)control_byte2[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", control_byte2)); // 1
+                    switch ((int)control_byte2[0]) {
+                        case 0:
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            break;
+                        case 1:
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                            break;
+                        case 2:
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                        break;
-                    case 3:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case '\n':
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //3
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1))); //4
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4))); //8
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2))); //10
-                        break;
+                            break;
+                        case 3:
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            break;
+                        case 4:
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                            break;
+                        case '\n':
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 3
+                            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));  // 4
+                            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 10
+                            break;
                     }
                     break;
                 case 0x50:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x51:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 case 0x52:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 case 0x53:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x54:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x6F:
                 case 0x6E:
@@ -4144,1367 +4320,1504 @@ class CS4Builder : public Builder
                 case 0x67:
                 case 0x65:
                 case 100:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
+            }
+        }
+    };
+    class OPCode55 : public Instruction {
+      public:
+        OPCode55()
+          : Instruction(-1, 0x55, nullptr) {}
+        OPCode55(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x55", 0x55, Maker) {}
+        OPCode55(int addr, Builder* Maker)
+          : Instruction(addr, "0x55", 0x55, Maker) {}
+        OPCode55(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x55", 0x55, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    class OPCode56 : public Instruction {
+      public:
+        OPCode56()
+          : Instruction(-1, 0x56, nullptr) {}
+        OPCode56(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x56", 0x56, Maker) {}
+        OPCode56(int addr, Builder* Maker)
+          : Instruction(addr, "0x56", 0x56, Maker) {}
+        OPCode56(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x56", 0x56, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 10
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 14
+        }
+    };
+    class OPCode57 : public Instruction {
+      public:
+        OPCode57()
+          : Instruction(-1, 0x57, nullptr) {}
+        OPCode57(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x57", 0x57, Maker) {}
+        OPCode57(int addr, Builder* Maker)
+          : Instruction(addr, "0x57", 0x57, Maker) {}
+        OPCode57(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x57", 0x57, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode58 : public Instruction {
+      public:
+        OPCode58()
+          : Instruction(-1, 0x58, nullptr) {}
+        OPCode58(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x58", 0x58, Maker) {}
+        OPCode58(int addr, Builder* Maker)
+          : Instruction(addr, "0x58", 0x58, Maker) {}
+        OPCode58(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x58", 0x58, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    class OPCode5A : public Instruction {
+      public:
+        OPCode5A()
+          : Instruction(-1, 0x5A, nullptr) {}
+        OPCode5A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x5A", 0x5A, Maker) {}
+        OPCode5A(int addr, Builder* Maker)
+          : Instruction(addr, "0x5A", 0x5A, Maker) {}
+        OPCode5A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x5A", 0x5A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            if ((unsigned char)control_byte[0] == 0) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            }
+        }
+    };
+    class OPCode5B : public Instruction {
+      public:
+        OPCode5B()
+          : Instruction(-1, 0x5B, nullptr) {}
+        OPCode5B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x5B", 0x5B, Maker) {}
+        OPCode5B(int addr, Builder* Maker)
+          : Instruction(addr, "0x5B", 0x5B, Maker) {}
+        OPCode5B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x5B", 0x5B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            sub05(addr, content, this);
+        }
+    };
+    class OPCode5C : public Instruction {
+      public:
+        OPCode5C()
+          : Instruction(-1, 0x5C, nullptr) {}
+        OPCode5C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5C, Maker) {}
+        OPCode5C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5C, Maker) {}
+        OPCode5C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    class OPCode5D : public Instruction {
+      public:
+        OPCode5D()
+          : Instruction(-1, 0x5D, nullptr) {}
+        OPCode5D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5D, Maker) {}
+        OPCode5D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {}
+        OPCode5D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode5E : public Instruction {
+      public:
+        OPCode5E()
+          : Instruction(-1, 0x5E, nullptr) {}
+        OPCode5E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5E, Maker) {}
+        OPCode5E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {}
+        OPCode5E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-                }
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode60 : public Instruction {
+      public:
+        OPCode60()
+          : Instruction(-1, 0x60, nullptr) {}
+        OPCode60(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x60, Maker) {}
+        OPCode60(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {}
+        OPCode60(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    class OPCode61 : public Instruction {
+      public:
+        OPCode61()
+          : Instruction(-1, 0x61, nullptr) {}
+        OPCode61(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x61, Maker) {}
+        OPCode61(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {}
+        OPCode61(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {
+            addr++;
 
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode62 : public Instruction {
+      public:
+        OPCode62()
+          : Instruction(-1, 0x62, nullptr) {}
+        OPCode62(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x62, Maker) {}
+        OPCode62(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x62, Maker) {}
+        OPCode62(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x62, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode63 : public Instruction {
+      public:
+        OPCode63()
+          : Instruction(-1, 0x63, nullptr) {}
+        OPCode63(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x63, Maker) {}
+        OPCode63(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x63, Maker) {}
+        OPCode63(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x63, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            this->AddOperande(operande(addr, "short", control_short));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    class OPCode64 : public Instruction {
+      public:
+        OPCode64()
+          : Instruction(-1, 0x64, nullptr) {}
+        OPCode64(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x64, Maker) {}
+        OPCode64(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {}
+        OPCode64(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+    class OPCode65 : public Instruction {
+      public:
+        OPCode65()
+          : Instruction(-1, 0x65, nullptr) {}
+        OPCode65(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x65, Maker) {}
+        OPCode65(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {}
+        OPCode65(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 2:
+                case 3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+    class OPCode66 : public Instruction {
+      public:
+        OPCode66()
+          : Instruction(-1, 0x66, nullptr) {}
+        OPCode66(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x66, Maker) {}
+        OPCode66(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {}
+        OPCode66(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                case 4:
+                case 8:
+                case 6:
+                case 9:
+                case 10:
 
+                case 0xF:
+                case 0x10:
+                case 0x11:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0xB:
+                case 2:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0xD:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
     };
-    class OPCode55 : public Instruction
-    {
-        public:
-        OPCode55():Instruction(-1,0x55,nullptr){}
-        OPCode55(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x55", 0x55,Maker){}
-        OPCode55(int addr, Builder *Maker):Instruction(addr,"0x55",0x55,Maker){}
-        OPCode55(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x55", 0x55,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+    class OPCode67 : public Instruction {
+      public:
+        OPCode67()
+          : Instruction(-1, 0x67, nullptr) {}
+        OPCode67(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x67, Maker) {}
+        OPCode67(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {}
+        OPCode67(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
     };
-    class OPCode56 : public Instruction
-    {
-        public:
-        OPCode56():Instruction(-1,0x56,nullptr){}
-        OPCode56(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x56", 0x56,Maker){}
-        OPCode56(int addr, Builder *Maker):Instruction(addr,"0x56",0x56,Maker){}
-        OPCode56(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x56", 0x56,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//10
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//14
-        }
-    };
-    class OPCode57 : public Instruction
-    {
-        public:
-        OPCode57():Instruction(-1,0x57,nullptr){}
-        OPCode57(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x57", 0x57,Maker){}
-        OPCode57(int addr, Builder *Maker):Instruction(addr,"0x57",0x57,Maker){}
-        OPCode57(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x57", 0x57,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-    };
-    class OPCode58 : public Instruction
-    {
-        public:
-        OPCode58():Instruction(-1,0x58,nullptr){}
-        OPCode58(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x58", 0x58,Maker){}
-        OPCode58(int addr, Builder *Maker):Instruction(addr,"0x58",0x58,Maker){}
-        OPCode58(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x58", 0x58,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCode5A : public Instruction
-    {
-        public:
-        OPCode5A():Instruction(-1,0x5A,nullptr){}
-        OPCode5A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x5A", 0x5A,Maker){}
-        OPCode5A(int addr, Builder *Maker):Instruction(addr,"0x5A",0x5A,Maker){}
-        OPCode5A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x5A", 0x5A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                if ((unsigned char)control_byte[0] == 0){
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                }
-
-
-        }
-    };
-    class OPCode5B : public Instruction
-    {
-        public:
-        OPCode5B():Instruction(-1,0x5B,nullptr){}
-        OPCode5B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x5B", 0x5B,Maker){}
-        OPCode5B(int addr, Builder *Maker):Instruction(addr,"0x5B",0x5B,Maker){}
-        OPCode5B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x5B", 0x5B,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                sub05(addr, content, this);
-        }
-    };
-    class OPCode5C : public Instruction
-    {
-        public:
-        OPCode5C():Instruction(-1,0x5C,nullptr){}
-        OPCode5C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5C,Maker){}
-        OPCode5C(int addr, Builder *Maker):Instruction(addr,"???",0x5C,Maker){}
-        OPCode5C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-    class OPCode5D : public Instruction
-    {
-        public:
-        OPCode5D():Instruction(-1,0x5D,nullptr){}
-        OPCode5D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5D,Maker){}
-        OPCode5D(int addr, Builder *Maker):Instruction(addr,"???",0x5D,Maker){}
-        OPCode5D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        }
-    };
-    class OPCode5E : public Instruction
-    {
-        public:
-        OPCode5E():Instruction(-1,0x5E,nullptr){}
-        OPCode5E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5E,Maker){}
-        OPCode5E(int addr, Builder *Maker):Instruction(addr,"???",0x5E,Maker){}
-        OPCode5E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5E,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
-
-        }
-    };
-    class OPCode60 : public Instruction
-    {
-        public:
-        OPCode60():Instruction(-1,0x60,nullptr){}
-        OPCode60(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x60,Maker){}
-        OPCode60(int addr, Builder *Maker):Instruction(addr,"???",0x60,Maker){}
-        OPCode60(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x60,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-        }
-    };
-    class OPCode61 : public Instruction
-    {
-        public:
-        OPCode61():Instruction(-1,0x61,nullptr){}
-        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x61,Maker){}
-        OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){}
-        OPCode61(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){
-                addr++;
-
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                }
-
-
-
-        }
-    };
-    class OPCode62 : public Instruction
-    {
-        public:
-        OPCode62():Instruction(-1,0x62,nullptr){}
-        OPCode62(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x62,Maker){}
-        OPCode62(int addr, Builder *Maker):Instruction(addr,"???",0x62,Maker){}
-        OPCode62(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x62,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-        }
-    };
-    class OPCode63 : public Instruction
-    {
-        public:
-        OPCode63():Instruction(-1,0x63,nullptr){}
-        OPCode63(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x63,Maker){}
-        OPCode63(int addr, Builder *Maker):Instruction(addr,"???",0x63,Maker){}
-        OPCode63(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x63,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                this->AddOperande(operande(addr,"short", control_short));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-        }
-    };
-    class OPCode64 : public Instruction
-    {
-        public:
-        OPCode64():Instruction(-1,0x64,nullptr){}
-        OPCode64(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x64,Maker){}
-        OPCode64(int addr, Builder *Maker):Instruction(addr,"???",0x64,Maker){}
-        OPCode64(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x64,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                }
-        }
-    };
-    class OPCode65 : public Instruction
-    {
-        public:
-        OPCode65():Instruction(-1,0x65,nullptr){}
-        OPCode65(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x65,Maker){}
-        OPCode65(int addr, Builder *Maker):Instruction(addr,"???",0x65,Maker){}
-        OPCode65(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x65,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 2:
-                    case 3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-
-                }
-        }
-    };
-    class OPCode66 : public Instruction
-    {
-        public:
-        OPCode66():Instruction(-1,0x66,nullptr){}
-        OPCode66(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x66,Maker){}
-        OPCode66(int addr, Builder *Maker):Instruction(addr,"???",0x66,Maker){}
-        OPCode66(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x66,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-                    case 4:
-                    case 8:
-                    case 6:
-                    case 9:
-                    case 10:
-
-                    case 0xF:
-                    case 0x10:
-                    case 0x11:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0xB:
-                    case 2:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0xD:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-
-                }
-        }
-    };
-    class OPCode67 : public Instruction
-    {
-        public:
-        OPCode67():Instruction(-1,0x67,nullptr){}
-        OPCode67(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x67,Maker){}
-        OPCode67(int addr, Builder *Maker):Instruction(addr,"???",0x67,Maker){}
-        OPCode67(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x67,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
-        }
-    };
-    class OPCode68 : public Instruction
-    {
-        public:
-        OPCode68():Instruction(-1,0x68,nullptr){}
-        OPCode68(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x68,Maker){}
-        OPCode68(int addr, Builder *Maker):Instruction(addr,"???",0x68,Maker){}
-        OPCode68(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x68,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                switch((unsigned char)control_byte[0]){
+    class OPCode68 : public Instruction {
+      public:
+        OPCode68()
+          : Instruction(-1, 0x68, nullptr) {}
+        OPCode68(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x68, Maker) {}
+        OPCode68(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {}
+        OPCode68(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
                 case 1:
                 case '\v':
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 2:
                 case 3:
                 case 4:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case '\a':
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case '\b':
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case '\x18':
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
-
-                }
+            }
         }
     };
-    class OPCode69 : public Instruction
-    {
-        public:
-        OPCode69():Instruction(-1,0x69,nullptr){}
-        OPCode69(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x69,Maker){}
-        OPCode69(int addr, Builder *Maker):Instruction(addr,"???",0x69,Maker){}
-        OPCode69(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x69,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 1:
-                    case 4:
-                    case 7:
-                    case 8:
-                    case 9:
-                    case 0xB:
-                    case 0x13:
-                    case 0x15:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 2:
-                    case 3:
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 10:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-
-                    case 0xC:
-                    case 0xD:
-                    case 0x12:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x14:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x18:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                }
-        }
-    };
-    class OPCode6A : public Instruction
-    {
-        public:
-        OPCode6A():Instruction(-1,0x6A,nullptr){}
-        OPCode6A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6A,Maker){}
-        OPCode6A(int addr, Builder *Maker):Instruction(addr,"???",0x6A,Maker){}
-        OPCode6A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6A,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    case 4:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 5:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-
-                }
-        }
-    };
-    class OPCode6B : public Instruction
-    {
-        public:
-        OPCode6B():Instruction(-1,0x6B,nullptr){}
-        OPCode6B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x6B", 0x6B,Maker){}
-        OPCode6B(int addr, Builder *Maker):Instruction(addr,"0x6B",0x6B,Maker){}
-        OPCode6B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x6B", 0x6B,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCode6C : public Instruction
-    {
-        public:
-        OPCode6C():Instruction(-1,0x6C,nullptr){}
-        OPCode6C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6C,Maker){}
-        OPCode6C(int addr, Builder *Maker):Instruction(addr,"???",0x6C,Maker){}
-        OPCode6C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6C,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode6E : public Instruction
-    {
-        public:
-        OPCode6E():Instruction(-1,0x6E,nullptr){}
-        OPCode6E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6E,Maker){}
-        OPCode6E(int addr, Builder *Maker):Instruction(addr,"???",0x6E,Maker){}
-        OPCode6E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-        }
-    };
-    class OPCode6F : public Instruction
-    {
-        public:
-        OPCode6F():Instruction(-1,0x6F,nullptr){}
-        OPCode6F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x6F", 0x6F,Maker){}
-        OPCode6F(int addr, Builder *Maker):Instruction(addr,"0x6F",0x6F,Maker){}
-        OPCode6F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x6F", 0x6F,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCode70 : public Instruction
-    {
-        public:
-        OPCode70():Instruction(-1,0x70,nullptr){}
-        OPCode70(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x70,Maker){}
-        OPCode70(int addr, Builder *Maker):Instruction(addr,"???",0x70,Maker){}
-        OPCode70(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x70,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 1:
-                    case 7:
-                    case 0xB:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                        break;
-                    case 4:
-                    case 9:
-                    case 0xC:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 3:
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 8:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 10:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 0x0D:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x0E:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
-        }
-    };
-    class OPCode71 : public Instruction // not sure at all
-    {
-        public:
-        OPCode71():Instruction(-1,0x71,nullptr){}
-        OPCode71(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x71,Maker){}
-        OPCode71(int addr, Builder *Maker):Instruction(addr,"???",0x71,Maker){}
-        OPCode71(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x71,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode72 : public Instruction // not sure at all
-    {
-        public:
-        OPCode72():Instruction(-1,0x72,nullptr){}
-        OPCode72(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x72,Maker){}
-        OPCode72(int addr, Builder *Maker):Instruction(addr,"???",0x72,Maker){}
-        OPCode72(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x72,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", control_short));
-                ushort control_shrt = ReadShortFromByteArray(0, control_short);
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                if ((unsigned char) (control_byte[0] - 1U) < 2) {
-                  this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                  this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                }
-                else {
-                  if ((unsigned char)(control_byte[0] - 3U) < 2) {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                  }
-                }
-                if (control_shrt != 0xFFFF){
-                    if (control_shrt<0x100){
-                        switch((unsigned char) control_byte[0]){
-                        case '\x06':
-                            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                            break;
-
-                        }
-                    }
-                }
-        }
-    };
-    class OPCode73 : public Instruction
-    {
-        public:
-        OPCode73():Instruction(-1,0x73,nullptr){}
-        OPCode73(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x73,Maker){}
-        OPCode73(int addr, Builder *Maker):Instruction(addr,"???",0x73,Maker){}
-        OPCode73(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x73,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 1:
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-
-                    case 0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                }
-        }
-    };
-    class OPCode74 : public Instruction
-    {
-        public:
-        OPCode74():Instruction(-1,0x74,nullptr){}
-        OPCode74(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x74,Maker){}
-        OPCode74(int addr, Builder *Maker):Instruction(addr,"???",0x74,Maker){}
-        OPCode74(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x74,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                    case 0x14:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 3:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                }
-        }
-    };
-    class OPCode75 : public Instruction
-    {
-        public:
-        OPCode75():Instruction(-1,0x75,nullptr){}
-        OPCode75(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x75,Maker){}
-        OPCode75(int addr, Builder *Maker):Instruction(addr,"???",0x75,Maker){}
-        OPCode75(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x75,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", control_byte2));
-                if((unsigned char)control_byte2[0]<4){
-                    switch ((unsigned char)control_byte[0])  {
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                    case 4:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case 6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 7:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
-               }
-        }
-    };
-    class OPCode76 : public Instruction
-    {
-        public:
-        OPCode76():Instruction(-1,0x76,nullptr){}
-        OPCode76(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x76,Maker){}
-        OPCode76(int addr, Builder *Maker):Instruction(addr,"???",0x76,Maker){}
-        OPCode76(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x76,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class OPCode77 : public Instruction
-    {
-        public:
-        OPCode77():Instruction(-1,0x77,nullptr){}
-        OPCode77(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x77,Maker){}
-        OPCode77(int addr, Builder *Maker):Instruction(addr,"???",0x77,Maker){}
-        OPCode77(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x77,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-    };
-    class OPCode78 : public Instruction
-    {
-        public:
-        OPCode78():Instruction(-1,0x78,nullptr){}
-        OPCode78(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x78,Maker){}
-        OPCode78(int addr, Builder *Maker):Instruction(addr,"???",0x78,Maker){}
-        OPCode78(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x78,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                switch((unsigned char)control_byte[0]){
-
-                    case 0x1:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-        }
-    };
-    class OPCode79 : public Instruction
-    {
-        public:
-        OPCode79():Instruction(-1,0x79,nullptr){}
-        OPCode79(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x79,Maker){}
-        OPCode79(int addr, Builder *Maker):Instruction(addr,"???",0x79,Maker){}
-        OPCode79(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x79,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                switch((unsigned char)control_byte[0]){
-
-                    case 0x7:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-
-        }
-    };
-    class OPCode7A : public Instruction
-    {
-        public:
-        OPCode7A():Instruction(-1,0x7A,nullptr){}
-        OPCode7A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7A,Maker){}
-        OPCode7A(int addr, Builder *Maker):Instruction(addr,"???",0x7A,Maker){}
-        OPCode7A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 0:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    case 1:
-                    case 2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                }
-        }
-    };
-    class OPCode7B : public Instruction
-    {
-        public:
-        OPCode7B():Instruction(-1,0x7B,nullptr){}
-        OPCode7B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7B,Maker){}
-        OPCode7B(int addr, Builder *Maker):Instruction(addr,"???",0x7B,Maker){}
-        OPCode7B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7B,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 1:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-        }
-    };
-    class OPCode7C : public Instruction
-    {
-        public:
-        OPCode7C():Instruction(-1,0x7C,nullptr){}
-        OPCode7C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7C,Maker){}
-        OPCode7C(int addr, Builder *Maker):Instruction(addr,"???",0x7C,Maker){}
-        OPCode7C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7C,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 0:
-
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//3
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//5
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//7
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//9
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//B
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//D
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//f
-                        break;
-                }
-        }
-    };
-    class OPCode7D : public Instruction
-    {
-        public:
-        OPCode7D():Instruction(-1,0x7D,nullptr){}
-        OPCode7D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7D,Maker){}
-        OPCode7D(int addr, Builder *Maker):Instruction(addr,"???",0x7D,Maker){}
-        OPCode7D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-        }
-    };
-    class OPCode7E : public Instruction
-    {
-        public:
-        OPCode7E():Instruction(-1,0x7E,nullptr){}
-        OPCode7E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7E,Maker){}
-        OPCode7E(int addr, Builder *Maker):Instruction(addr,"???",0x7E,Maker){}
-        OPCode7E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7E,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 2:
-                    case 6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                    case 4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                    case 5:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    break;
-                    case 7:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-
-                }
-        }
-    };
-    class OPCode80 : public Instruction
-    {
-        public:
-        OPCode80():Instruction(-1,0x80,nullptr){}
-        OPCode80(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x80,Maker){}
-        OPCode80(int addr, Builder *Maker):Instruction(addr,"???",0x80,Maker){}
-        OPCode80(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x80,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class OPCode82 : public Instruction
-    {
-        public:
-        OPCode82():Instruction(-1,0x82,nullptr){}
-        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x82,Maker){}
-        OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){}
-        OPCode82(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode83 : public Instruction
-    {
-        public:
-        OPCode83():Instruction(-1,0x83,nullptr){}
-        OPCode83(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x83,Maker){}
-        OPCode83(int addr, Builder *Maker):Instruction(addr,"???",0x83,Maker){}
-        OPCode83(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x83,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    class OPCode84 : public Instruction
-    {
-        public:
-        OPCode84():Instruction(-1,0x84,nullptr){}
-        OPCode84(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x84,Maker){}
-        OPCode84(int addr, Builder *Maker):Instruction(addr,"???",0x84,Maker){}
-        OPCode84(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-
-                switch((unsigned char)control_byte[0]){
-
-                    case 3:{ //not sure
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-                        this->AddOperande(operande(addr,"byte", control_byte2));
-                    break;}
-                    default:{
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    }
-                }
-        }
-    };
-    class OPCode86 : public Instruction
-    {
-        public:
-        OPCode86():Instruction(-1,0x86,nullptr){}
-        OPCode86(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x86", 0x86,Maker){}
-        OPCode86(int addr, Builder *Maker):Instruction(addr,"0x86",0x86,Maker){}
-        OPCode86(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x86", 0x86,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//2
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//4
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//6
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//8
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//c
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-        }
-    };
-    class OPCode87 : public Instruction
-    {
-        public:
-        OPCode87():Instruction(-1,0x87,nullptr){}
-        OPCode87(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x87", 0x87,Maker){}
-        OPCode87(int addr, Builder *Maker):Instruction(addr,"0x87",0x87,Maker){}
-        OPCode87(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x87", 0x87, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-        }
-    };
-    class OPCode88 : public Instruction
-    {
-        public:
-        OPCode88():Instruction(-1,0x88,nullptr){}
-        OPCode88(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x88", 0x88,Maker){}
-        OPCode88(int addr, Builder *Maker):Instruction(addr,"0x88",0x88,Maker){}
-        OPCode88(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x88", 0x88, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-        }
-    };
-    class OPCode89 : public Instruction
-    {
-        public:
-        OPCode89():Instruction(-1,0x89,nullptr){}
-        OPCode89(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x89", 0x89,Maker){}
-        OPCode89(int addr, Builder *Maker):Instruction(addr,"0x89",0x89,Maker){}
-        OPCode89(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x89", 0x89, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-        }
-    };
-    class OPCode8A : public Instruction
-    {
-        public:
-        OPCode8A():Instruction(-1,0x8A,nullptr){}
-        OPCode8A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8A", 0x8A,Maker){}
-        OPCode8A(int addr, Builder *Maker):Instruction(addr,"0x8A",0x8A,Maker){}
-        OPCode8A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8A", 0x8A,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode69 : public Instruction {
+      public:
+        OPCode69()
+          : Instruction(-1, 0x69, nullptr) {}
+        OPCode69(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x69, Maker) {}
+        OPCode69(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {}
+        OPCode69(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 1:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 4:
+                case 7:
+                case 8:
+                case 9:
+                case 0xB:
+                case 0x13:
+                case 0x15:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 2:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 3:
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 10:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+
+                case 0xC:
+                case 0xD:
+                case 0x12:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x14:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x18:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode6A : public Instruction {
+      public:
+        OPCode6A()
+          : Instruction(-1, 0x6A, nullptr) {}
+        OPCode6A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6A, Maker) {}
+        OPCode6A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {}
+        OPCode6A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                case 4:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 5:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+            }
+        }
+    };
+    class OPCode6B : public Instruction {
+      public:
+        OPCode6B()
+          : Instruction(-1, 0x6B, nullptr) {}
+        OPCode6B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x6B", 0x6B, Maker) {}
+        OPCode6B(int addr, Builder* Maker)
+          : Instruction(addr, "0x6B", 0x6B, Maker) {}
+        OPCode6B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x6B", 0x6B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode6C : public Instruction {
+      public:
+        OPCode6C()
+          : Instruction(-1, 0x6C, nullptr) {}
+        OPCode6C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6C, Maker) {}
+        OPCode6C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {}
+        OPCode6C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode6E : public Instruction {
+      public:
+        OPCode6E()
+          : Instruction(-1, 0x6E, nullptr) {}
+        OPCode6E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6E, Maker) {}
+        OPCode6E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {}
+        OPCode6E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCode6F : public Instruction {
+      public:
+        OPCode6F()
+          : Instruction(-1, 0x6F, nullptr) {}
+        OPCode6F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x6F", 0x6F, Maker) {}
+        OPCode6F(int addr, Builder* Maker)
+          : Instruction(addr, "0x6F", 0x6F, Maker) {}
+        OPCode6F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x6F", 0x6F, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode70 : public Instruction {
+      public:
+        OPCode70()
+          : Instruction(-1, 0x70, nullptr) {}
+        OPCode70(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x70, Maker) {}
+        OPCode70(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {}
+        OPCode70(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 1:
+                case 7:
+                case 0xB:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                case 4:
+                case 9:
+                case 0xC:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 3:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 8:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 10:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x0D:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x0E:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
+        }
+    };
+    class OPCode71
+      : public Instruction // not sure at all
+    {
+      public:
+        OPCode71()
+          : Instruction(-1, 0x71, nullptr) {}
+        OPCode71(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x71, Maker) {}
+        OPCode71(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x71, Maker) {}
+        OPCode71(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x71, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode72
+      : public Instruction // not sure at all
+    {
+      public:
+        OPCode72()
+          : Instruction(-1, 0x72, nullptr) {}
+        OPCode72(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x72, Maker) {}
+        OPCode72(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {}
+        OPCode72(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            this->AddOperande(operande(addr, "short", control_short));
+            ushort control_shrt = ReadShortFromByteArray(0, control_short);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            if ((unsigned char)(control_byte[0] - 1U) < 2) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+            } else {
+                if ((unsigned char)(control_byte[0] - 3U) < 2) {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                }
+            }
+            if (control_shrt != 0xFFFF) {
+                if (control_shrt < 0x100) {
+                    switch ((unsigned char)control_byte[0]) {
+                        case '\x06':
+                            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                            break;
+                    }
+                }
+            }
+        }
+    };
+    class OPCode73 : public Instruction {
+      public:
+        OPCode73()
+          : Instruction(-1, 0x73, nullptr) {}
+        OPCode73(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x73, Maker) {}
+        OPCode73(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {}
+        OPCode73(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 1:
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+
+                case 0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+            }
+        }
+    };
+    class OPCode74 : public Instruction {
+      public:
+        OPCode74()
+          : Instruction(-1, 0x74, nullptr) {}
+        OPCode74(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x74, Maker) {}
+        OPCode74(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {}
+        OPCode74(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 0x14:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+            }
+        }
+    };
+    class OPCode75 : public Instruction {
+      public:
+        OPCode75()
+          : Instruction(-1, 0x75, nullptr) {}
+        OPCode75(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x75, Maker) {}
+        OPCode75(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x75, Maker) {}
+        OPCode75(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x75, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte2));
+            if ((unsigned char)control_byte2[0] < 4) {
+                switch ((unsigned char)control_byte[0]) {
+                    case 0:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 1:
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 2:
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                        break;
+                    case 4:
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                        break;
+                    case 5:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    case 6:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    case 7:
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                }
+            }
+        }
+    };
+    class OPCode76 : public Instruction {
+      public:
+        OPCode76()
+          : Instruction(-1, 0x76, nullptr) {}
+        OPCode76(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x76, Maker) {}
+        OPCode76(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x76, Maker) {}
+        OPCode76(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x76, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode77 : public Instruction {
+      public:
+        OPCode77()
+          : Instruction(-1, 0x77, nullptr) {}
+        OPCode77(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x77, Maker) {}
+        OPCode77(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x77, Maker) {}
+        OPCode77(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x77, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode78 : public Instruction {
+      public:
+        OPCode78()
+          : Instruction(-1, 0x78, nullptr) {}
+        OPCode78(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x78, Maker) {}
+        OPCode78(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {}
+        OPCode78(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
+
+                case 0x1:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode79 : public Instruction {
+      public:
+        OPCode79()
+          : Instruction(-1, 0x79, nullptr) {}
+        OPCode79(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x79, Maker) {}
+        OPCode79(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {}
+        OPCode79(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+
+                case 0x7:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode7A : public Instruction {
+      public:
+        OPCode7A()
+          : Instruction(-1, 0x7A, nullptr) {}
+        OPCode7A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7A, Maker) {}
+        OPCode7A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {}
+        OPCode7A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 0:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 1:
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+            }
+        }
+    };
+    class OPCode7B : public Instruction {
+      public:
+        OPCode7B()
+          : Instruction(-1, 0x7B, nullptr) {}
+        OPCode7B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7B, Maker) {}
+        OPCode7B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {}
+        OPCode7B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 1:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode7C : public Instruction {
+      public:
+        OPCode7C()
+          : Instruction(-1, 0x7C, nullptr) {}
+        OPCode7C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7C, Maker) {}
+        OPCode7C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7C, Maker) {}
+        OPCode7C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 0:
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 3
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 5
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 7
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 9
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // B
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // D
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // f
+                    break;
+            }
+        }
+    };
+    class OPCode7D : public Instruction {
+      public:
+        OPCode7D()
+          : Instruction(-1, 0x7D, nullptr) {}
+        OPCode7D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7D, Maker) {}
+        OPCode7D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7D, Maker) {}
+        OPCode7D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode7E : public Instruction {
+      public:
+        OPCode7E()
+          : Instruction(-1, 0x7E, nullptr) {}
+        OPCode7E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7E, Maker) {}
+        OPCode7E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {}
+        OPCode7E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 2:
+                case 6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 4:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 5:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 7:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCode80 : public Instruction {
+      public:
+        OPCode80()
+          : Instruction(-1, 0x80, nullptr) {}
+        OPCode80(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x80, Maker) {}
+        OPCode80(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {}
+        OPCode80(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode82 : public Instruction {
+      public:
+        OPCode82()
+          : Instruction(-1, 0x82, nullptr) {}
+        OPCode82(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x82, Maker) {}
+        OPCode82(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {}
+        OPCode82(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode83 : public Instruction {
+      public:
+        OPCode83()
+          : Instruction(-1, 0x83, nullptr) {}
+        OPCode83(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x83, Maker) {}
+        OPCode83(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {}
+        OPCode83(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode84 : public Instruction {
+      public:
+        OPCode84()
+          : Instruction(-1, 0x84, nullptr) {}
+        OPCode84(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x84, Maker) {}
+        OPCode84(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {}
+        OPCode84(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            switch ((unsigned char)control_byte[0]) {
+
+                case 3: { // not sure
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+                    this->AddOperande(operande(addr, "byte", control_byte2));
+                    break;
+                }
+                default: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                }
+            }
+        }
+    };
+    class OPCode86 : public Instruction {
+      public:
+        OPCode86()
+          : Instruction(-1, 0x86, nullptr) {}
+        OPCode86(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x86", 0x86, Maker) {}
+        OPCode86(int addr, Builder* Maker)
+          : Instruction(addr, "0x86", 0x86, Maker) {}
+        OPCode86(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x86", 0x86, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 2
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 4
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 6
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 8
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // A
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // c
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    class OPCode87 : public Instruction {
+      public:
+        OPCode87()
+          : Instruction(-1, 0x87, nullptr) {}
+        OPCode87(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x87", 0x87, Maker) {}
+        OPCode87(int addr, Builder* Maker)
+          : Instruction(addr, "0x87", 0x87, Maker) {}
+        OPCode87(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x87", 0x87, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCode88 : public Instruction {
+      public:
+        OPCode88()
+          : Instruction(-1, 0x88, nullptr) {}
+        OPCode88(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x88", 0x88, Maker) {}
+        OPCode88(int addr, Builder* Maker)
+          : Instruction(addr, "0x88", 0x88, Maker) {}
+        OPCode88(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x88", 0x88, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode89 : public Instruction {
+      public:
+        OPCode89()
+          : Instruction(-1, 0x89, nullptr) {}
+        OPCode89(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x89", 0x89, Maker) {}
+        OPCode89(int addr, Builder* Maker)
+          : Instruction(addr, "0x89", 0x89, Maker) {}
+        OPCode89(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x89", 0x89, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCode8A : public Instruction {
+      public:
+        OPCode8A()
+          : Instruction(-1, 0x8A, nullptr) {}
+        OPCode8A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8A", 0x8A, Maker) {}
+        OPCode8A(int addr, Builder* Maker)
+          : Instruction(addr, "0x8A", 0x8A, Maker) {}
+        OPCode8A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8A", 0x8A, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xA:
                 case 0xC:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0xB:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 case 0xD:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
 
                 case 0xFE:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xFF:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 default:
-                    if (((unsigned char)control_byte[0] - 0x32U) < 2){
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    if (((unsigned char)control_byte[0] - 0x32U) < 2) {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     }
                     break;
-                }
+            }
         }
     };
-    class OPCode8B : public Instruction
-    {
-        public:
-        OPCode8B():Instruction(-1,0x8B,nullptr){}
-        OPCode8B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8B", 0x8B,Maker){}
-        OPCode8B(int addr, Builder *Maker):Instruction(addr,"0x8B",0x8B,Maker){}
-        OPCode8B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8B", 0x8B,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+    class OPCode8B : public Instruction {
+      public:
+        OPCode8B()
+          : Instruction(-1, 0x8B, nullptr) {}
+        OPCode8B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8B", 0x8B, Maker) {}
+        OPCode8B(int addr, Builder* Maker)
+          : Instruction(addr, "0x8B", 0x8B, Maker) {}
+        OPCode8B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8B", 0x8B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCode8C : public Instruction
-    {
-        public:
-        OPCode8C():Instruction(-1,0x8C,nullptr){}
-        OPCode8C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8C", 0x8C,Maker){}
-        OPCode8C(int addr, Builder *Maker):Instruction(addr,"0x8C",0x8C,Maker){}
-        OPCode8C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8C", 0x8C,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode8C : public Instruction {
+      public:
+        OPCode8C()
+          : Instruction(-1, 0x8C, nullptr) {}
+        OPCode8C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8C", 0x8C, Maker) {}
+        OPCode8C(int addr, Builder* Maker)
+          : Instruction(addr, "0x8C", 0x8C, Maker) {}
+        OPCode8C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8C", 0x8C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 case 3:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 4:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
-                }
+            }
         }
     };
-    class OPCode8D : public Instruction
-    {
-        public:
-        OPCode8D():Instruction(-1,0x8D,nullptr){}
-        OPCode8D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8D", 0x8D,Maker){}
-        OPCode8D(int addr, Builder *Maker):Instruction(addr,"0x8D",0x8D,Maker){}
-        OPCode8D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8D", 0x8D, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
+    class OPCode8D : public Instruction {
+      public:
+        OPCode8D()
+          : Instruction(-1, 0x8D, nullptr) {}
+        OPCode8D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8D", 0x8D, Maker) {}
+        OPCode8D(int addr, Builder* Maker)
+          : Instruction(addr, "0x8D", 0x8D, Maker) {}
+        OPCode8D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8D", 0x8D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode8E : public Instruction
-    {
-        public:
-        OPCode8E():Instruction(-1,0x8E,nullptr){}
-        OPCode8E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8E", 0x8E,Maker){}
-        OPCode8E(int addr, Builder *Maker):Instruction(addr,"0x8E",0x8E,Maker){}
-        OPCode8E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x8E", 0x8E, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCode8E : public Instruction {
+      public:
+        OPCode8E()
+          : Instruction(-1, 0x8E, nullptr) {}
+        OPCode8E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8E", 0x8E, Maker) {}
+        OPCode8E(int addr, Builder* Maker)
+          : Instruction(addr, "0x8E", 0x8E, Maker) {}
+        OPCode8E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8E", 0x8E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode8F : public Instruction
-    {
-        public:
-        OPCode8F():Instruction(-1,0x8F,nullptr){}
-        OPCode8F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x8F", 0x8F,Maker){}
-        OPCode8F(int addr, Builder *Maker):Instruction(addr,"0x8F",0x8F,Maker){}
-        OPCode8F(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0x8F", 0x8F, Maker){
-                addr++;
+    class OPCode8F : public Instruction {
+      public:
+        OPCode8F()
+          : Instruction(-1, 0x8F, nullptr) {}
+        OPCode8F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x8F", 0x8F, Maker) {}
+        OPCode8F(int addr, Builder* Maker)
+          : Instruction(addr, "0x8F", 0x8F, Maker) {}
+        OPCode8F(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x8F", 0x8F, Maker) {
+            addr++;
         }
     };
-    class OPCode98 : public Instruction
-    {
-        public:
-        OPCode98():Instruction(-1,0x98,nullptr){}
-        OPCode98(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x98", 0x98,Maker){}
-        OPCode98(int addr, Builder *Maker):Instruction(addr,"0x98",0x98,Maker){}
-        OPCode98(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x98", 0x98,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                this->AddOperande(operande(addr,"short", control_short));
-                short control_shrt = ReadShortFromByteArray(0, control_short);
-                switch(control_shrt){
-                 case 1:
-                 case 2:
-                 case 6:
-                 case 7:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+    class OPCode98 : public Instruction {
+      public:
+        OPCode98()
+          : Instruction(-1, 0x98, nullptr) {}
+        OPCode98(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x98", 0x98, Maker) {}
+        OPCode98(int addr, Builder* Maker)
+          : Instruction(addr, "0x98", 0x98, Maker) {}
+        OPCode98(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x98", 0x98, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            this->AddOperande(operande(addr, "short", control_short));
+            short control_shrt = ReadShortFromByteArray(0, control_short);
+            switch (control_shrt) {
+                case 1:
+                case 2:
+                case 6:
+                case 7:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
-                 case 3:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                 case 0x3E8:
-                 case 0x3E9:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x3E8:
+                case 0x3E9:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 2000:
-                   this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                   this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                   this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                   break;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
                 case 3000:
-                   this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                   this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                   this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                   this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                   break;
+                    break;
                 case 4000:
-                   this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                   this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                   this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                   this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                   break;
+                    break;
                 case 0xFA1:
-                   this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                   this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                   this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                   this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                   break;
+                    break;
                 case 5000:
                 case 0x1389:
                 case 0x138A:
@@ -5512,1795 +5825,2096 @@ class CS4Builder : public Builder
                 case 0x1964:
                 case 6000:
                 case 9000:
-                   this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                   break;
+                    break;
                 case 7000:
-                   this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                   break;
+                    break;
                 case 8000:
-                   this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                   this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                   break;
-                }
-
-
-
+                    break;
+            }
         }
     };
-    class OPCode90 : public Instruction
-    {
-        public:
-        OPCode90():Instruction(-1,0x90,nullptr){}
-        OPCode90(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x90", 0x90,Maker){}
-        OPCode90(int addr, Builder *Maker):Instruction(addr,"0x90",0x90,Maker){}
-        OPCode90(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x90", 0x90,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+    class OPCode90 : public Instruction {
+      public:
+        OPCode90()
+          : Instruction(-1, 0x90, nullptr) {}
+        OPCode90(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x90", 0x90, Maker) {}
+        OPCode90(int addr, Builder* Maker)
+          : Instruction(addr, "0x90", 0x90, Maker) {}
+        OPCode90(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x90", 0x90, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode91 : public Instruction
-    {
-        public:
-        OPCode91():Instruction(-1,0x91,nullptr){}
-        OPCode91(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x91", 0x91,Maker){}
-        OPCode91(int addr, Builder *Maker):Instruction(addr,"0x91",0x91,Maker){}
-        OPCode91(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x91", 0x91, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode91 : public Instruction {
+      public:
+        OPCode91()
+          : Instruction(-1, 0x91, nullptr) {}
+        OPCode91(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x91", 0x91, Maker) {}
+        OPCode91(int addr, Builder* Maker)
+          : Instruction(addr, "0x91", 0x91, Maker) {}
+        OPCode91(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x91", 0x91, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
                 case 1:
                 case 5:
                 case 0xA:
                 case 0xB:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 2:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-
-                }
-
+            }
         }
     };
-    class OPCode92 : public Instruction
-    {
-        public:
-        OPCode92():Instruction(-1,0x92,nullptr){}
-        OPCode92(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x92", 0x92,Maker){}
-        OPCode92(int addr, Builder *Maker):Instruction(addr,"0x92",0x92,Maker){}
-        OPCode92(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x92", 0x92,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+    class OPCode92 : public Instruction {
+      public:
+        OPCode92()
+          : Instruction(-1, 0x92, nullptr) {}
+        OPCode92(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x92", 0x92, Maker) {}
+        OPCode92(int addr, Builder* Maker)
+          : Instruction(addr, "0x92", 0x92, Maker) {}
+        OPCode92(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x92", 0x92, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode93 : public Instruction
-    {
-        public:
-        OPCode93():Instruction(-1,0x93,nullptr){}
-        OPCode93(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x93", 0x93,Maker){}
-        OPCode93(int addr, Builder *Maker):Instruction(addr,"0x93",0x93,Maker){}
-        OPCode93(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x93", 0x93, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((char)control_byte[0]){
+    class OPCode93 : public Instruction {
+      public:
+        OPCode93()
+          : Instruction(-1, 0x93, nullptr) {}
+        OPCode93(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x93", 0x93, Maker) {}
+        OPCode93(int addr, Builder* Maker)
+          : Instruction(addr, "0x93", 0x93, Maker) {}
+        OPCode93(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x93", 0x93, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((char)control_byte[0]) {
                 case 0:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case -0x2e:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
-                }
-
-
+            }
         }
     };
-    class OPCode94 : public Instruction
-    {
-        public:
-        OPCode94():Instruction(-1,0x94,nullptr){}
-        OPCode94(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x94", 0x94,Maker){}
-        OPCode94(int addr, Builder *Maker):Instruction(addr,"0x94",0x94,Maker){}
-        OPCode94(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x94", 0x94,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode94 : public Instruction {
+      public:
+        OPCode94()
+          : Instruction(-1, 0x94, nullptr) {}
+        OPCode94(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x94", 0x94, Maker) {}
+        OPCode94(int addr, Builder* Maker)
+          : Instruction(addr, "0x94", 0x94, Maker) {}
+        OPCode94(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x94", 0x94, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
-                }
-
-
+            }
         }
     };
-    class OPCode95 : public Instruction
-    {
-        public:
-        OPCode95():Instruction(-1,0x95,nullptr){}
-        OPCode95(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x95", 0x95,Maker){}
-        OPCode95(int addr, Builder *Maker):Instruction(addr,"0x95",0x95,Maker){}
-        OPCode95(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x95", 0x95, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                }
-
-
+    class OPCode95 : public Instruction {
+      public:
+        OPCode95()
+          : Instruction(-1, 0x95, nullptr) {}
+        OPCode95(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x95", 0x95, Maker) {}
+        OPCode95(int addr, Builder* Maker)
+          : Instruction(addr, "0x95", 0x95, Maker) {}
+        OPCode95(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x95", 0x95, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
     };
-    class OPCode97 : public Instruction
-    {
-        public:
-        OPCode97():Instruction(-1,0x97,nullptr){}
-        OPCode97(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x97", 0x97,Maker){}
-        OPCode97(int addr, Builder *Maker):Instruction(addr,"0x97",0x97,Maker){}
-        OPCode97(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x97", 0x97, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
+    class OPCode97 : public Instruction {
+      public:
+        OPCode97()
+          : Instruction(-1, 0x97, nullptr) {}
+        OPCode97(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x97", 0x97, Maker) {}
+        OPCode97(int addr, Builder* Maker)
+          : Instruction(addr, "0x97", 0x97, Maker) {}
+        OPCode97(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x97", 0x97, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCode99 : public Instruction
-    {
-        public:
-        OPCode99():Instruction(-1,0x99,nullptr){}
-        OPCode99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x99", 0x99,Maker){}
-        OPCode99(int addr, Builder *Maker):Instruction(addr,"0x99",0x99,Maker){}
-        OPCode99(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x99", 0x99, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+    class OPCode99 : public Instruction {
+      public:
+        OPCode99()
+          : Instruction(-1, 0x99, nullptr) {}
+        OPCode99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x99", 0x99, Maker) {}
+        OPCode99(int addr, Builder* Maker)
+          : Instruction(addr, "0x99", 0x99, Maker) {}
+        OPCode99(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x99", 0x99, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode9A : public Instruction
-    {
-        public:
-        OPCode9A():Instruction(-1,0x9A,nullptr){}
-        OPCode9A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9A", 0x9A,Maker){}
-        OPCode9A(int addr, Builder *Maker):Instruction(addr,"0x9A",0x9A,Maker){}
-        OPCode9A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9A", 0x9A, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-
+    class OPCode9A : public Instruction {
+      public:
+        OPCode9A()
+          : Instruction(-1, 0x9A, nullptr) {}
+        OPCode9A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9A", 0x9A, Maker) {}
+        OPCode9A(int addr, Builder* Maker)
+          : Instruction(addr, "0x9A", 0x9A, Maker) {}
+        OPCode9A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9A", 0x9A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCode9B : public Instruction
-    {
-        public:
-        OPCode9B():Instruction(-1,0x9B,nullptr){}
-        OPCode9B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9B", 0x9B,Maker){}
-        OPCode9B(int addr, Builder *Maker):Instruction(addr,"0x9B",0x9B,Maker){}
-        OPCode9B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9B", 0x9B, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x00:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-
-                }
-
+    class OPCode9B : public Instruction {
+      public:
+        OPCode9B()
+          : Instruction(-1, 0x9B, nullptr) {}
+        OPCode9B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9B", 0x9B, Maker) {}
+        OPCode9B(int addr, Builder* Maker)
+          : Instruction(addr, "0x9B", 0x9B, Maker) {}
+        OPCode9B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9B", 0x9B, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
     };
-    class OPCode9C : public Instruction
-    {
-        public:
-        OPCode9C():Instruction(-1,0x9C,nullptr){}
-        OPCode9C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9C", 0x9C,Maker){}
-        OPCode9C(int addr, Builder *Maker):Instruction(addr,"0x9C",0x9C,Maker){}
-        OPCode9C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9C", 0x9C, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode9C : public Instruction {
+      public:
+        OPCode9C()
+          : Instruction(-1, 0x9C, nullptr) {}
+        OPCode9C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9C", 0x9C, Maker) {}
+        OPCode9C(int addr, Builder* Maker)
+          : Instruction(addr, "0x9C", 0x9C, Maker) {}
+        OPCode9C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9C", 0x9C, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
                 case 0x00:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
 
                 case 0x02:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
-                }
-
+            }
         }
     };
-    class OPCode9D : public Instruction
-    {
-        public:
-        OPCode9D():Instruction(-1,0x9D,nullptr){}
-        OPCode9D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9D", 0x9D,Maker){}
-        OPCode9D(int addr, Builder *Maker):Instruction(addr,"0x9D",0x9D,Maker){}
-        OPCode9D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9D", 0x9D, Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+    class OPCode9D : public Instruction {
+      public:
+        OPCode9D()
+          : Instruction(-1, 0x9D, nullptr) {}
+        OPCode9D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9D", 0x9D, Maker) {}
+        OPCode9D(int addr, Builder* Maker)
+          : Instruction(addr, "0x9D", 0x9D, Maker) {}
+        OPCode9D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9D", 0x9D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCode9E : public Instruction
-    {
-        public:
-        OPCode9E():Instruction(-1,0x9E,nullptr){}
-        OPCode9E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0x9E", 0x9E,Maker){}
-        OPCode9E(int addr, Builder *Maker):Instruction(addr,"0x9E",0x9E,Maker){}
-        OPCode9E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0x9E", 0x9E, Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode9E : public Instruction {
+      public:
+        OPCode9E()
+          : Instruction(-1, 0x9E, nullptr) {}
+        OPCode9E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0x9E", 0x9E, Maker) {}
+        OPCode9E(int addr, Builder* Maker)
+          : Instruction(addr, "0x9E", 0x9E, Maker) {}
+        OPCode9E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0x9E", 0x9E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
                 case 0xF:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x11:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 0x12:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                }
-
+            }
         }
     };
-    class OPCodeA0 : public Instruction
-    {
-        public:
-        OPCodeA0():Instruction(-1,0xA0,nullptr){}
-        OPCodeA0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA0", 0xA0,Maker){}
-        OPCodeA0(int addr, Builder *Maker):Instruction(addr,"0xA0",0xA0,Maker){}
-        OPCodeA0(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xA0", 0xA0,Maker){
-                addr++;
+    class OPCodeA0 : public Instruction {
+      public:
+        OPCodeA0()
+          : Instruction(-1, 0xA0, nullptr) {}
+        OPCodeA0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA0", 0xA0, Maker) {}
+        OPCodeA0(int addr, Builder* Maker)
+          : Instruction(addr, "0xA0", 0xA0, Maker) {}
+        OPCodeA0(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA0", 0xA0, Maker) {
+            addr++;
         }
     };
-    class OPCodeA1 : public Instruction
-    {
-        public:
-        OPCodeA1():Instruction(-1,0xA1,nullptr){}
-        OPCodeA1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA1", 0xA1,Maker){}
-        OPCodeA1(int addr, Builder *Maker):Instruction(addr,"0xA1",0xA1,Maker){}
-        OPCodeA1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA1", 0xA1,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCodeA1 : public Instruction {
+      public:
+        OPCodeA1()
+          : Instruction(-1, 0xA1, nullptr) {}
+        OPCodeA1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA1", 0xA1, Maker) {}
+        OPCodeA1(int addr, Builder* Maker)
+          : Instruction(addr, "0xA1", 0xA1, Maker) {}
+        OPCodeA1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA1", 0xA1, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCodeA3 : public Instruction
-    {
-        public:
-        OPCodeA3():Instruction(-1,0xA3,nullptr){}
-        OPCodeA3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA3", 0xA3,Maker){}
-        OPCodeA3(int addr, Builder *Maker):Instruction(addr,"0xA3",0xA3,Maker){}
-        OPCodeA3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA3", 0xA3,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCodeA3 : public Instruction {
+      public:
+        OPCodeA3()
+          : Instruction(-1, 0xA3, nullptr) {}
+        OPCodeA3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA3", 0xA3, Maker) {}
+        OPCodeA3(int addr, Builder* Maker)
+          : Instruction(addr, "0xA3", 0xA3, Maker) {}
+        OPCodeA3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA3", 0xA3, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCodeA4 : public Instruction
-    {
-        public:
-        OPCodeA4():Instruction(-1,0xA4,nullptr){}
-        OPCodeA4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA4", 0xA4,Maker){}
-        OPCodeA4(int addr, Builder *Maker):Instruction(addr,"0xA4",0xA4,Maker){}
-        OPCodeA4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA4", 0xA4,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+    class OPCodeA4 : public Instruction {
+      public:
+        OPCodeA4()
+          : Instruction(-1, 0xA4, nullptr) {}
+        OPCodeA4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA4", 0xA4, Maker) {}
+        OPCodeA4(int addr, Builder* Maker)
+          : Instruction(addr, "0xA4", 0xA4, Maker) {}
+        OPCodeA4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA4", 0xA4, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCodeA6 : public Instruction
-    {
-        public:
-        OPCodeA6():Instruction(-1,0xA6,nullptr){}
-        OPCodeA6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA6", 0xA6,Maker){}
-        OPCodeA6(int addr, Builder *Maker):Instruction(addr,"0xA6",0xA6,Maker){}
-        OPCodeA6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA6", 0xA6,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
+    class OPCodeA6 : public Instruction {
+      public:
+        OPCodeA6()
+          : Instruction(-1, 0xA6, nullptr) {}
+        OPCodeA6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA6", 0xA6, Maker) {}
+        OPCodeA6(int addr, Builder* Maker)
+          : Instruction(addr, "0xA6", 0xA6, Maker) {}
+        OPCodeA6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA6", 0xA6, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCodeA8 : public Instruction
-    {
-        public:
-        OPCodeA8():Instruction(-1,0xA8,nullptr){}
-        OPCodeA8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA8", 0xA8,Maker){}
-        OPCodeA8(int addr, Builder *Maker):Instruction(addr,"0xA8",0xA8,Maker){}
-        OPCodeA8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA8", 0xA8,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
+    class OPCodeA8 : public Instruction {
+      public:
+        OPCodeA8()
+          : Instruction(-1, 0xA8, nullptr) {}
+        OPCodeA8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA8", 0xA8, Maker) {}
+        OPCodeA8(int addr, Builder* Maker)
+          : Instruction(addr, "0xA8", 0xA8, Maker) {}
+        OPCodeA8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA8", 0xA8, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class OPCodeA9 : public Instruction
-    {
-        public:
-        OPCodeA9():Instruction(-1,0xA9,nullptr){}
-        OPCodeA9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xA9", 0xA9,Maker){}
-        OPCodeA9(int addr, Builder *Maker):Instruction(addr,"0xA9",0xA9,Maker){}
-        OPCodeA9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xA9", 0xA9,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+    class OPCodeA9 : public Instruction {
+      public:
+        OPCodeA9()
+          : Instruction(-1, 0xA9, nullptr) {}
+        OPCodeA9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xA9", 0xA9, Maker) {}
+        OPCodeA9(int addr, Builder* Maker)
+          : Instruction(addr, "0xA9", 0xA9, Maker) {}
+        OPCodeA9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xA9", 0xA9, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCodeAA : public Instruction
-    {
-        public:
-        OPCodeAA():Instruction(-1,0xAA,nullptr){}
-        OPCodeAA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAA", 0xAA,Maker){}
-        OPCodeAA(int addr, Builder *Maker):Instruction(addr,"0xAA",0xAA,Maker){}
-        OPCodeAA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAA", 0xAA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+    class OPCodeAA : public Instruction {
+      public:
+        OPCodeAA()
+          : Instruction(-1, 0xAA, nullptr) {}
+        OPCodeAA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAA", 0xAA, Maker) {}
+        OPCodeAA(int addr, Builder* Maker)
+          : Instruction(addr, "0xAA", 0xAA, Maker) {}
+        OPCodeAA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAA", 0xAA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCodeAB : public Instruction
-    {
-        public:
-        OPCodeAB():Instruction(-1,0xAB,nullptr){}
-        OPCodeAB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAB", 0xAB,Maker){}
-        OPCodeAB(int addr, Builder *Maker):Instruction(addr,"0xAB",0xAB,Maker){}
-        OPCodeAB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAB", 0xAB,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        for (int i = 4; i <=0x36; i++) this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-
-                    case 0x2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        for (int i = 3; i <=0x65; i+=2) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        break;
-                }
-
-        }
-    };
-    class OPCodeAC : public Instruction
-    {
-        public:
-        OPCodeAC():Instruction(-1,0xAC,nullptr){}
-        OPCodeAC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAC", 0xAC,Maker){}
-        OPCodeAC(int addr, Builder *Maker):Instruction(addr,"0xAC",0xAC,Maker){}
-        OPCodeAC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAC", 0xAC,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-
-                    case 0x1:
-                        fun_1403c90e0(addr, content, this, 1);
-
-                        break;
-                    case 0x2:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    case '\r':
-                    case 0x5:
-                    case 0x3:
-                    case 0x4:
-                    case 0x12:
-                        fun_1403c90e0(addr, content, this, 1);
-
-                        break;
-                    case 0xF:
-                    case '\v':
-                    case '\a':
-                    case '\t':
-                    case 0x13:
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                }
-
-        }
-    };
-    class OPCodeAD : public Instruction
-    {
-        public:
-        OPCodeAD():Instruction(-1,0xAD,nullptr){}
-        OPCodeAD(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAD", 0xAD,Maker){}
-        OPCodeAD(int addr, Builder *Maker):Instruction(addr,"0xAD",0xAD,Maker){}
-        OPCodeAD(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAD", 0xAD,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x00:
-                    case 0x01:
-                    case 0x03:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x02:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                }
-        }
-    };
-    class OPCodeAE : public Instruction
-    {
-        public:
-        OPCodeAE():Instruction(-1,0xAE,nullptr){}
-        OPCodeAE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAE", 0xAE,Maker){}
-        OPCodeAE(int addr, Builder *Maker):Instruction(addr,"0xAE",0xAE,Maker){}
-        OPCodeAE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAE", 0xAE,Maker){
-                addr++;
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-        }
-    };
-    class OPCodeAF : public Instruction
-    {
-        public:
-        OPCodeAF():Instruction(-1,0xAF,nullptr){}
-        OPCodeAF(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xAF", 0xAF,Maker){}
-        OPCodeAF(int addr, Builder *Maker):Instruction(addr,"0xAF",0xAF,Maker){}
-        OPCodeAF(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xAF", 0xAF,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCodeB1 : public Instruction
-    {
-        public:
-        OPCodeB1():Instruction(-1,0xB1,nullptr){}
-        OPCodeB1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB1", 0xB1,Maker){}
-        OPCodeB1(int addr, Builder *Maker):Instruction(addr,"0xB1",0xB1,Maker){}
-        OPCodeB1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB1", 0xB1,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCodeB2 : public Instruction
-    {
-        public:
-        OPCodeB2():Instruction(-1,0xB2,nullptr){}
-        OPCodeB2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB2", 0xB2,Maker){}
-        OPCodeB2(int addr, Builder *Maker):Instruction(addr,"0xB2",0xB2,Maker){}
-        OPCodeB2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB2", 0xB2,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-
-        }
-    };
-    class OPCodeB3 : public Instruction
-    {
-        public:
-        OPCodeB3():Instruction(-1,0xB3,nullptr){}
-        OPCodeB3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB3", 0xB3,Maker){}
-        OPCodeB3(int addr, Builder *Maker):Instruction(addr,"0xB3",0xB3,Maker){}
-        OPCodeB3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB3", 0xB3,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-
-        }
-    };
-    class OPCodeB4 : public Instruction
-    {
-        public:
-        OPCodeB4():Instruction(-1,0xB4,nullptr){}
-        OPCodeB4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB4", 0xB4,Maker){}
-        OPCodeB4(int addr, Builder *Maker):Instruction(addr,"0xB4",0xB4,Maker){}
-        OPCodeB4(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xB4", 0xB4,Maker){
-                addr++;
-
-
-        }
-    };
-    class OPCodeB5 : public Instruction
-    {
-        public:
-        OPCodeB5():Instruction(-1,0xB5,nullptr){}
-        OPCodeB5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB5", 0xB5,Maker){}
-        OPCodeB5(int addr, Builder *Maker):Instruction(addr,"0xB5",0xB5,Maker){}
-        OPCodeB5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB5", 0xB5,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-
-        }
-    };
-    class OPCodeB6 : public Instruction
-    {
-        public:
-        OPCodeB6():Instruction(-1,0xB6,nullptr){}
-        OPCodeB6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB6", 0xB6,Maker){}
-        OPCodeB6(int addr, Builder *Maker):Instruction(addr,"0xB6",0xB6,Maker){}
-        OPCodeB6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB6", 0xB6,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-
-        }
-    };
-    class OPCodeB7 : public Instruction
-    {
-        public:
-        OPCodeB7():Instruction(-1,0xB7,nullptr){}
-        OPCodeB7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB7", 0xB7,Maker){}
-        OPCodeB7(int addr, Builder *Maker):Instruction(addr,"0xB7",0xB7,Maker){}
-        OPCodeB7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB7", 0xB7,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-        }
-    };
-    class OPCodeBA : public Instruction
-    {
-        public:
-        OPCodeBA():Instruction(-1,0xBA,nullptr){}
-        OPCodeBA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBA", 0xBA,Maker){}
-        OPCodeBA(int addr, Builder *Maker):Instruction(addr,"0xBA",0xBA,Maker){}
-        OPCodeBA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBA", 0xBA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x14:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+    class OPCodeAB : public Instruction {
+      public:
+        OPCodeAB()
+          : Instruction(-1, 0xAB, nullptr) {}
+        OPCodeAB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAB", 0xAB, Maker) {}
+        OPCodeAB(int addr, Builder* Maker)
+          : Instruction(addr, "0xAB", 0xAB, Maker) {}
+        OPCodeAB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAB", 0xAB, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    for (int i = 4; i <= 0x36; i++)
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
-                }
+
+                case 0x2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    for (int i = 3; i <= 0x65; i += 2)
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
     };
-    class OPCodeB8 : public Instruction
-    {
-        public:
-        OPCodeB8():Instruction(-1,0xB8,nullptr){}
-        OPCodeB8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB8", 0xB8,Maker){}
-        OPCodeB8(int addr, Builder *Maker):Instruction(addr,"0xB8",0xB8,Maker){}
-        OPCodeB8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB8", 0xB8,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                fun_1403c90e0(addr, content, this, 1);
-                fun_1403c90e0(addr, content, this, 1);
+    class OPCodeAC : public Instruction {
+      public:
+        OPCodeAC()
+          : Instruction(-1, 0xAC, nullptr) {}
+        OPCodeAC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAC", 0xAC, Maker) {}
+        OPCodeAC(int addr, Builder* Maker)
+          : Instruction(addr, "0xAC", 0xAC, Maker) {}
+        OPCodeAC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAC", 0xAC, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
 
+                case 0x1:
+                    fun_1403c90e0(addr, content, this, 1);
+
+                    break;
+                case 0x2:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case '\r':
+                case 0x5:
+                case 0x3:
+                case 0x4:
+                case 0x12:
+                    fun_1403c90e0(addr, content, this, 1);
+
+                    break;
+                case 0xF:
+                case '\v':
+                case '\a':
+                case '\t':
+                case 0x13:
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
     };
-    class OPCodeB9 : public Instruction
-    {
-        public:
-        OPCodeB9():Instruction(-1,0xB9,nullptr){}
-        OPCodeB9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xB9", 0xB9,Maker){}
-        OPCodeB9(int addr, Builder *Maker):Instruction(addr,"0xB9",0xB9,Maker){}
-        OPCodeB9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xB9", 0xB9,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 2:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                }
-
+    class OPCodeAD : public Instruction {
+      public:
+        OPCodeAD()
+          : Instruction(-1, 0xAD, nullptr) {}
+        OPCodeAD(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAD", 0xAD, Maker) {}
+        OPCodeAD(int addr, Builder* Maker)
+          : Instruction(addr, "0xAD", 0xAD, Maker) {}
+        OPCodeAD(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAD", 0xAD, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                case 0x01:
+                case 0x03:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x02:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
     };
+    class OPCodeAE : public Instruction {
+      public:
+        OPCodeAE()
+          : Instruction(-1, 0xAE, nullptr) {}
+        OPCodeAE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAE", 0xAE, Maker) {}
+        OPCodeAE(int addr, Builder* Maker)
+          : Instruction(addr, "0xAE", 0xAE, Maker) {}
+        OPCodeAE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAE", 0xAE, Maker) {
+            addr++;
 
-    class OPCodeBB : public Instruction
-    {
-        public:
-        OPCodeBB():Instruction(-1,0xBB,nullptr){}
-        OPCodeBB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBB", 0xBB,Maker){}
-        OPCodeBB(int addr, Builder *Maker):Instruction(addr,"0xBB",0xBB,Maker){}
-        OPCodeBB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBB", 0xBB,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class OPCodeBC : public Instruction
-    {
-        public:
-        OPCodeBC():Instruction(-1,0xBC,nullptr){}
-        OPCodeBC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBC", 0xBC,Maker){}
-        OPCodeBC(int addr, Builder *Maker):Instruction(addr,"0xBC",0xBC,Maker){}
-        OPCodeBC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBC", 0xBC,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                fun_1403c90e0(addr, content, this, 1);
-                switch((unsigned char)control_byte[0]){
+    class OPCodeAF : public Instruction {
+      public:
+        OPCodeAF()
+          : Instruction(-1, 0xAF, nullptr) {}
+        OPCodeAF(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xAF", 0xAF, Maker) {}
+        OPCodeAF(int addr, Builder* Maker)
+          : Instruction(addr, "0xAF", 0xAF, Maker) {}
+        OPCodeAF(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xAF", 0xAF, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    class OPCodeB1 : public Instruction {
+      public:
+        OPCodeB1()
+          : Instruction(-1, 0xB1, nullptr) {}
+        OPCodeB1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB1", 0xB1, Maker) {}
+        OPCodeB1(int addr, Builder* Maker)
+          : Instruction(addr, "0xB1", 0xB1, Maker) {}
+        OPCodeB1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB1", 0xB1, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCodeB2 : public Instruction {
+      public:
+        OPCodeB2()
+          : Instruction(-1, 0xB2, nullptr) {}
+        OPCodeB2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB2", 0xB2, Maker) {}
+        OPCodeB2(int addr, Builder* Maker)
+          : Instruction(addr, "0xB2", 0xB2, Maker) {}
+        OPCodeB2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB2", 0xB2, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeB3 : public Instruction {
+      public:
+        OPCodeB3()
+          : Instruction(-1, 0xB3, nullptr) {}
+        OPCodeB3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB3", 0xB3, Maker) {}
+        OPCodeB3(int addr, Builder* Maker)
+          : Instruction(addr, "0xB3", 0xB3, Maker) {}
+        OPCodeB3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB3", 0xB3, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeB4 : public Instruction {
+      public:
+        OPCodeB4()
+          : Instruction(-1, 0xB4, nullptr) {}
+        OPCodeB4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB4", 0xB4, Maker) {}
+        OPCodeB4(int addr, Builder* Maker)
+          : Instruction(addr, "0xB4", 0xB4, Maker) {}
+        OPCodeB4(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB4", 0xB4, Maker) {
+            addr++;
+        }
+    };
+    class OPCodeB5 : public Instruction {
+      public:
+        OPCodeB5()
+          : Instruction(-1, 0xB5, nullptr) {}
+        OPCodeB5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB5", 0xB5, Maker) {}
+        OPCodeB5(int addr, Builder* Maker)
+          : Instruction(addr, "0xB5", 0xB5, Maker) {}
+        OPCodeB5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB5", 0xB5, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeB6 : public Instruction {
+      public:
+        OPCodeB6()
+          : Instruction(-1, 0xB6, nullptr) {}
+        OPCodeB6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB6", 0xB6, Maker) {}
+        OPCodeB6(int addr, Builder* Maker)
+          : Instruction(addr, "0xB6", 0xB6, Maker) {}
+        OPCodeB6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB6", 0xB6, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    class OPCodeB7 : public Instruction {
+      public:
+        OPCodeB7()
+          : Instruction(-1, 0xB7, nullptr) {}
+        OPCodeB7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB7", 0xB7, Maker) {}
+        OPCodeB7(int addr, Builder* Maker)
+          : Instruction(addr, "0xB7", 0xB7, Maker) {}
+        OPCodeB7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB7", 0xB7, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeBA : public Instruction {
+      public:
+        OPCodeBA()
+          : Instruction(-1, 0xBA, nullptr) {}
+        OPCodeBA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBA", 0xBA, Maker) {}
+        OPCodeBA(int addr, Builder* Maker)
+          : Instruction(addr, "0xBA", 0xBA, Maker) {}
+        OPCodeBA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBA", 0xBA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x14:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCodeB8 : public Instruction {
+      public:
+        OPCodeB8()
+          : Instruction(-1, 0xB8, nullptr) {}
+        OPCodeB8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB8", 0xB8, Maker) {}
+        OPCodeB8(int addr, Builder* Maker)
+          : Instruction(addr, "0xB8", 0xB8, Maker) {}
+        OPCodeB8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB8", 0xB8, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            fun_1403c90e0(addr, content, this, 1);
+            fun_1403c90e0(addr, content, this, 1);
+        }
+    };
+    class OPCodeB9 : public Instruction {
+      public:
+        OPCodeB9()
+          : Instruction(-1, 0xB9, nullptr) {}
+        OPCodeB9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xB9", 0xB9, Maker) {}
+        OPCodeB9(int addr, Builder* Maker)
+          : Instruction(addr, "0xB9", 0xB9, Maker) {}
+        OPCodeB9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xB9", 0xB9, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
                 case 1:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//C
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//0
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//4
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));//8
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 2:
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
+        }
+    };
+
+    class OPCodeBB : public Instruction {
+      public:
+        OPCodeBB()
+          : Instruction(-1, 0xBB, nullptr) {}
+        OPCodeBB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBB", 0xBB, Maker) {}
+        OPCodeBB(int addr, Builder* Maker)
+          : Instruction(addr, "0xBB", 0xBB, Maker) {}
+        OPCodeBB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBB", 0xBB, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    class OPCodeBC : public Instruction {
+      public:
+        OPCodeBC()
+          : Instruction(-1, 0xBC, nullptr) {}
+        OPCodeBC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBC", 0xBC, Maker) {}
+        OPCodeBC(int addr, Builder* Maker)
+          : Instruction(addr, "0xBC", 0xBC, Maker) {}
+        OPCodeBC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBC", 0xBC, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            fun_1403c90e0(addr, content, this, 1);
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                case 1:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // C
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 0
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 4
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4))); // 8
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 case 4:
                 case 5:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 7:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 8:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 9:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                  break;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 case 10:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                  break;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
                 case 0xb:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xc:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xd:
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0xe:
                     fun_1403c90e0(addr, content, this, 1);
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0xf:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 case 0x10:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                  break;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 case 0x11:
                 case 0x12:
                 case 0x13:
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                  break;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
                 case 0x14:
                 case 0x15:
                 case 0x16:
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                  break;
-
-
-                }
-
-        }
-    };
-    class OPCodeBD : public Instruction
-    {
-        public:
-        OPCodeBD():Instruction(-1,0xBD,nullptr){}
-        OPCodeBD(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBD", 0xBD,Maker){}
-        OPCodeBD(int addr, Builder *Maker):Instruction(addr,"0xBD",0xBD,Maker){}
-        OPCodeBD(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBD", 0xBD,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x3:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeBE : public Instruction
-    {
-        public:
-        OPCodeBE():Instruction(-1,0xBE,nullptr){}
-        OPCodeBE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xBE", 0xBE,Maker){}
-        OPCodeBE(int addr, Builder *Maker):Instruction(addr,"0xBE",0xBE,Maker){}
-        OPCodeBE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xBE", 0xBE,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCodeC0 : public Instruction
-    {
-        public:
-        OPCodeC0():Instruction(-1,0xC0,nullptr){}
-        OPCodeC0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC0", 0xC0,Maker){}
-        OPCodeC0(int addr, Builder *Maker):Instruction(addr,"0xC0",0xC0,Maker){}
-        OPCodeC0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC0", 0xC0,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                short control_shrt = ReadShortFromByteArray(0, control_short);
-                this->AddOperande(operande(addr,"short", control_short));
-                switch(control_shrt){
-                    case 0x1:
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-
-                    case 0x3:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 1000:
-                    case 0x3E9:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-
-
-                }
-
-        }
-    };
-    class OPCodeC1 : public Instruction
-    {
-        public:
-        OPCodeC1():Instruction(-1,0xC1,nullptr){}
-        OPCodeC1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC1", 0xC1,Maker){}
-        OPCodeC1(int addr, Builder *Maker):Instruction(addr,"0xC1",0xC1,Maker){}
-        OPCodeC1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"0xC1", 0xC1,Maker){
-                addr++;
-
-        }
-    };
-    class OPCodeC2 : public Instruction
-    {
-        public:
-        OPCodeC2():Instruction(-1,0xC2,nullptr){}
-        OPCodeC2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC2", 0xC2,Maker){}
-        OPCodeC2(int addr, Builder *Maker):Instruction(addr,"0xC2",0xC2,Maker){}
-        OPCodeC2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC2", 0xC2,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCodeC3 : public Instruction
-    {
-        public:
-        OPCodeC3():Instruction(-1,0xC3,nullptr){}
-        OPCodeC3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC3", 0xC3,Maker){}
-        OPCodeC3(int addr, Builder *Maker):Instruction(addr,"0xC3",0xC3,Maker){}
-        OPCodeC3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC3", 0xC3,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x1:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeC4 : public Instruction
-    {
-        public:
-        OPCodeC4():Instruction(-1,0xC4,nullptr){}
-        OPCodeC4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC4", 0xC4,Maker){}
-        OPCodeC4(int addr, Builder *Maker):Instruction(addr,"0xC4",0xC4,Maker){}
-        OPCodeC4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC4", 0xC4,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x1:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x2:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x4:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        fun_1403c90e0(addr, content, this, 0);
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                    case 0x5:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeC5 : public Instruction
-    {
-        public:
-        OPCodeC5():Instruction(-1,0xC5,nullptr){}
-        OPCodeC5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC5", 0xC5,Maker){}
-        OPCodeC5(int addr, Builder *Maker):Instruction(addr,"0xC5",0xC5,Maker){}
-        OPCodeC5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC5", 0xC5,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                }
-
-        }
-    };
-    class OPCodeC6 : public Instruction
-    {
-        public:
-        OPCodeC6():Instruction(-1,0xC6,nullptr){}
-        OPCodeC6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC6", 0xC6,Maker){}
-        OPCodeC6(int addr, Builder *Maker):Instruction(addr,"0xC6",0xC6,Maker){}
-        OPCodeC6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC6", 0xC6,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x2:
-                    case 0x3:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x4:
-                    case 0x5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                    case 0x6:
-                    case 0x7:
-                    case 0x9:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x8:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                 }
-
-        }
-    };
-    class OPCodeC7 : public Instruction
-    {
-        public:
-        OPCodeC7():Instruction(-1,0xC7,nullptr){}
-        OPCodeC7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC7", 0xC7,Maker){}
-        OPCodeC7(int addr, Builder *Maker):Instruction(addr,"0xC7",0xC7,Maker){}
-        OPCodeC7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC7", 0xC7,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-
-                    case 0x1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-                 }
-
-        }
-    };
-    class OPCodeC8 : public Instruction
-    {
-        public:
-        OPCodeC8():Instruction(-1,0xC8,nullptr){}
-        OPCodeC8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC8", 0xC8,Maker){}
-        OPCodeC8(int addr, Builder *Maker):Instruction(addr,"0xC8",0xC8,Maker){}
-        OPCodeC8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC8", 0xC8,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-        }
-    };
-    class OPCodeC9 : public Instruction
-    {
-        public:
-        OPCodeC9():Instruction(-1,0xC9,nullptr){}
-        OPCodeC9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xC9", 0xC9,Maker){}
-        OPCodeC9(int addr, Builder *Maker):Instruction(addr,"0xC9",0xC9,Maker){}
-        OPCodeC9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xC9", 0xC9,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                    case 0x1:
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
-                    case 0x3:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    break;
-                    case 0xA:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    break;
-                }
-        }
-    };
-    class OPCodeCA : public Instruction
-    {
-        public:
-        OPCodeCA():Instruction(-1,0xCA,nullptr){}
-        OPCodeCA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCA", 0xCA,Maker){}
-        OPCodeCA(int addr, Builder *Maker):Instruction(addr,"0xCA",0xCA,Maker){}
-        OPCodeCA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCA", 0xCA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeCB : public Instruction
-    {
-        public:
-        OPCodeCB():Instruction(-1,0xCB,nullptr){}
-        OPCodeCB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCB", 0xCB,Maker){}
-        OPCodeCB(int addr, Builder *Maker):Instruction(addr,"0xCB",0xCB,Maker){}
-        OPCodeCB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCB", 0xCB,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCodeCC : public Instruction
-    {
-        public:
-        OPCodeCC():Instruction(-1,0xCC,nullptr){}
-        OPCodeCC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCC", 0xCC,Maker){}
-        OPCodeCC(int addr, Builder *Maker):Instruction(addr,"0xCC",0xCC,Maker){}
-        OPCodeCC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCC", 0xCC,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    class OPCodeCD : public Instruction
-    {
-        public:
-        OPCodeCD():Instruction(-1,0xCD,nullptr){}
-        OPCodeCD(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCD", 0xCD,Maker){}
-        OPCodeCD(int addr, Builder *Maker):Instruction(addr,"0xCD",0xCD,Maker){}
-        OPCodeCD(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCD", 0xCD,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        break;
-                    case 0x2:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-                    case 0x6:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-                }
-
-        }
-    };
-    class OPCodeCE : public Instruction
-    {
-        public:
-        OPCodeCE():Instruction(-1,0xCE,nullptr){}
-        OPCodeCE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCE", 0xCE,Maker){}
-        OPCodeCE(int addr, Builder *Maker):Instruction(addr,"0xCE",0xCE,Maker){}
-        OPCodeCE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCE", 0xCE,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                short control_shrt = ReadShortFromByteArray(0, control_short);
-                this->AddOperande(operande(addr,"short", control_short));
-                switch(control_shrt){
-                    case 0:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 1:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 2:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 8:
-                    case 7:
-                    case 6:
-                    case 3:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 5:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 4:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 9:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 10:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 11:
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 0x14:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 0x15:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 0x1E:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 0x1F:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 0x28:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 0x32:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                    case 0x33:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                }
-
-        }
-    };
-    class OPCodeCF : public Instruction
-    {
-        public:
-        OPCodeCF():Instruction(-1,0xCF,nullptr){}
-        OPCodeCF(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xCF", 0xCF,Maker){}
-        OPCodeCF(int addr, Builder *Maker):Instruction(addr,"0xCF",0xCF,Maker){}
-        OPCodeCF(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xCF", 0xCF,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-
-                }
-
-        }
-    };
-    class OPCodeD0 : public Instruction
-    {
-        public:
-        OPCodeD0():Instruction(-1,0xD0,nullptr){}
-        OPCodeD0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD0", 0xD0,Maker){}
-        OPCodeD0(int addr, Builder *Maker):Instruction(addr,"0xD0",0xD0,Maker){}
-        OPCodeD0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD0", 0xD0,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x1E:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                    default:
-
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                }
-
-        }
-    };
-    class OPCodeD1 : public Instruction
-    {
-        public:
-        OPCodeD1():Instruction(-1,0xD1,nullptr){}
-        OPCodeD1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD1", 0xD1,Maker){}
-        OPCodeD1(int addr, Builder *Maker):Instruction(addr,"0xD1",0xD1,Maker){}
-        OPCodeD1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD1", 0xD1,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
-                        break;
-                    case 1:
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-                }
-
-        }
-    };
-    class OPCodeD2 : public Instruction
-    {
-        public:
-        OPCodeD2():Instruction(-1,0xD2,nullptr){}
-        OPCodeD2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD2", 0xD2,Maker){}
-        OPCodeD2(int addr, Builder *Maker):Instruction(addr,"0xD2",0xD2,Maker){}
-        OPCodeD2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD2", 0xD2,Maker){
-                addr++;
-                QByteArray control_short = ReadSubByteArray(content, addr, 2);
-                short control_shrt = ReadShortFromByteArray(0, control_short);
-                this->AddOperande(operande(addr,"short", control_short));
-                switch(control_shrt){
-                    case 0x0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case -2:
-                    case -1:
-                        fun_1403c90e0(addr, content, this, 0);
-                        break;
-                }
-
-        }
-    };
-    class OPCodeD3 : public Instruction
-    {
-        public:
-        OPCodeD3():Instruction(-1,0xD3,nullptr){}
-        OPCodeD3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD3", 0xD3,Maker){}
-        OPCodeD3(int addr, Builder *Maker):Instruction(addr,"0xD3",0xD3,Maker){}
-        OPCodeD3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD3", 0xD3,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeD4 : public Instruction
-    {
-        public:
-        OPCodeD4():Instruction(-1,0xD4,nullptr){}
-        OPCodeD4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD4", 0xD4,Maker){}
-        OPCodeD4(int addr, Builder *Maker):Instruction(addr,"0xD4",0xD4,Maker){}
-        OPCodeD4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD4", 0xD4,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte2));
-
-        }
-    };
-    class OPCodeD5 : public Instruction
-    {
-        public:
-        OPCodeD5():Instruction(-1,0xD5,nullptr){}
-        OPCodeD5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD5", 0xD5,Maker){}
-        OPCodeD5(int addr, Builder *Maker):Instruction(addr,"0xD5",0xD5,Maker){}
-        OPCodeD5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD5", 0xD5,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 1:
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeD6 : public Instruction
-    {
-        public:
-        OPCodeD6():Instruction(-1,0xD6,nullptr){}
-        OPCodeD6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD6", 0xD6,Maker){}
-        OPCodeD6(int addr, Builder *Maker):Instruction(addr,"0xD6",0xD6,Maker){}
-        OPCodeD6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD6", 0xD6,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-                fun_1403c90e0(addr, content, this, 0);
-        }
-    };
-    class OPCodeD7 : public Instruction
-    {
-        public:
-        OPCodeD7():Instruction(-1,0xD7,nullptr){}
-        OPCodeD7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD7", 0xD7,Maker){}
-        OPCodeD7(int addr, Builder *Maker):Instruction(addr,"0xD7",0xD7,Maker){}
-        OPCodeD7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD7", 0xD7,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
-        }
-    };
-    class OPCodeD8 : public Instruction
-    {
-        public:
-        OPCodeD8():Instruction(-1,0xD8,nullptr){}
-        OPCodeD8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xD8", 0xD8,Maker){}
-        OPCodeD8(int addr, Builder *Maker):Instruction(addr,"0xD8",0xD8,Maker){}
-        OPCodeD8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xD8", 0xD8,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                        break;
-
-                }
-
-        }
-    };
-    class OPCodeFA : public Instruction //Should remove this one, Just did that for btl0500
-    {
-        public:
-        OPCodeFA():Instruction(-1,0xFA,nullptr){}
-        OPCodeFA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"0xFA", 0xFA,Maker){}
-        OPCodeFA(int addr, Builder *Maker):Instruction(addr,"0xFA",0xFA,Maker){}
-        OPCodeFA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"0xFA", 0xFA,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    std::shared_ptr<Instruction> CreateInstructionFromDAT(int &addr, QByteArray &dat_content, int function_type){
-        int OP = (dat_content[addr]&0xFF);
-        //qDebug() << hex << "OP: " << OP << " at addr " << addr << " type: " << function_type;
-        if (function_type == 0){ //the function is read with OPCodes
-
-
-            switch(OP){
-                case 0x00: return std::make_shared<OPCode0>(addr,dat_content,this);
-                case 0x01: return std::make_shared<OPCode1>(addr,dat_content,this);
-                case 0x02: return std::make_shared<OPCode2>(addr,dat_content,this);
-                case 0x03: return std::make_shared<OPCode3>(addr,dat_content,this);
-                case 0x04: return std::make_shared<OPCode4>(addr,dat_content,this);
-                case 0x05: return std::make_shared<OPCode5>(addr,dat_content,this);
-                case 0x06: return std::make_shared<OPCode6>(addr,dat_content,this);
-                case 0x07: return std::make_shared<OPCode7>(addr,dat_content,this);
-                case 0x08: return std::make_shared<OPCode8>(addr,dat_content,this);
-                case 0x0A: return std::make_shared<OPCodeA>(addr,dat_content,this);
-                case 0x0B: return std::make_shared<OPCodeB>(addr,dat_content,this);
-                case 0x0C: return std::make_shared<OPCodeC>(addr,dat_content,this);
-                case 0x0D: return std::make_shared<OPCode0D>(addr,dat_content,this);
-                case 0x0E: return std::make_shared<OPCodeE>(addr,dat_content,this);
-                case 0x10: return std::make_shared<OPCode10>(addr,dat_content,this);
-                case 0x11: return std::make_shared<OPCode11>(addr,dat_content,this);
-                case 0x12: return std::make_shared<OPCode12>(addr,dat_content,this);
-                case 0x13: return std::make_shared<OPCode13>(addr,dat_content,this);
-                case 0x14: return std::make_shared<OPCode14>(addr,dat_content,this);
-                case 0x15: return std::make_shared<OPCode15>(addr,dat_content,this);
-                case 0x16: return std::make_shared<OPCode16>(addr,dat_content,this);
-                case 0x17: return std::make_shared<OPCode17>(addr,dat_content,this);
-                case 0x18: return std::make_shared<OPCode18>(addr,dat_content,this);
-                case 0x19: return std::make_shared<OPCode19>(addr,dat_content,this);
-                case 0x1A: return std::make_shared<OPCode1A>(addr,dat_content,this);
-                case 0x1D: return std::make_shared<OPCode1D>(addr,dat_content,this);
-                case 0x1E: return std::make_shared<OPCode1E>(addr,dat_content,this);
-                case 0x1F: return std::make_shared<OPCode1F>(addr,dat_content,this);
-                case 0x20: return std::make_shared<OPCode20>(addr,dat_content,this);
-                case 0x21: return std::make_shared<OPCode21>(addr,dat_content,this);
-                case 0x22: return std::make_shared<OPCode22>(addr,dat_content,this);
-                case 0x23: return std::make_shared<OPCode23>(addr,dat_content,this);
-                case 0x24: return std::make_shared<OPCode24>(addr,dat_content,this);
-                case 0x25: return std::make_shared<OPCode25>(addr,dat_content,this);
-                case 0x26: return std::make_shared<OPCode26>(addr,dat_content,this);
-                case 0x27: return std::make_shared<OPCode27>(addr,dat_content,this);
-                case 0x28: return std::make_shared<OPCode28>(addr,dat_content,this);
-                case 0x29: return std::make_shared<OPCode29>(addr,dat_content,this);
-                case 0x2A: return std::make_shared<OPCode2A>(addr,dat_content,this);
-                case 0x2B: return std::make_shared<OPCode2B>(addr,dat_content,this);
-                case 0x2C: return std::make_shared<OPCode2C>(addr,dat_content,this);
-                case 0x2D: return std::make_shared<OPCode2D>(addr,dat_content,this);
-                case 0x2E: return std::make_shared<OPCode2E>(addr,dat_content,this);
-                case 0x2F: return std::make_shared<OPCode2F>(addr,dat_content,this);
-                case 0x30: return std::make_shared<OPCode30>(addr,dat_content,this);
-                case 0x31: return std::make_shared<OPCode31>(addr,dat_content,this);
-                case 0x32: return std::make_shared<OPCode32>(addr,dat_content,this);
-                case 0x33: return std::make_shared<OPCode33>(addr,dat_content,this);
-                case 0x34: return std::make_shared<OPCode34>(addr,dat_content,this);
-                case 0x35: return std::make_shared<OPCode35>(addr,dat_content,this);
-                case 0x36: return std::make_shared<OPCode36>(addr,dat_content,this);
-                case 0x37: return std::make_shared<OPCode37>(addr,dat_content,this);
-                case 0x38: return std::make_shared<OPCode38>(addr,dat_content,this);
-                case 0x39: return std::make_shared<OPCode39>(addr,dat_content,this);
-                case 0x3A: return std::make_shared<OPCode3A>(addr,dat_content,this);
-                case 0x3B: return std::make_shared<OPCode3B>(addr,dat_content,this);
-                case 0x3C: return std::make_shared<OPCode3C>(addr,dat_content,this);
-                case 0x3D: return std::make_shared<OPCode3D>(addr,dat_content,this);
-                case 0x3E: return std::make_shared<OPCode3E>(addr,dat_content,this);
-                case 0x3F: return std::make_shared<OPCode3F>(addr,dat_content,this);
-                case 0x40: return std::make_shared<OPCode40>(addr,dat_content,this);
-                case 0x41: return std::make_shared<OPCode41>(addr,dat_content,this);
-                case 0x42: return std::make_shared<OPCode42>(addr,dat_content,this);
-                case 0x43: return std::make_shared<OPCode43>(addr,dat_content,this);
-                case 0x44: return std::make_shared<OPCode44>(addr,dat_content,this);
-                case 0x45: return std::make_shared<OPCode45>(addr,dat_content,this);
-                case 0x46: return std::make_shared<OPCode46>(addr,dat_content,this);
-                case 0x47: return std::make_shared<OPCode47>(addr,dat_content,this);
-                case 0x48: return std::make_shared<OPCode48>(addr,dat_content,this);
-                case 0x49: return std::make_shared<OPCode49>(addr,dat_content,this);
-                case 0x4A: return std::make_shared<OPCode4A>(addr,dat_content,this);
-                case 0x4B: return std::make_shared<OPCode4B>(addr,dat_content,this);
-                case 0x4C: return std::make_shared<OPCode4C>(addr,dat_content,this);
-                case 0x4D: return std::make_shared<OPCode4D>(addr,dat_content,this);
-                case 0x4E: return std::make_shared<OPCode4E>(addr,dat_content,this);
-                case 0x4F: return std::make_shared<OPCode4F>(addr,dat_content,this);
-                case 0x50: return std::make_shared<OPCode50>(addr,dat_content,this);
-                case 0x51: return std::make_shared<OPCode51>(addr,dat_content,this);
-                case 0x52: return std::make_shared<OPCode52>(addr,dat_content,this);
-                case 0x53: return std::make_shared<OPCode53>(addr,dat_content,this);
-                case 0x54: return std::make_shared<OPCode54>(addr,dat_content,this);
-                case 0x55: return std::make_shared<OPCode55>(addr,dat_content,this);
-                case 0x56: return std::make_shared<OPCode56>(addr,dat_content,this);
-                case 0x57: return std::make_shared<OPCode57>(addr,dat_content,this);
-                case 0x58: return std::make_shared<OPCode58>(addr,dat_content,this);
-                case 0x5A: return std::make_shared<OPCode5A>(addr,dat_content,this);
-//                case 0x5B: return std::make_shared<OPCode5B>(addr,dat_content,this);
-                case 0x5C: return std::make_shared<OPCode5C>(addr,dat_content,this);
-                case 0x5D: return std::make_shared<OPCode5D>(addr,dat_content,this);
-                case 0x5E: return std::make_shared<OPCode5E>(addr,dat_content,this);
-                case 0x60: return std::make_shared<OPCode60>(addr,dat_content,this);
-                case 0x61: return std::make_shared<OPCode61>(addr,dat_content,this);
-                case 0x62: return std::make_shared<OPCode62>(addr,dat_content,this);
-                case 0x63: return std::make_shared<OPCode63>(addr,dat_content,this);
-                case 0x64: return std::make_shared<OPCode64>(addr,dat_content,this);
-                case 0x65: return std::make_shared<OPCode65>(addr,dat_content,this);
-                case 0x66: return std::make_shared<OPCode66>(addr,dat_content,this);
-                case 0x67: return std::make_shared<OPCode67>(addr,dat_content,this);
-                case 0x68: return std::make_shared<OPCode68>(addr,dat_content,this);
-                case 0x69: return std::make_shared<OPCode69>(addr,dat_content,this);
-                case 0x6A: return std::make_shared<OPCode6A>(addr,dat_content,this);
-                case 0x6B: return std::make_shared<OPCode6B>(addr,dat_content,this);
-                case 0x6C: return std::make_shared<OPCode6C>(addr,dat_content,this);
-                case 0x6E: return std::make_shared<OPCode6E>(addr,dat_content,this);
-                case 0x6F: return std::make_shared<OPCode6F>(addr,dat_content,this);
-                case 0x70: return std::make_shared<OPCode70>(addr,dat_content,this);
-                case 0x71: return std::make_shared<OPCode71>(addr,dat_content,this);
-                case 0x72: return std::make_shared<OPCode72>(addr,dat_content,this);
-                case 0x73: return std::make_shared<OPCode73>(addr,dat_content,this);
-                case 0x74: return std::make_shared<OPCode74>(addr,dat_content,this);
-                case 0x75: return std::make_shared<OPCode75>(addr,dat_content,this);
-                case 0x76: return std::make_shared<OPCode76>(addr,dat_content,this);
-                case 0x77: return std::make_shared<OPCode77>(addr,dat_content,this);
-                case 0x78: return std::make_shared<OPCode78>(addr,dat_content,this);
-                case 0x79: return std::make_shared<OPCode79>(addr,dat_content,this);
-                case 0x7A: return std::make_shared<OPCode7A>(addr,dat_content,this);
-                case 0x7B: return std::make_shared<OPCode7B>(addr,dat_content,this);
-                case 0x7C: return std::make_shared<OPCode7C>(addr,dat_content,this);
-                case 0x7D: return std::make_shared<OPCode7D>(addr,dat_content,this);
-                case 0x7E: return std::make_shared<OPCode7E>(addr,dat_content,this);
-                case 0x80: return std::make_shared<OPCode80>(addr,dat_content,this);
-                case 0x82: return std::make_shared<OPCode82>(addr,dat_content,this);
-                case 0x83: return std::make_shared<OPCode83>(addr,dat_content,this);
-                case 0x84: return std::make_shared<OPCode84>(addr,dat_content,this);
-                case 0x86: return std::make_shared<OPCode86>(addr,dat_content,this);
-                case 0x87: return std::make_shared<OPCode87>(addr,dat_content,this);
-                case 0x88: return std::make_shared<OPCode88>(addr,dat_content,this);
-                case 0x89: return std::make_shared<OPCode89>(addr,dat_content,this);
-                case 0x8A: return std::make_shared<OPCode8A>(addr,dat_content,this);
-                case 0x8B: return std::make_shared<OPCode8B>(addr,dat_content,this);
-                case 0x8C: return std::make_shared<OPCode8C>(addr,dat_content,this);
-                case 0x8D: return std::make_shared<OPCode8D>(addr,dat_content,this);
-                case 0x8E: return std::make_shared<OPCode8E>(addr,dat_content,this);
-                case 0x8F: return std::make_shared<OPCode8F>(addr,dat_content,this);
-                case 0x90: return std::make_shared<OPCode90>(addr,dat_content,this);
-                case 0x91: return std::make_shared<OPCode91>(addr,dat_content,this);
-                case 0x92: return std::make_shared<OPCode92>(addr,dat_content,this);
-                case 0x93: return std::make_shared<OPCode93>(addr,dat_content,this);
-                case 0x94: return std::make_shared<OPCode94>(addr,dat_content,this);
-                case 0x95: return std::make_shared<OPCode95>(addr,dat_content,this);
-                case 0x97: return std::make_shared<OPCode97>(addr,dat_content,this);
-                case 0x98: return std::make_shared<OPCode98>(addr,dat_content,this);
-                case 0x99: return std::make_shared<OPCode99>(addr,dat_content,this);
-                case 0x9A: return std::make_shared<OPCode9A>(addr,dat_content,this);
-                case 0x9B: return std::make_shared<OPCode9B>(addr,dat_content,this);
-                case 0x9C: return std::make_shared<OPCode9C>(addr,dat_content,this);
-                case 0x9D: return std::make_shared<OPCode9D>(addr,dat_content,this);
-                case 0x9E: return std::make_shared<OPCode9E>(addr,dat_content,this);
-                case 0xA0: return std::make_shared<OPCodeA0>(addr,dat_content,this);
-                case 0xA1: return std::make_shared<OPCodeA1>(addr,dat_content,this);
-                case 0xA3: return std::make_shared<OPCodeA3>(addr,dat_content,this);
-                case 0xA4: return std::make_shared<OPCodeA4>(addr,dat_content,this);
-                case 0xA6: return std::make_shared<OPCodeA6>(addr,dat_content,this);
-                case 0xA8: return std::make_shared<OPCodeA8>(addr,dat_content,this);
-                case 0xA9: return std::make_shared<OPCodeA9>(addr,dat_content,this);
-                case 0xAA: return std::make_shared<OPCodeAA>(addr,dat_content,this);
-                case 0xAB: return std::make_shared<OPCodeAB>(addr,dat_content,this);
-                case 0xAC: return std::make_shared<OPCodeAC>(addr,dat_content,this);
-                case 0xAD: return std::make_shared<OPCodeAD>(addr,dat_content,this);
-                case 0xAE: return std::make_shared<OPCodeAE>(addr,dat_content,this);
-                case 0xAF: return std::make_shared<OPCodeAF>(addr,dat_content,this);
-                case 0xB1: return std::make_shared<OPCodeB1>(addr,dat_content,this);
-                case 0xB2: return std::make_shared<OPCodeB2>(addr,dat_content,this);
-                case 0xB3: return std::make_shared<OPCodeB3>(addr,dat_content,this);
-                case 0xB4: return std::make_shared<OPCodeB4>(addr,dat_content,this);
-                case 0xB5: return std::make_shared<OPCodeB5>(addr,dat_content,this);
-                case 0xB6: return std::make_shared<OPCodeB6>(addr,dat_content,this);
-                case 0xB7: return std::make_shared<OPCodeB7>(addr,dat_content,this);
-                case 0xB8: return std::make_shared<OPCodeB8>(addr,dat_content,this);
-                case 0xB9: return std::make_shared<OPCodeB9>(addr,dat_content,this);
-                case 0xBA: return std::make_shared<OPCodeBA>(addr,dat_content,this);
-                case 0xBB: return std::make_shared<OPCodeBB>(addr,dat_content,this);
-                case 0xBC: return std::make_shared<OPCodeBC>(addr,dat_content,this);
-                case 0xBD: return std::make_shared<OPCodeBD>(addr,dat_content,this);
-                case 0xBE: return std::make_shared<OPCodeBE>(addr,dat_content,this);
-                case 0xC0: return std::make_shared<OPCodeC0>(addr,dat_content,this);
-                case 0xC1: return std::make_shared<OPCodeC1>(addr,dat_content,this);
-                case 0xC2: return std::make_shared<OPCodeC2>(addr,dat_content,this);
-                case 0xC3: return std::make_shared<OPCodeC3>(addr,dat_content,this);
-                case 0xC4: return std::make_shared<OPCodeC4>(addr,dat_content,this);
-                case 0xC5: return std::make_shared<OPCodeC5>(addr,dat_content,this);
-                case 0xC6: return std::make_shared<OPCodeC6>(addr,dat_content,this);
-                case 0xC7: return std::make_shared<OPCodeC7>(addr,dat_content,this);
-                case 0xC8: return std::make_shared<OPCodeC8>(addr,dat_content,this);
-                case 0xC9: return std::make_shared<OPCodeC9>(addr,dat_content,this);
-//                case 0xCA: return std::make_shared<OPCodeCA>(addr,dat_content,this);
-//                case 0xCB: return std::make_shared<OPCodeCB>(addr,dat_content,this);
-//                case 0xCC: return std::make_shared<OPCodeCC>(addr,dat_content,this);
-                case 0xCD: return std::make_shared<OPCodeCD>(addr,dat_content,this);
-                case 0xCE: return std::make_shared<OPCodeCE>(addr,dat_content,this);
-                case 0xCF: return std::make_shared<OPCodeCF>(addr,dat_content,this);
-                case 0xD0: return std::make_shared<OPCodeD0>(addr,dat_content,this);
-                case 0xD1: return std::make_shared<OPCodeD1>(addr,dat_content,this);
-                case 0xD2: return std::make_shared<OPCodeD2>(addr,dat_content,this);
-                case 0xD3: return std::make_shared<OPCodeD3>(addr,dat_content,this);
-                case 0xD4: return std::make_shared<OPCodeD4>(addr,dat_content,this);
-                case 0xD5: return std::make_shared<OPCodeD5>(addr,dat_content,this);
-                case 0xD6: return std::make_shared<OPCodeD6>(addr,dat_content,this);
-                case 0xD7: return std::make_shared<OPCodeD7>(addr,dat_content,this);
-                case 0xD8: return std::make_shared<OPCodeD8>(addr,dat_content,this);
-                case 0xFA: return std::make_shared<OPCodeFA>(addr,dat_content,this);
-                default:
-                std::stringstream stream;
-                stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
-                /*std::string result( stream.str() );
-
-                qFatal(result.c_str());*/
-                error = true;
-                addr++;
-                return std::shared_ptr<Instruction>();
             }
         }
-        else if (function_type==1){//the function is a "CreateMonsters" function
-
-            return std::make_shared<CreateMonsters>(addr,dat_content,this);
+    };
+    class OPCodeBD : public Instruction {
+      public:
+        OPCodeBD()
+          : Instruction(-1, 0xBD, nullptr) {}
+        OPCodeBD(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBD", 0xBD, Maker) {}
+        OPCodeBD(int addr, Builder* Maker)
+          : Instruction(addr, "0xBD", 0xBD, Maker) {}
+        OPCodeBD(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBD", 0xBD, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x3:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
-        else if (function_type==2){//the function is a "effect" function
-
-            return std::make_shared<EffectsInstr>(addr,dat_content,this);
+    };
+    class OPCodeBE : public Instruction {
+      public:
+        OPCodeBE()
+          : Instruction(-1, 0xBE, nullptr) {}
+        OPCodeBE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xBE", 0xBE, Maker) {}
+        OPCodeBE(int addr, Builder* Maker)
+          : Instruction(addr, "0xBE", 0xBE, Maker) {}
+        OPCodeBE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xBE", 0xBE, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-        else if (function_type==3){
+    };
+    class OPCodeC0 : public Instruction {
+      public:
+        OPCodeC0()
+          : Instruction(-1, 0xC0, nullptr) {}
+        OPCodeC0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC0", 0xC0, Maker) {}
+        OPCodeC0(int addr, Builder* Maker)
+          : Instruction(addr, "0xC0", 0xC0, Maker) {}
+        OPCodeC0(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC0", 0xC0, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            short control_shrt = ReadShortFromByteArray(0, control_short);
+            this->AddOperande(operande(addr, "short", control_short));
+            switch (control_shrt) {
+                case 0x1:
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-            return std::make_shared<ActionTable>(addr,dat_content,this);
+                case 0x3:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 1000:
+                case 0x3E9:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+            }
         }
-        else if (function_type==4){
-
-            return std::make_shared<AlgoTable>(addr,dat_content,this);
+    };
+    class OPCodeC1 : public Instruction {
+      public:
+        OPCodeC1()
+          : Instruction(-1, 0xC1, nullptr) {}
+        OPCodeC1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC1", 0xC1, Maker) {}
+        OPCodeC1(int addr, Builder* Maker)
+          : Instruction(addr, "0xC1", 0xC1, Maker) {}
+        OPCodeC1(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC1", 0xC1, Maker) {
+            addr++;
         }
-        else if (function_type==5){
-
-            return std::make_shared<WeaponAttTable>(addr,dat_content,this);
+    };
+    class OPCodeC2 : public Instruction {
+      public:
+        OPCodeC2()
+          : Instruction(-1, 0xC2, nullptr) {}
+        OPCodeC2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC2", 0xC2, Maker) {}
+        OPCodeC2(int addr, Builder* Maker)
+          : Instruction(addr, "0xC2", 0xC2, Maker) {}
+        OPCodeC2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC2", 0xC2, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
-        else if (function_type==6){
-
-            return std::make_shared<BreakTable>(addr,dat_content,this);
+    };
+    class OPCodeC3 : public Instruction {
+      public:
+        OPCodeC3()
+          : Instruction(-1, 0xC3, nullptr) {}
+        OPCodeC3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC3", 0xC3, Maker) {}
+        OPCodeC3(int addr, Builder* Maker)
+          : Instruction(addr, "0xC3", 0xC3, Maker) {}
+        OPCodeC3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC3", 0xC3, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x1:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
         }
-        else if (function_type==7){
+    };
+    class OPCodeC4 : public Instruction {
+      public:
+        OPCodeC4()
+          : Instruction(-1, 0xC4, nullptr) {}
+        OPCodeC4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC4", 0xC4, Maker) {}
+        OPCodeC4(int addr, Builder* Maker)
+          : Instruction(addr, "0xC4", 0xC4, Maker) {}
+        OPCodeC4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC4", 0xC4, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x1:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x2:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x4:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    fun_1403c90e0(addr, content, this, 0);
 
-            return std::make_shared<SummonTable>(addr,dat_content,this);
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                case 0x5:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
         }
-        else if (function_type==8){
+    };
+    class OPCodeC5 : public Instruction {
+      public:
+        OPCodeC5()
+          : Instruction(-1, 0xC5, nullptr) {}
+        OPCodeC5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC5", 0xC5, Maker) {}
+        OPCodeC5(int addr, Builder* Maker)
+          : Instruction(addr, "0xC5", 0xC5, Maker) {}
+        OPCodeC5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC5", 0xC5, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            return std::make_shared<ReactionTable>(addr,dat_content,this);
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
         }
-        else if (function_type==9){
+    };
+    class OPCodeC6 : public Instruction {
+      public:
+        OPCodeC6()
+          : Instruction(-1, 0xC6, nullptr) {}
+        OPCodeC6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC6", 0xC6, Maker) {}
+        OPCodeC6(int addr, Builder* Maker)
+          : Instruction(addr, "0xC6", 0xC6, Maker) {}
+        OPCodeC6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC6", 0xC6, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            return std::make_shared<PartTable>(addr,dat_content,this);
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x2:
+                case 0x3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x4:
+                case 0x5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                case 0x6:
+                case 0x7:
+                case 0x9:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x8:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
         }
-        else if (function_type==10){
+    };
+    class OPCodeC7 : public Instruction {
+      public:
+        OPCodeC7()
+          : Instruction(-1, 0xC7, nullptr) {}
+        OPCodeC7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC7", 0xC7, Maker) {}
+        OPCodeC7(int addr, Builder* Maker)
+          : Instruction(addr, "0xC7", 0xC7, Maker) {}
+        OPCodeC7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC7", 0xC7, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            return std::make_shared<AnimeClipTable>(addr,dat_content,this);
+                case 0x1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
-        else if (function_type==11){
-
-            return std::make_shared<FieldMonsterData>(addr,dat_content,this);
+    };
+    class OPCodeC8 : public Instruction {
+      public:
+        OPCodeC8()
+          : Instruction(-1, 0xC8, nullptr) {}
+        OPCodeC8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC8", 0xC8, Maker) {}
+        OPCodeC8(int addr, Builder* Maker)
+          : Instruction(addr, "0xC8", 0xC8, Maker) {}
+        OPCodeC8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC8", 0xC8, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-        else if (function_type==12){
-
-            return std::make_shared<FieldFollowData>(addr,dat_content,this);
+    };
+    class OPCodeC9 : public Instruction {
+      public:
+        OPCodeC9()
+          : Instruction(-1, 0xC9, nullptr) {}
+        OPCodeC9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xC9", 0xC9, Maker) {}
+        OPCodeC9(int addr, Builder* Maker)
+          : Instruction(addr, "0xC9", 0xC9, Maker) {}
+        OPCodeC9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xC9", 0xC9, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x3:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0xA:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+            }
         }
-        else if (function_type==13){
-
-            return std::make_shared<FC_autoX>(addr,dat_content,this);
+    };
+    class OPCodeCA : public Instruction {
+      public:
+        OPCodeCA()
+          : Instruction(-1, 0xCA, nullptr) {}
+        OPCodeCA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCA", 0xCA, Maker) {}
+        OPCodeCA(int addr, Builder* Maker)
+          : Instruction(addr, "0xCA", 0xCA, Maker) {}
+        OPCodeCA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCA", 0xCA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+            }
         }
-        else if (function_type==14){
-
-            return std::make_shared<BookData99>(addr,dat_content,this);
+    };
+    class OPCodeCB : public Instruction {
+      public:
+        OPCodeCB()
+          : Instruction(-1, 0xCB, nullptr) {}
+        OPCodeCB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCB", 0xCB, Maker) {}
+        OPCodeCB(int addr, Builder* Maker)
+          : Instruction(addr, "0xCB", 0xCB, Maker) {}
+        OPCodeCB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCB", 0xCB, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
-        else if (function_type==15){
-
-            return std::make_shared<BookDataX>(addr,dat_content,this);
+    };
+    class OPCodeCC : public Instruction {
+      public:
+        OPCodeCC()
+          : Instruction(-1, 0xCC, nullptr) {}
+        OPCodeCC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCC", 0xCC, Maker) {}
+        OPCodeCC(int addr, Builder* Maker)
+          : Instruction(addr, "0xCC", 0xCC, Maker) {}
+        OPCodeCC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCC", 0xCC, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
         }
-        else if (function_type==16){
+    };
+    class OPCodeCD : public Instruction {
+      public:
+        OPCodeCD()
+          : Instruction(-1, 0xCD, nullptr) {}
+        OPCodeCD(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCD", 0xCD, Maker) {}
+        OPCodeCD(int addr, Builder* Maker)
+          : Instruction(addr, "0xCD", 0xCD, Maker) {}
+        OPCodeCD(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCD", 0xCD, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x2:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            return std::make_shared<AddCollision>(addr,dat_content,this);
+                    break;
+                case 0x6:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+            }
         }
-        else if (function_type==18){
+    };
+    class OPCodeCE : public Instruction {
+      public:
+        OPCodeCE()
+          : Instruction(-1, 0xCE, nullptr) {}
+        OPCodeCE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCE", 0xCE, Maker) {}
+        OPCodeCE(int addr, Builder* Maker)
+          : Instruction(addr, "0xCE", 0xCE, Maker) {}
+        OPCodeCE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCE", 0xCE, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            short control_shrt = ReadShortFromByteArray(0, control_short);
+            this->AddOperande(operande(addr, "short", control_short));
+            switch (control_shrt) {
+                case 0:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 2:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 8:
+                case 7:
+                case 6:
+                case 3:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 5:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 4:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 9:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 10:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 11:
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x14:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x15:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x1E:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x1F:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x28:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x32:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x33:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+            }
+        }
+    };
+    class OPCodeCF : public Instruction {
+      public:
+        OPCodeCF()
+          : Instruction(-1, 0xCF, nullptr) {}
+        OPCodeCF(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xCF", 0xCF, Maker) {}
+        OPCodeCF(int addr, Builder* Maker)
+          : Instruction(addr, "0xCF", 0xCF, Maker) {}
+        OPCodeCF(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xCF", 0xCF, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {}
+        }
+    };
+    class OPCodeD0 : public Instruction {
+      public:
+        OPCodeD0()
+          : Instruction(-1, 0xD0, nullptr) {}
+        OPCodeD0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD0", 0xD0, Maker) {}
+        OPCodeD0(int addr, Builder* Maker)
+          : Instruction(addr, "0xD0", 0xD0, Maker) {}
+        OPCodeD0(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD0", 0xD0, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x1E:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-            return std::make_shared<StyleName>(addr,dat_content,this);
+                    break;
+                default:
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+            }
+        }
+    };
+    class OPCodeD1 : public Instruction {
+      public:
+        OPCodeD1()
+          : Instruction(-1, 0xD1, nullptr) {}
+        OPCodeD1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD1", 0xD1, Maker) {}
+        OPCodeD1(int addr, Builder* Maker)
+          : Instruction(addr, "0xD1", 0xD1, Maker) {}
+        OPCodeD1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD1", 0xD1, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                case 1:
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+            }
+        }
+    };
+    class OPCodeD2 : public Instruction {
+      public:
+        OPCodeD2()
+          : Instruction(-1, 0xD2, nullptr) {}
+        OPCodeD2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD2", 0xD2, Maker) {}
+        OPCodeD2(int addr, Builder* Maker)
+          : Instruction(addr, "0xD2", 0xD2, Maker) {}
+        OPCodeD2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD2", 0xD2, Maker) {
+            addr++;
+            QByteArray control_short = ReadSubByteArray(content, addr, 2);
+            short control_shrt = ReadShortFromByteArray(0, control_short);
+            this->AddOperande(operande(addr, "short", control_short));
+            switch (control_shrt) {
+                case 0x0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case -2:
+                case -1:
+                    fun_1403c90e0(addr, content, this, 0);
+                    break;
+            }
+        }
+    };
+    class OPCodeD3 : public Instruction {
+      public:
+        OPCodeD3()
+          : Instruction(-1, 0xD3, nullptr) {}
+        OPCodeD3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD3", 0xD3, Maker) {}
+        OPCodeD3(int addr, Builder* Maker)
+          : Instruction(addr, "0xD3", 0xD3, Maker) {}
+        OPCodeD3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD3", 0xD3, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+            }
+        }
+    };
+    class OPCodeD4 : public Instruction {
+      public:
+        OPCodeD4()
+          : Instruction(-1, 0xD4, nullptr) {}
+        OPCodeD4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD4", 0xD4, Maker) {}
+        OPCodeD4(int addr, Builder* Maker)
+          : Instruction(addr, "0xD4", 0xD4, Maker) {}
+        OPCodeD4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD4", 0xD4, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte2));
+        }
+    };
+    class OPCodeD5 : public Instruction {
+      public:
+        OPCodeD5()
+          : Instruction(-1, 0xD5, nullptr) {}
+        OPCodeD5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD5", 0xD5, Maker) {}
+        OPCodeD5(int addr, Builder* Maker)
+          : Instruction(addr, "0xD5", 0xD5, Maker) {}
+        OPCodeD5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD5", 0xD5, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 1:
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+            }
+        }
+    };
+    class OPCodeD6 : public Instruction {
+      public:
+        OPCodeD6()
+          : Instruction(-1, 0xD6, nullptr) {}
+        OPCodeD6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD6", 0xD6, Maker) {}
+        OPCodeD6(int addr, Builder* Maker)
+          : Instruction(addr, "0xD6", 0xD6, Maker) {}
+        OPCodeD6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD6", 0xD6, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+            fun_1403c90e0(addr, content, this, 0);
+        }
+    };
+    class OPCodeD7 : public Instruction {
+      public:
+        OPCodeD7()
+          : Instruction(-1, 0xD7, nullptr) {}
+        OPCodeD7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD7", 0xD7, Maker) {}
+        OPCodeD7(int addr, Builder* Maker)
+          : Instruction(addr, "0xD7", 0xD7, Maker) {}
+        OPCodeD7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD7", 0xD7, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class OPCodeD8 : public Instruction {
+      public:
+        OPCodeD8()
+          : Instruction(-1, 0xD8, nullptr) {}
+        OPCodeD8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xD8", 0xD8, Maker) {}
+        OPCodeD8(int addr, Builder* Maker)
+          : Instruction(addr, "0xD8", 0xD8, Maker) {}
+        OPCodeD8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xD8", 0xD8, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0:
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+            }
+        }
+    };
+    class OPCodeFA
+      : public Instruction // Should remove this one, Just did that for btl0500
+    {
+      public:
+        OPCodeFA()
+          : Instruction(-1, 0xFA, nullptr) {}
+        OPCodeFA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "0xFA", 0xFA, Maker) {}
+        OPCodeFA(int addr, Builder* Maker)
+          : Instruction(addr, "0xFA", 0xFA, Maker) {}
+        OPCodeFA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "0xFA", 0xFA, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    std::shared_ptr<Instruction> CreateInstructionFromDAT(int& addr, QByteArray& dat_content, int function_type) {
+        int OP = (dat_content[addr] & 0xFF);
+        // qDebug() << hex << "OP: " << OP << " at addr " << addr << " type: " << function_type;
+        if (function_type == 0) { // the function is read with OPCodes
+
+            switch (OP) {
+                case 0x00:
+                    return std::make_shared<OPCode0>(addr, dat_content, this);
+                case 0x01:
+                    return std::make_shared<OPCode1>(addr, dat_content, this);
+                case 0x02:
+                    return std::make_shared<OPCode2>(addr, dat_content, this);
+                case 0x03:
+                    return std::make_shared<OPCode3>(addr, dat_content, this);
+                case 0x04:
+                    return std::make_shared<OPCode4>(addr, dat_content, this);
+                case 0x05:
+                    return std::make_shared<OPCode5>(addr, dat_content, this);
+                case 0x06:
+                    return std::make_shared<OPCode6>(addr, dat_content, this);
+                case 0x07:
+                    return std::make_shared<OPCode7>(addr, dat_content, this);
+                case 0x08:
+                    return std::make_shared<OPCode8>(addr, dat_content, this);
+                case 0x0A:
+                    return std::make_shared<OPCodeA>(addr, dat_content, this);
+                case 0x0B:
+                    return std::make_shared<OPCodeB>(addr, dat_content, this);
+                case 0x0C:
+                    return std::make_shared<OPCodeC>(addr, dat_content, this);
+                case 0x0D:
+                    return std::make_shared<OPCode0D>(addr, dat_content, this);
+                case 0x0E:
+                    return std::make_shared<OPCodeE>(addr, dat_content, this);
+                case 0x10:
+                    return std::make_shared<OPCode10>(addr, dat_content, this);
+                case 0x11:
+                    return std::make_shared<OPCode11>(addr, dat_content, this);
+                case 0x12:
+                    return std::make_shared<OPCode12>(addr, dat_content, this);
+                case 0x13:
+                    return std::make_shared<OPCode13>(addr, dat_content, this);
+                case 0x14:
+                    return std::make_shared<OPCode14>(addr, dat_content, this);
+                case 0x15:
+                    return std::make_shared<OPCode15>(addr, dat_content, this);
+                case 0x16:
+                    return std::make_shared<OPCode16>(addr, dat_content, this);
+                case 0x17:
+                    return std::make_shared<OPCode17>(addr, dat_content, this);
+                case 0x18:
+                    return std::make_shared<OPCode18>(addr, dat_content, this);
+                case 0x19:
+                    return std::make_shared<OPCode19>(addr, dat_content, this);
+                case 0x1A:
+                    return std::make_shared<OPCode1A>(addr, dat_content, this);
+                case 0x1D:
+                    return std::make_shared<OPCode1D>(addr, dat_content, this);
+                case 0x1E:
+                    return std::make_shared<OPCode1E>(addr, dat_content, this);
+                case 0x1F:
+                    return std::make_shared<OPCode1F>(addr, dat_content, this);
+                case 0x20:
+                    return std::make_shared<OPCode20>(addr, dat_content, this);
+                case 0x21:
+                    return std::make_shared<OPCode21>(addr, dat_content, this);
+                case 0x22:
+                    return std::make_shared<OPCode22>(addr, dat_content, this);
+                case 0x23:
+                    return std::make_shared<OPCode23>(addr, dat_content, this);
+                case 0x24:
+                    return std::make_shared<OPCode24>(addr, dat_content, this);
+                case 0x25:
+                    return std::make_shared<OPCode25>(addr, dat_content, this);
+                case 0x26:
+                    return std::make_shared<OPCode26>(addr, dat_content, this);
+                case 0x27:
+                    return std::make_shared<OPCode27>(addr, dat_content, this);
+                case 0x28:
+                    return std::make_shared<OPCode28>(addr, dat_content, this);
+                case 0x29:
+                    return std::make_shared<OPCode29>(addr, dat_content, this);
+                case 0x2A:
+                    return std::make_shared<OPCode2A>(addr, dat_content, this);
+                case 0x2B:
+                    return std::make_shared<OPCode2B>(addr, dat_content, this);
+                case 0x2C:
+                    return std::make_shared<OPCode2C>(addr, dat_content, this);
+                case 0x2D:
+                    return std::make_shared<OPCode2D>(addr, dat_content, this);
+                case 0x2E:
+                    return std::make_shared<OPCode2E>(addr, dat_content, this);
+                case 0x2F:
+                    return std::make_shared<OPCode2F>(addr, dat_content, this);
+                case 0x30:
+                    return std::make_shared<OPCode30>(addr, dat_content, this);
+                case 0x31:
+                    return std::make_shared<OPCode31>(addr, dat_content, this);
+                case 0x32:
+                    return std::make_shared<OPCode32>(addr, dat_content, this);
+                case 0x33:
+                    return std::make_shared<OPCode33>(addr, dat_content, this);
+                case 0x34:
+                    return std::make_shared<OPCode34>(addr, dat_content, this);
+                case 0x35:
+                    return std::make_shared<OPCode35>(addr, dat_content, this);
+                case 0x36:
+                    return std::make_shared<OPCode36>(addr, dat_content, this);
+                case 0x37:
+                    return std::make_shared<OPCode37>(addr, dat_content, this);
+                case 0x38:
+                    return std::make_shared<OPCode38>(addr, dat_content, this);
+                case 0x39:
+                    return std::make_shared<OPCode39>(addr, dat_content, this);
+                case 0x3A:
+                    return std::make_shared<OPCode3A>(addr, dat_content, this);
+                case 0x3B:
+                    return std::make_shared<OPCode3B>(addr, dat_content, this);
+                case 0x3C:
+                    return std::make_shared<OPCode3C>(addr, dat_content, this);
+                case 0x3D:
+                    return std::make_shared<OPCode3D>(addr, dat_content, this);
+                case 0x3E:
+                    return std::make_shared<OPCode3E>(addr, dat_content, this);
+                case 0x3F:
+                    return std::make_shared<OPCode3F>(addr, dat_content, this);
+                case 0x40:
+                    return std::make_shared<OPCode40>(addr, dat_content, this);
+                case 0x41:
+                    return std::make_shared<OPCode41>(addr, dat_content, this);
+                case 0x42:
+                    return std::make_shared<OPCode42>(addr, dat_content, this);
+                case 0x43:
+                    return std::make_shared<OPCode43>(addr, dat_content, this);
+                case 0x44:
+                    return std::make_shared<OPCode44>(addr, dat_content, this);
+                case 0x45:
+                    return std::make_shared<OPCode45>(addr, dat_content, this);
+                case 0x46:
+                    return std::make_shared<OPCode46>(addr, dat_content, this);
+                case 0x47:
+                    return std::make_shared<OPCode47>(addr, dat_content, this);
+                case 0x48:
+                    return std::make_shared<OPCode48>(addr, dat_content, this);
+                case 0x49:
+                    return std::make_shared<OPCode49>(addr, dat_content, this);
+                case 0x4A:
+                    return std::make_shared<OPCode4A>(addr, dat_content, this);
+                case 0x4B:
+                    return std::make_shared<OPCode4B>(addr, dat_content, this);
+                case 0x4C:
+                    return std::make_shared<OPCode4C>(addr, dat_content, this);
+                case 0x4D:
+                    return std::make_shared<OPCode4D>(addr, dat_content, this);
+                case 0x4E:
+                    return std::make_shared<OPCode4E>(addr, dat_content, this);
+                case 0x4F:
+                    return std::make_shared<OPCode4F>(addr, dat_content, this);
+                case 0x50:
+                    return std::make_shared<OPCode50>(addr, dat_content, this);
+                case 0x51:
+                    return std::make_shared<OPCode51>(addr, dat_content, this);
+                case 0x52:
+                    return std::make_shared<OPCode52>(addr, dat_content, this);
+                case 0x53:
+                    return std::make_shared<OPCode53>(addr, dat_content, this);
+                case 0x54:
+                    return std::make_shared<OPCode54>(addr, dat_content, this);
+                case 0x55:
+                    return std::make_shared<OPCode55>(addr, dat_content, this);
+                case 0x56:
+                    return std::make_shared<OPCode56>(addr, dat_content, this);
+                case 0x57:
+                    return std::make_shared<OPCode57>(addr, dat_content, this);
+                case 0x58:
+                    return std::make_shared<OPCode58>(addr, dat_content, this);
+                case 0x5A:
+                    return std::make_shared<OPCode5A>(addr, dat_content, this);
+                    //                case 0x5B: return std::make_shared<OPCode5B>(addr,dat_content,this);
+                case 0x5C:
+                    return std::make_shared<OPCode5C>(addr, dat_content, this);
+                case 0x5D:
+                    return std::make_shared<OPCode5D>(addr, dat_content, this);
+                case 0x5E:
+                    return std::make_shared<OPCode5E>(addr, dat_content, this);
+                case 0x60:
+                    return std::make_shared<OPCode60>(addr, dat_content, this);
+                case 0x61:
+                    return std::make_shared<OPCode61>(addr, dat_content, this);
+                case 0x62:
+                    return std::make_shared<OPCode62>(addr, dat_content, this);
+                case 0x63:
+                    return std::make_shared<OPCode63>(addr, dat_content, this);
+                case 0x64:
+                    return std::make_shared<OPCode64>(addr, dat_content, this);
+                case 0x65:
+                    return std::make_shared<OPCode65>(addr, dat_content, this);
+                case 0x66:
+                    return std::make_shared<OPCode66>(addr, dat_content, this);
+                case 0x67:
+                    return std::make_shared<OPCode67>(addr, dat_content, this);
+                case 0x68:
+                    return std::make_shared<OPCode68>(addr, dat_content, this);
+                case 0x69:
+                    return std::make_shared<OPCode69>(addr, dat_content, this);
+                case 0x6A:
+                    return std::make_shared<OPCode6A>(addr, dat_content, this);
+                case 0x6B:
+                    return std::make_shared<OPCode6B>(addr, dat_content, this);
+                case 0x6C:
+                    return std::make_shared<OPCode6C>(addr, dat_content, this);
+                case 0x6E:
+                    return std::make_shared<OPCode6E>(addr, dat_content, this);
+                case 0x6F:
+                    return std::make_shared<OPCode6F>(addr, dat_content, this);
+                case 0x70:
+                    return std::make_shared<OPCode70>(addr, dat_content, this);
+                case 0x71:
+                    return std::make_shared<OPCode71>(addr, dat_content, this);
+                case 0x72:
+                    return std::make_shared<OPCode72>(addr, dat_content, this);
+                case 0x73:
+                    return std::make_shared<OPCode73>(addr, dat_content, this);
+                case 0x74:
+                    return std::make_shared<OPCode74>(addr, dat_content, this);
+                case 0x75:
+                    return std::make_shared<OPCode75>(addr, dat_content, this);
+                case 0x76:
+                    return std::make_shared<OPCode76>(addr, dat_content, this);
+                case 0x77:
+                    return std::make_shared<OPCode77>(addr, dat_content, this);
+                case 0x78:
+                    return std::make_shared<OPCode78>(addr, dat_content, this);
+                case 0x79:
+                    return std::make_shared<OPCode79>(addr, dat_content, this);
+                case 0x7A:
+                    return std::make_shared<OPCode7A>(addr, dat_content, this);
+                case 0x7B:
+                    return std::make_shared<OPCode7B>(addr, dat_content, this);
+                case 0x7C:
+                    return std::make_shared<OPCode7C>(addr, dat_content, this);
+                case 0x7D:
+                    return std::make_shared<OPCode7D>(addr, dat_content, this);
+                case 0x7E:
+                    return std::make_shared<OPCode7E>(addr, dat_content, this);
+                case 0x80:
+                    return std::make_shared<OPCode80>(addr, dat_content, this);
+                case 0x82:
+                    return std::make_shared<OPCode82>(addr, dat_content, this);
+                case 0x83:
+                    return std::make_shared<OPCode83>(addr, dat_content, this);
+                case 0x84:
+                    return std::make_shared<OPCode84>(addr, dat_content, this);
+                case 0x86:
+                    return std::make_shared<OPCode86>(addr, dat_content, this);
+                case 0x87:
+                    return std::make_shared<OPCode87>(addr, dat_content, this);
+                case 0x88:
+                    return std::make_shared<OPCode88>(addr, dat_content, this);
+                case 0x89:
+                    return std::make_shared<OPCode89>(addr, dat_content, this);
+                case 0x8A:
+                    return std::make_shared<OPCode8A>(addr, dat_content, this);
+                case 0x8B:
+                    return std::make_shared<OPCode8B>(addr, dat_content, this);
+                case 0x8C:
+                    return std::make_shared<OPCode8C>(addr, dat_content, this);
+                case 0x8D:
+                    return std::make_shared<OPCode8D>(addr, dat_content, this);
+                case 0x8E:
+                    return std::make_shared<OPCode8E>(addr, dat_content, this);
+                case 0x8F:
+                    return std::make_shared<OPCode8F>(addr, dat_content, this);
+                case 0x90:
+                    return std::make_shared<OPCode90>(addr, dat_content, this);
+                case 0x91:
+                    return std::make_shared<OPCode91>(addr, dat_content, this);
+                case 0x92:
+                    return std::make_shared<OPCode92>(addr, dat_content, this);
+                case 0x93:
+                    return std::make_shared<OPCode93>(addr, dat_content, this);
+                case 0x94:
+                    return std::make_shared<OPCode94>(addr, dat_content, this);
+                case 0x95:
+                    return std::make_shared<OPCode95>(addr, dat_content, this);
+                case 0x97:
+                    return std::make_shared<OPCode97>(addr, dat_content, this);
+                case 0x98:
+                    return std::make_shared<OPCode98>(addr, dat_content, this);
+                case 0x99:
+                    return std::make_shared<OPCode99>(addr, dat_content, this);
+                case 0x9A:
+                    return std::make_shared<OPCode9A>(addr, dat_content, this);
+                case 0x9B:
+                    return std::make_shared<OPCode9B>(addr, dat_content, this);
+                case 0x9C:
+                    return std::make_shared<OPCode9C>(addr, dat_content, this);
+                case 0x9D:
+                    return std::make_shared<OPCode9D>(addr, dat_content, this);
+                case 0x9E:
+                    return std::make_shared<OPCode9E>(addr, dat_content, this);
+                case 0xA0:
+                    return std::make_shared<OPCodeA0>(addr, dat_content, this);
+                case 0xA1:
+                    return std::make_shared<OPCodeA1>(addr, dat_content, this);
+                case 0xA3:
+                    return std::make_shared<OPCodeA3>(addr, dat_content, this);
+                case 0xA4:
+                    return std::make_shared<OPCodeA4>(addr, dat_content, this);
+                case 0xA6:
+                    return std::make_shared<OPCodeA6>(addr, dat_content, this);
+                case 0xA8:
+                    return std::make_shared<OPCodeA8>(addr, dat_content, this);
+                case 0xA9:
+                    return std::make_shared<OPCodeA9>(addr, dat_content, this);
+                case 0xAA:
+                    return std::make_shared<OPCodeAA>(addr, dat_content, this);
+                case 0xAB:
+                    return std::make_shared<OPCodeAB>(addr, dat_content, this);
+                case 0xAC:
+                    return std::make_shared<OPCodeAC>(addr, dat_content, this);
+                case 0xAD:
+                    return std::make_shared<OPCodeAD>(addr, dat_content, this);
+                case 0xAE:
+                    return std::make_shared<OPCodeAE>(addr, dat_content, this);
+                case 0xAF:
+                    return std::make_shared<OPCodeAF>(addr, dat_content, this);
+                case 0xB1:
+                    return std::make_shared<OPCodeB1>(addr, dat_content, this);
+                case 0xB2:
+                    return std::make_shared<OPCodeB2>(addr, dat_content, this);
+                case 0xB3:
+                    return std::make_shared<OPCodeB3>(addr, dat_content, this);
+                case 0xB4:
+                    return std::make_shared<OPCodeB4>(addr, dat_content, this);
+                case 0xB5:
+                    return std::make_shared<OPCodeB5>(addr, dat_content, this);
+                case 0xB6:
+                    return std::make_shared<OPCodeB6>(addr, dat_content, this);
+                case 0xB7:
+                    return std::make_shared<OPCodeB7>(addr, dat_content, this);
+                case 0xB8:
+                    return std::make_shared<OPCodeB8>(addr, dat_content, this);
+                case 0xB9:
+                    return std::make_shared<OPCodeB9>(addr, dat_content, this);
+                case 0xBA:
+                    return std::make_shared<OPCodeBA>(addr, dat_content, this);
+                case 0xBB:
+                    return std::make_shared<OPCodeBB>(addr, dat_content, this);
+                case 0xBC:
+                    return std::make_shared<OPCodeBC>(addr, dat_content, this);
+                case 0xBD:
+                    return std::make_shared<OPCodeBD>(addr, dat_content, this);
+                case 0xBE:
+                    return std::make_shared<OPCodeBE>(addr, dat_content, this);
+                case 0xC0:
+                    return std::make_shared<OPCodeC0>(addr, dat_content, this);
+                case 0xC1:
+                    return std::make_shared<OPCodeC1>(addr, dat_content, this);
+                case 0xC2:
+                    return std::make_shared<OPCodeC2>(addr, dat_content, this);
+                case 0xC3:
+                    return std::make_shared<OPCodeC3>(addr, dat_content, this);
+                case 0xC4:
+                    return std::make_shared<OPCodeC4>(addr, dat_content, this);
+                case 0xC5:
+                    return std::make_shared<OPCodeC5>(addr, dat_content, this);
+                case 0xC6:
+                    return std::make_shared<OPCodeC6>(addr, dat_content, this);
+                case 0xC7:
+                    return std::make_shared<OPCodeC7>(addr, dat_content, this);
+                case 0xC8:
+                    return std::make_shared<OPCodeC8>(addr, dat_content, this);
+                case 0xC9:
+                    return std::make_shared<OPCodeC9>(addr, dat_content, this);
+                    //                case 0xCA: return std::make_shared<OPCodeCA>(addr,dat_content,this);
+                    //                case 0xCB: return std::make_shared<OPCodeCB>(addr,dat_content,this);
+                    //                case 0xCC: return std::make_shared<OPCodeCC>(addr,dat_content,this);
+                case 0xCD:
+                    return std::make_shared<OPCodeCD>(addr, dat_content, this);
+                case 0xCE:
+                    return std::make_shared<OPCodeCE>(addr, dat_content, this);
+                case 0xCF:
+                    return std::make_shared<OPCodeCF>(addr, dat_content, this);
+                case 0xD0:
+                    return std::make_shared<OPCodeD0>(addr, dat_content, this);
+                case 0xD1:
+                    return std::make_shared<OPCodeD1>(addr, dat_content, this);
+                case 0xD2:
+                    return std::make_shared<OPCodeD2>(addr, dat_content, this);
+                case 0xD3:
+                    return std::make_shared<OPCodeD3>(addr, dat_content, this);
+                case 0xD4:
+                    return std::make_shared<OPCodeD4>(addr, dat_content, this);
+                case 0xD5:
+                    return std::make_shared<OPCodeD5>(addr, dat_content, this);
+                case 0xD6:
+                    return std::make_shared<OPCodeD6>(addr, dat_content, this);
+                case 0xD7:
+                    return std::make_shared<OPCodeD7>(addr, dat_content, this);
+                case 0xD8:
+                    return std::make_shared<OPCodeD8>(addr, dat_content, this);
+                case 0xFA:
+                    return std::make_shared<OPCodeFA>(addr, dat_content, this);
+                default:
+                    std::stringstream stream;
+                    stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
+                    /*std::string result( stream.str() );
+
+                    qFatal(result.c_str());*/
+                    error = true;
+                    addr++;
+                    return std::shared_ptr<Instruction>();
+            }
+        } else if (function_type == 1) { // the function is a "CreateMonsters" function
+
+            return std::make_shared<CreateMonsters>(addr, dat_content, this);
+        } else if (function_type == 2) { // the function is a "effect" function
+
+            return std::make_shared<EffectsInstr>(addr, dat_content, this);
+        } else if (function_type == 3) {
+
+            return std::make_shared<ActionTable>(addr, dat_content, this);
+        } else if (function_type == 4) {
+
+            return std::make_shared<AlgoTable>(addr, dat_content, this);
+        } else if (function_type == 5) {
+
+            return std::make_shared<WeaponAttTable>(addr, dat_content, this);
+        } else if (function_type == 6) {
+
+            return std::make_shared<BreakTable>(addr, dat_content, this);
+        } else if (function_type == 7) {
+
+            return std::make_shared<SummonTable>(addr, dat_content, this);
+        } else if (function_type == 8) {
+
+            return std::make_shared<ReactionTable>(addr, dat_content, this);
+        } else if (function_type == 9) {
+
+            return std::make_shared<PartTable>(addr, dat_content, this);
+        } else if (function_type == 10) {
+
+            return std::make_shared<AnimeClipTable>(addr, dat_content, this);
+        } else if (function_type == 11) {
+
+            return std::make_shared<FieldMonsterData>(addr, dat_content, this);
+        } else if (function_type == 12) {
+
+            return std::make_shared<FieldFollowData>(addr, dat_content, this);
+        } else if (function_type == 13) {
+
+            return std::make_shared<FC_autoX>(addr, dat_content, this);
+        } else if (function_type == 14) {
+
+            return std::make_shared<BookData99>(addr, dat_content, this);
+        } else if (function_type == 15) {
+
+            return std::make_shared<BookDataX>(addr, dat_content, this);
+        } else if (function_type == 16) {
+
+            return std::make_shared<AddCollision>(addr, dat_content, this);
+        } else if (function_type == 18) {
+
+            return std::make_shared<StyleName>(addr, dat_content, this);
         }
         return std::shared_ptr<Instruction>();
     }
-    bool CreateHeaderFromDAT(QByteArray &dat_content){
-
+    bool CreateHeaderFromDAT(QByteArray& dat_content) {
 
         display_text("Reading header...");
         uint nb_functions = ReadIntegerFromByteArray(0x14, dat_content);
@@ -7309,251 +7923,464 @@ class CS4Builder : public Builder
         QString filename = ReadStringFromByteArray(position, dat_content);
         SceneName = filename;
         int start_offset_area = ReadIntegerFromByteArray(0x8, dat_content);
-        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++){
-            position = start_offset_area + 4*idx_fun;
-            next_position = start_offset_area + 4*(idx_fun+1);
+        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++) {
+            position = start_offset_area + 4 * idx_fun;
+            next_position = start_offset_area + 4 * (idx_fun + 1);
             int addr = ReadIntegerFromByteArray(position, dat_content);
-            position = start_offset_area + 4*nb_functions + 2 * idx_fun;
+            position = start_offset_area + 4 * nb_functions + 2 * idx_fun;
             short name_pos = ReadShortFromByteArray(position, dat_content);
             int name_pos_int = name_pos;
             QString function_name = ReadStringFromByteArray(name_pos_int, dat_content);
             int end_addr;
-            if (idx_fun == nb_functions-1) //we are at the last function, so it ends at the end of the file
+            if (idx_fun == nb_functions - 1) // we are at the last function, so it ends at the end of the file
                 end_addr = dat_content.size();
-            else
-            {
+            else {
                 end_addr = ReadIntegerFromByteArray(next_position, dat_content);
             }
-            FunctionsToParse.push_back(function(idx_fun,function_name,name_pos,addr,end_addr));
-
+            FunctionsToParse.push_back(function(idx_fun, function_name, name_pos, addr, end_addr));
         }
         display_text("Header parsed.");
         return true;
     }
-    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int &addr, int row, QXlsx::Document &xls_content){
+    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int& addr, int row, QXlsx::Document& xls_content) {
 
-        uint OP = xls_content.read(row+1, 2).toInt();
+        uint OP = xls_content.read(row + 1, 2).toInt();
 
-        switch(OP){
-        case 0x00: return std::make_shared<OPCode0>(addr,row, xls_content,this);
-        case 0x01: return std::make_shared<OPCode1>(addr,row, xls_content,this);
-        case 0x02: return std::make_shared<OPCode2>(addr,row, xls_content,this);
-        case 0x03: return std::make_shared<OPCode3>(addr,row, xls_content,this);
-        case 0x04: return std::make_shared<OPCode4>(addr,row, xls_content,this);
-        case 0x05: return std::make_shared<OPCode5>(addr,row, xls_content,this);
-        case 0x06: return std::make_shared<OPCode6>(addr,row, xls_content,this);
-        case 0x07: return std::make_shared<OPCode7>(addr,row, xls_content,this);
-        case 0x08: return std::make_shared<OPCode8>(addr,row, xls_content,this);
-        case 0x0A: return std::make_shared<OPCodeA>(addr,row, xls_content,this);
-        case 0x0B: return std::make_shared<OPCodeB>(addr,row, xls_content,this);
-        case 0x0C: return std::make_shared<OPCodeC>(addr,row, xls_content,this);
-        case 0x0D: return std::make_shared<OPCode0D>(addr,row, xls_content,this);
-        case 0x0E: return std::make_shared<OPCodeE>(addr,row, xls_content,this);
-        case 0x10: return std::make_shared<OPCode10>(addr,row, xls_content,this);
-        case 0x11: return std::make_shared<OPCode11>(addr,row, xls_content,this);
-        case 0x12: return std::make_shared<OPCode12>(addr,row, xls_content,this);
-        case 0x13: return std::make_shared<OPCode13>(addr,row, xls_content,this);
-        case 0x14: return std::make_shared<OPCode14>(addr,row, xls_content,this);
-        case 0x15: return std::make_shared<OPCode15>(addr,row, xls_content,this);
-        case 0x16: return std::make_shared<OPCode16>(addr,row, xls_content,this);
-        case 0x17: return std::make_shared<OPCode17>(addr,row, xls_content,this);
-        case 0x18: return std::make_shared<OPCode18>(addr,row, xls_content,this);
-        case 0x19: return std::make_shared<OPCode19>(addr,row, xls_content,this);
-        case 0x1A: return std::make_shared<OPCode1A>(addr,row, xls_content,this);
-        case 0x1D: return std::make_shared<OPCode1D>(addr,row, xls_content,this);
-        case 0x1E: return std::make_shared<OPCode1E>(addr,row, xls_content,this);
-        case 0x1F: return std::make_shared<OPCode1F>(addr,row, xls_content,this);
-        case 0x20: return std::make_shared<OPCode20>(addr,row, xls_content,this);
-        case 0x21: return std::make_shared<OPCode21>(addr,row, xls_content,this);
-        case 0x22: return std::make_shared<OPCode22>(addr,row, xls_content,this);
-        case 0x23: return std::make_shared<OPCode23>(addr,row, xls_content,this);
-        case 0x24: return std::make_shared<OPCode24>(addr,row, xls_content,this);
-        case 0x25: return std::make_shared<OPCode25>(addr,row, xls_content,this);
-        case 0x26: return std::make_shared<OPCode26>(addr,row, xls_content,this);
-        case 0x27: return std::make_shared<OPCode27>(addr,row, xls_content,this);
-        case 0x28: return std::make_shared<OPCode28>(addr,row, xls_content,this);
-        case 0x29: return std::make_shared<OPCode29>(addr,row, xls_content,this);
-        case 0x2A: return std::make_shared<OPCode2A>(addr,row, xls_content,this);
-        case 0x2B: return std::make_shared<OPCode2B>(addr,row, xls_content,this);
-        case 0x2C: return std::make_shared<OPCode2C>(addr,row, xls_content,this);
-        case 0x2D: return std::make_shared<OPCode2D>(addr,row, xls_content,this);
-        case 0x2E: return std::make_shared<OPCode2E>(addr,row, xls_content,this);
-        case 0x2F: return std::make_shared<OPCode2F>(addr,row, xls_content,this);
-        case 0x30: return std::make_shared<OPCode30>(addr,row, xls_content,this);
-        case 0x31: return std::make_shared<OPCode31>(addr,row, xls_content,this);
-        case 0x32: return std::make_shared<OPCode32>(addr,row, xls_content,this);
-        case 0x33: return std::make_shared<OPCode33>(addr,row, xls_content,this);
-        case 0x34: return std::make_shared<OPCode34>(addr,row, xls_content,this);
-        case 0x35: return std::make_shared<OPCode35>(addr,row, xls_content,this);
-        case 0x36: return std::make_shared<OPCode36>(addr,row, xls_content,this);
-        case 0x37: return std::make_shared<OPCode37>(addr,row, xls_content,this);
-        case 0x38: return std::make_shared<OPCode38>(addr,row, xls_content,this);
-        case 0x39: return std::make_shared<OPCode39>(addr,row, xls_content,this);
-        case 0x3A: return std::make_shared<OPCode3A>(addr,row, xls_content,this);
-        case 0x3B: return std::make_shared<OPCode3B>(addr,row, xls_content,this);
-        case 0x3C: return std::make_shared<OPCode3C>(addr,row, xls_content,this);
-        case 0x3D: return std::make_shared<OPCode3D>(addr,row, xls_content,this);
-        case 0x3E: return std::make_shared<OPCode3E>(addr,row, xls_content,this);
-        case 0x3F: return std::make_shared<OPCode3F>(addr,row, xls_content,this);
-        case 0x40: return std::make_shared<OPCode40>(addr,row, xls_content,this);
-        case 0x41: return std::make_shared<OPCode41>(addr,row, xls_content,this);
-        case 0x42: return std::make_shared<OPCode42>(addr,row, xls_content,this);
-        case 0x43: return std::make_shared<OPCode43>(addr,row, xls_content,this);
-        case 0x44: return std::make_shared<OPCode44>(addr,row, xls_content,this);
-        case 0x45: return std::make_shared<OPCode45>(addr,row, xls_content,this);
-        case 0x46: return std::make_shared<OPCode46>(addr,row, xls_content,this);
-        case 0x47: return std::make_shared<OPCode47>(addr,row, xls_content,this);
-        case 0x48: return std::make_shared<OPCode48>(addr,row, xls_content,this);
-        case 0x49: return std::make_shared<OPCode49>(addr,row, xls_content,this);
-        case 0x4A: return std::make_shared<OPCode4A>(addr,row, xls_content,this);
-        case 0x4B: return std::make_shared<OPCode4B>(addr,row, xls_content,this);
-        case 0x4C: return std::make_shared<OPCode4C>(addr,row, xls_content,this);
-        case 0x4D: return std::make_shared<OPCode4D>(addr,row, xls_content,this);
-        case 0x4E: return std::make_shared<OPCode4E>(addr,row, xls_content,this);
-        case 0x4F: return std::make_shared<OPCode4F>(addr,row, xls_content,this);
-        case 0x50: return std::make_shared<OPCode50>(addr,row, xls_content,this);
-        case 0x51: return std::make_shared<OPCode51>(addr,row, xls_content,this);
-        case 0x52: return std::make_shared<OPCode52>(addr,row, xls_content,this);
-        case 0x53: return std::make_shared<OPCode53>(addr,row, xls_content,this);
-        case 0x54: return std::make_shared<OPCode54>(addr,row, xls_content,this);
-        case 0x55: return std::make_shared<OPCode55>(addr,row, xls_content,this);
-        case 0x56: return std::make_shared<OPCode56>(addr,row, xls_content,this);
-        case 0x57: return std::make_shared<OPCode57>(addr,row, xls_content,this);
-        case 0x58: return std::make_shared<OPCode58>(addr,row, xls_content,this);
-        case 0x5A: return std::make_shared<OPCode5A>(addr,row, xls_content,this);
-//                case 0x5B: return std::make_shared<OPCode5B>(addr,row, xls_content,this);
-        case 0x5C: return std::make_shared<OPCode5C>(addr,row, xls_content,this);
-        case 0x5D: return std::make_shared<OPCode5D>(addr,row, xls_content,this);
-        case 0x5E: return std::make_shared<OPCode5E>(addr,row, xls_content,this);
-        case 0x60: return std::make_shared<OPCode60>(addr,row, xls_content,this);
-        case 0x61: return std::make_shared<OPCode61>(addr,row, xls_content,this);
-        case 0x62: return std::make_shared<OPCode62>(addr,row, xls_content,this);
-        case 0x63: return std::make_shared<OPCode63>(addr,row, xls_content,this);
-        case 0x64: return std::make_shared<OPCode64>(addr,row, xls_content,this);
-        case 0x65: return std::make_shared<OPCode65>(addr,row, xls_content,this);
-        case 0x66: return std::make_shared<OPCode66>(addr,row, xls_content,this);
-        case 0x67: return std::make_shared<OPCode67>(addr,row, xls_content,this);
-        case 0x68: return std::make_shared<OPCode68>(addr,row, xls_content,this);
-        case 0x69: return std::make_shared<OPCode69>(addr,row, xls_content,this);
-        case 0x6A: return std::make_shared<OPCode6A>(addr,row, xls_content,this);
-        case 0x6B: return std::make_shared<OPCode6B>(addr,row, xls_content,this);
-        case 0x6C: return std::make_shared<OPCode6C>(addr,row, xls_content,this);
-        case 0x6E: return std::make_shared<OPCode6E>(addr,row, xls_content,this);
-        case 0x6F: return std::make_shared<OPCode6F>(addr,row, xls_content,this);
-        case 0x70: return std::make_shared<OPCode70>(addr,row, xls_content,this);
-        case 0x71: return std::make_shared<OPCode71>(addr,row, xls_content,this);
-        case 0x72: return std::make_shared<OPCode72>(addr,row, xls_content,this);
-        case 0x73: return std::make_shared<OPCode73>(addr,row, xls_content,this);
-        case 0x74: return std::make_shared<OPCode74>(addr,row, xls_content,this);
-        case 0x75: return std::make_shared<OPCode75>(addr,row, xls_content,this);
-        case 0x76: return std::make_shared<OPCode76>(addr,row, xls_content,this);
-        case 0x77: return std::make_shared<OPCode77>(addr,row, xls_content,this);
-        case 0x78: return std::make_shared<OPCode78>(addr,row, xls_content,this);
-        case 0x79: return std::make_shared<OPCode79>(addr,row, xls_content,this);
-        case 0x7A: return std::make_shared<OPCode7A>(addr,row, xls_content,this);
-        case 0x7B: return std::make_shared<OPCode7B>(addr,row, xls_content,this);
-        case 0x7C: return std::make_shared<OPCode7C>(addr,row, xls_content,this);
-        case 0x7D: return std::make_shared<OPCode7D>(addr,row, xls_content,this);
-        case 0x7E: return std::make_shared<OPCode7E>(addr,row, xls_content,this);
-        case 0x80: return std::make_shared<OPCode80>(addr,row, xls_content,this);
-        case 0x82: return std::make_shared<OPCode82>(addr,row, xls_content,this);
-        case 0x83: return std::make_shared<OPCode83>(addr,row, xls_content,this);
-        case 0x84: return std::make_shared<OPCode84>(addr,row, xls_content,this);
-        case 0x86: return std::make_shared<OPCode86>(addr,row, xls_content,this);
-        case 0x87: return std::make_shared<OPCode87>(addr,row, xls_content,this);
-        case 0x88: return std::make_shared<OPCode88>(addr,row, xls_content,this);
-        case 0x89: return std::make_shared<OPCode89>(addr,row, xls_content,this);
-        case 0x8A: return std::make_shared<OPCode8A>(addr,row, xls_content,this);
-        case 0x8B: return std::make_shared<OPCode8B>(addr,row, xls_content,this);
-        case 0x8C: return std::make_shared<OPCode8C>(addr,row, xls_content,this);
-        case 0x8D: return std::make_shared<OPCode8D>(addr,row, xls_content,this);
-        case 0x8E: return std::make_shared<OPCode8E>(addr,row, xls_content,this);
-        case 0x8F: return std::make_shared<OPCode8F>(addr,row, xls_content,this);
-        case 0x90: return std::make_shared<OPCode90>(addr,row, xls_content,this);
-        case 0x91: return std::make_shared<OPCode91>(addr,row, xls_content,this);
-        case 0x92: return std::make_shared<OPCode92>(addr,row, xls_content,this);
-        case 0x93: return std::make_shared<OPCode93>(addr,row, xls_content,this);
-        case 0x94: return std::make_shared<OPCode94>(addr,row, xls_content,this);
-        case 0x95: return std::make_shared<OPCode95>(addr,row, xls_content,this);
-        case 0x97: return std::make_shared<OPCode97>(addr,row, xls_content,this);
-        case 0x98: return std::make_shared<OPCode98>(addr,row, xls_content,this);
-        case 0x99: return std::make_shared<OPCode99>(addr,row, xls_content,this);
-        case 0x9A: return std::make_shared<OPCode9A>(addr,row, xls_content,this);
-        case 0x9B: return std::make_shared<OPCode9B>(addr,row, xls_content,this);
-        case 0x9C: return std::make_shared<OPCode9C>(addr,row, xls_content,this);
-        case 0x9D: return std::make_shared<OPCode9D>(addr,row, xls_content,this);
-        case 0x9E: return std::make_shared<OPCode9E>(addr,row, xls_content,this);
-        case 0xA0: return std::make_shared<OPCodeA0>(addr,row, xls_content,this);
-        case 0xA1: return std::make_shared<OPCodeA1>(addr,row, xls_content,this);
-        case 0xA3: return std::make_shared<OPCodeA3>(addr,row, xls_content,this);
-        case 0xA4: return std::make_shared<OPCodeA4>(addr,row, xls_content,this);
-        case 0xA6: return std::make_shared<OPCodeA6>(addr,row, xls_content,this);
-        case 0xA8: return std::make_shared<OPCodeA8>(addr,row, xls_content,this);
-        case 0xA9: return std::make_shared<OPCodeA9>(addr,row, xls_content,this);
-        case 0xAA: return std::make_shared<OPCodeAA>(addr,row, xls_content,this);
-        case 0xAB: return std::make_shared<OPCodeAB>(addr,row, xls_content,this);
-        case 0xAC: return std::make_shared<OPCodeAC>(addr,row, xls_content,this);
-        case 0xAD: return std::make_shared<OPCodeAD>(addr,row, xls_content,this);
-        case 0xAE: return std::make_shared<OPCodeAE>(addr,row, xls_content,this);
-        case 0xAF: return std::make_shared<OPCodeAF>(addr,row, xls_content,this);
-        case 0xB1: return std::make_shared<OPCodeB1>(addr,row, xls_content,this);
-        case 0xB2: return std::make_shared<OPCodeB2>(addr,row, xls_content,this);
-        case 0xB3: return std::make_shared<OPCodeB3>(addr,row, xls_content,this);
-        case 0xB4: return std::make_shared<OPCodeB4>(addr,row, xls_content,this);
-        case 0xB5: return std::make_shared<OPCodeB5>(addr,row, xls_content,this);
-        case 0xB6: return std::make_shared<OPCodeB6>(addr,row, xls_content,this);
-        case 0xB7: return std::make_shared<OPCodeB7>(addr,row, xls_content,this);
-        case 0xB8: return std::make_shared<OPCodeB8>(addr,row, xls_content,this);
-        case 0xB9: return std::make_shared<OPCodeB9>(addr,row, xls_content,this);
-        case 0xBA: return std::make_shared<OPCodeBA>(addr,row, xls_content,this);
-        case 0xBB: return std::make_shared<OPCodeBB>(addr,row, xls_content,this);
-        case 0xBC: return std::make_shared<OPCodeBC>(addr,row, xls_content,this);
-        case 0xBD: return std::make_shared<OPCodeBD>(addr,row, xls_content,this);
-        case 0xBE: return std::make_shared<OPCodeBE>(addr,row, xls_content,this);
-        case 0xC0: return std::make_shared<OPCodeC0>(addr,row, xls_content,this);
-        case 0xC1: return std::make_shared<OPCodeC1>(addr,row, xls_content,this);
-        case 0xC2: return std::make_shared<OPCodeC2>(addr,row, xls_content,this);
-        case 0xC3: return std::make_shared<OPCodeC3>(addr,row, xls_content,this);
-        case 0xC4: return std::make_shared<OPCodeC4>(addr,row, xls_content,this);
-        case 0xC5: return std::make_shared<OPCodeC5>(addr,row, xls_content,this);
-        case 0xC6: return std::make_shared<OPCodeC6>(addr,row, xls_content,this);
-        case 0xC7: return std::make_shared<OPCodeC7>(addr,row, xls_content,this);
-        case 0xC8: return std::make_shared<OPCodeC8>(addr,row, xls_content,this);
-        case 0xC9: return std::make_shared<OPCodeC9>(addr,row, xls_content,this);
-//                case 0xCA: return std::make_shared<OPCodeCA>(addr,row, xls_content,this);
-//                case 0xCB: return std::make_shared<OPCodeCB>(addr,row, xls_content,this);
-//                case 0xCC: return std::make_shared<OPCodeCC>(addr,row, xls_content,this);
-        case 0xCD: return std::make_shared<OPCodeCD>(addr,row, xls_content,this);
-        case 0xCE: return std::make_shared<OPCodeCE>(addr,row, xls_content,this);
-        case 0xCF: return std::make_shared<OPCodeCF>(addr,row, xls_content,this);
-        case 0xD0: return std::make_shared<OPCodeD0>(addr,row, xls_content,this);
-        case 0xD1: return std::make_shared<OPCodeD1>(addr,row, xls_content,this);
-        case 0xD2: return std::make_shared<OPCodeD2>(addr,row, xls_content,this);
-        case 0xD3: return std::make_shared<OPCodeD3>(addr,row, xls_content,this);
-        case 0xD4: return std::make_shared<OPCodeD4>(addr,row, xls_content,this);
-        case 0xD5: return std::make_shared<OPCodeD5>(addr,row, xls_content,this);
-        case 0xD6: return std::make_shared<OPCodeD6>(addr,row, xls_content,this);
-        case 0xD7: return std::make_shared<OPCodeD7>(addr,row, xls_content,this);
-        case 0xD8: return std::make_shared<OPCodeD8>(addr,row, xls_content,this);
-        case 0xFA: return std::make_shared<OPCodeFA>(addr,row, xls_content,this);
-        case 256: return std::make_shared<CreateMonsters>(addr, row, xls_content,this);
-            case 257: return std::make_shared<EffectsInstr>(addr, row, xls_content,this);
-            case 258: return std::make_shared<ActionTable>(addr, row, xls_content,this);
-            case 259: return std::make_shared<AlgoTable>(addr, row, xls_content,this);
-            case 260: return std::make_shared<WeaponAttTable>(addr, row, xls_content,this);
-            case 261: return std::make_shared<BreakTable>(addr, row, xls_content,this);
-            case 262: return std::make_shared<SummonTable>(addr, row, xls_content,this);
-            case 263: return std::make_shared<ReactionTable>(addr, row, xls_content,this);
-            case 264: return std::make_shared<PartTable>(addr, row, xls_content,this);
-            case 265: return std::make_shared<AnimeClipTable>(addr, row, xls_content,this);
-            case 266: return std::make_shared<FieldMonsterData>(addr, row, xls_content,this);
-            case 267: return std::make_shared<FieldFollowData>(addr, row, xls_content,this);
-            case 268: return std::make_shared<FC_autoX>(addr, row, xls_content,this);
-            case 269: return std::make_shared<BookData99>(addr, row, xls_content,this);
-            case 270: return std::make_shared<BookDataX>(addr, row, xls_content,this);
-            case 271: return std::make_shared<AddCollision>(addr, row, xls_content,this);
-            case 273: return std::make_shared<AnimeClipData>(addr, row, xls_content,this);
-            case 274: return std::make_shared<StyleName>(addr, row, xls_content,this);
+        switch (OP) {
+            case 0x00:
+                return std::make_shared<OPCode0>(addr, row, xls_content, this);
+            case 0x01:
+                return std::make_shared<OPCode1>(addr, row, xls_content, this);
+            case 0x02:
+                return std::make_shared<OPCode2>(addr, row, xls_content, this);
+            case 0x03:
+                return std::make_shared<OPCode3>(addr, row, xls_content, this);
+            case 0x04:
+                return std::make_shared<OPCode4>(addr, row, xls_content, this);
+            case 0x05:
+                return std::make_shared<OPCode5>(addr, row, xls_content, this);
+            case 0x06:
+                return std::make_shared<OPCode6>(addr, row, xls_content, this);
+            case 0x07:
+                return std::make_shared<OPCode7>(addr, row, xls_content, this);
+            case 0x08:
+                return std::make_shared<OPCode8>(addr, row, xls_content, this);
+            case 0x0A:
+                return std::make_shared<OPCodeA>(addr, row, xls_content, this);
+            case 0x0B:
+                return std::make_shared<OPCodeB>(addr, row, xls_content, this);
+            case 0x0C:
+                return std::make_shared<OPCodeC>(addr, row, xls_content, this);
+            case 0x0D:
+                return std::make_shared<OPCode0D>(addr, row, xls_content, this);
+            case 0x0E:
+                return std::make_shared<OPCodeE>(addr, row, xls_content, this);
+            case 0x10:
+                return std::make_shared<OPCode10>(addr, row, xls_content, this);
+            case 0x11:
+                return std::make_shared<OPCode11>(addr, row, xls_content, this);
+            case 0x12:
+                return std::make_shared<OPCode12>(addr, row, xls_content, this);
+            case 0x13:
+                return std::make_shared<OPCode13>(addr, row, xls_content, this);
+            case 0x14:
+                return std::make_shared<OPCode14>(addr, row, xls_content, this);
+            case 0x15:
+                return std::make_shared<OPCode15>(addr, row, xls_content, this);
+            case 0x16:
+                return std::make_shared<OPCode16>(addr, row, xls_content, this);
+            case 0x17:
+                return std::make_shared<OPCode17>(addr, row, xls_content, this);
+            case 0x18:
+                return std::make_shared<OPCode18>(addr, row, xls_content, this);
+            case 0x19:
+                return std::make_shared<OPCode19>(addr, row, xls_content, this);
+            case 0x1A:
+                return std::make_shared<OPCode1A>(addr, row, xls_content, this);
+            case 0x1D:
+                return std::make_shared<OPCode1D>(addr, row, xls_content, this);
+            case 0x1E:
+                return std::make_shared<OPCode1E>(addr, row, xls_content, this);
+            case 0x1F:
+                return std::make_shared<OPCode1F>(addr, row, xls_content, this);
+            case 0x20:
+                return std::make_shared<OPCode20>(addr, row, xls_content, this);
+            case 0x21:
+                return std::make_shared<OPCode21>(addr, row, xls_content, this);
+            case 0x22:
+                return std::make_shared<OPCode22>(addr, row, xls_content, this);
+            case 0x23:
+                return std::make_shared<OPCode23>(addr, row, xls_content, this);
+            case 0x24:
+                return std::make_shared<OPCode24>(addr, row, xls_content, this);
+            case 0x25:
+                return std::make_shared<OPCode25>(addr, row, xls_content, this);
+            case 0x26:
+                return std::make_shared<OPCode26>(addr, row, xls_content, this);
+            case 0x27:
+                return std::make_shared<OPCode27>(addr, row, xls_content, this);
+            case 0x28:
+                return std::make_shared<OPCode28>(addr, row, xls_content, this);
+            case 0x29:
+                return std::make_shared<OPCode29>(addr, row, xls_content, this);
+            case 0x2A:
+                return std::make_shared<OPCode2A>(addr, row, xls_content, this);
+            case 0x2B:
+                return std::make_shared<OPCode2B>(addr, row, xls_content, this);
+            case 0x2C:
+                return std::make_shared<OPCode2C>(addr, row, xls_content, this);
+            case 0x2D:
+                return std::make_shared<OPCode2D>(addr, row, xls_content, this);
+            case 0x2E:
+                return std::make_shared<OPCode2E>(addr, row, xls_content, this);
+            case 0x2F:
+                return std::make_shared<OPCode2F>(addr, row, xls_content, this);
+            case 0x30:
+                return std::make_shared<OPCode30>(addr, row, xls_content, this);
+            case 0x31:
+                return std::make_shared<OPCode31>(addr, row, xls_content, this);
+            case 0x32:
+                return std::make_shared<OPCode32>(addr, row, xls_content, this);
+            case 0x33:
+                return std::make_shared<OPCode33>(addr, row, xls_content, this);
+            case 0x34:
+                return std::make_shared<OPCode34>(addr, row, xls_content, this);
+            case 0x35:
+                return std::make_shared<OPCode35>(addr, row, xls_content, this);
+            case 0x36:
+                return std::make_shared<OPCode36>(addr, row, xls_content, this);
+            case 0x37:
+                return std::make_shared<OPCode37>(addr, row, xls_content, this);
+            case 0x38:
+                return std::make_shared<OPCode38>(addr, row, xls_content, this);
+            case 0x39:
+                return std::make_shared<OPCode39>(addr, row, xls_content, this);
+            case 0x3A:
+                return std::make_shared<OPCode3A>(addr, row, xls_content, this);
+            case 0x3B:
+                return std::make_shared<OPCode3B>(addr, row, xls_content, this);
+            case 0x3C:
+                return std::make_shared<OPCode3C>(addr, row, xls_content, this);
+            case 0x3D:
+                return std::make_shared<OPCode3D>(addr, row, xls_content, this);
+            case 0x3E:
+                return std::make_shared<OPCode3E>(addr, row, xls_content, this);
+            case 0x3F:
+                return std::make_shared<OPCode3F>(addr, row, xls_content, this);
+            case 0x40:
+                return std::make_shared<OPCode40>(addr, row, xls_content, this);
+            case 0x41:
+                return std::make_shared<OPCode41>(addr, row, xls_content, this);
+            case 0x42:
+                return std::make_shared<OPCode42>(addr, row, xls_content, this);
+            case 0x43:
+                return std::make_shared<OPCode43>(addr, row, xls_content, this);
+            case 0x44:
+                return std::make_shared<OPCode44>(addr, row, xls_content, this);
+            case 0x45:
+                return std::make_shared<OPCode45>(addr, row, xls_content, this);
+            case 0x46:
+                return std::make_shared<OPCode46>(addr, row, xls_content, this);
+            case 0x47:
+                return std::make_shared<OPCode47>(addr, row, xls_content, this);
+            case 0x48:
+                return std::make_shared<OPCode48>(addr, row, xls_content, this);
+            case 0x49:
+                return std::make_shared<OPCode49>(addr, row, xls_content, this);
+            case 0x4A:
+                return std::make_shared<OPCode4A>(addr, row, xls_content, this);
+            case 0x4B:
+                return std::make_shared<OPCode4B>(addr, row, xls_content, this);
+            case 0x4C:
+                return std::make_shared<OPCode4C>(addr, row, xls_content, this);
+            case 0x4D:
+                return std::make_shared<OPCode4D>(addr, row, xls_content, this);
+            case 0x4E:
+                return std::make_shared<OPCode4E>(addr, row, xls_content, this);
+            case 0x4F:
+                return std::make_shared<OPCode4F>(addr, row, xls_content, this);
+            case 0x50:
+                return std::make_shared<OPCode50>(addr, row, xls_content, this);
+            case 0x51:
+                return std::make_shared<OPCode51>(addr, row, xls_content, this);
+            case 0x52:
+                return std::make_shared<OPCode52>(addr, row, xls_content, this);
+            case 0x53:
+                return std::make_shared<OPCode53>(addr, row, xls_content, this);
+            case 0x54:
+                return std::make_shared<OPCode54>(addr, row, xls_content, this);
+            case 0x55:
+                return std::make_shared<OPCode55>(addr, row, xls_content, this);
+            case 0x56:
+                return std::make_shared<OPCode56>(addr, row, xls_content, this);
+            case 0x57:
+                return std::make_shared<OPCode57>(addr, row, xls_content, this);
+            case 0x58:
+                return std::make_shared<OPCode58>(addr, row, xls_content, this);
+            case 0x5A:
+                return std::make_shared<OPCode5A>(addr, row, xls_content, this);
+                //                case 0x5B: return std::make_shared<OPCode5B>(addr,row, xls_content,this);
+            case 0x5C:
+                return std::make_shared<OPCode5C>(addr, row, xls_content, this);
+            case 0x5D:
+                return std::make_shared<OPCode5D>(addr, row, xls_content, this);
+            case 0x5E:
+                return std::make_shared<OPCode5E>(addr, row, xls_content, this);
+            case 0x60:
+                return std::make_shared<OPCode60>(addr, row, xls_content, this);
+            case 0x61:
+                return std::make_shared<OPCode61>(addr, row, xls_content, this);
+            case 0x62:
+                return std::make_shared<OPCode62>(addr, row, xls_content, this);
+            case 0x63:
+                return std::make_shared<OPCode63>(addr, row, xls_content, this);
+            case 0x64:
+                return std::make_shared<OPCode64>(addr, row, xls_content, this);
+            case 0x65:
+                return std::make_shared<OPCode65>(addr, row, xls_content, this);
+            case 0x66:
+                return std::make_shared<OPCode66>(addr, row, xls_content, this);
+            case 0x67:
+                return std::make_shared<OPCode67>(addr, row, xls_content, this);
+            case 0x68:
+                return std::make_shared<OPCode68>(addr, row, xls_content, this);
+            case 0x69:
+                return std::make_shared<OPCode69>(addr, row, xls_content, this);
+            case 0x6A:
+                return std::make_shared<OPCode6A>(addr, row, xls_content, this);
+            case 0x6B:
+                return std::make_shared<OPCode6B>(addr, row, xls_content, this);
+            case 0x6C:
+                return std::make_shared<OPCode6C>(addr, row, xls_content, this);
+            case 0x6E:
+                return std::make_shared<OPCode6E>(addr, row, xls_content, this);
+            case 0x6F:
+                return std::make_shared<OPCode6F>(addr, row, xls_content, this);
+            case 0x70:
+                return std::make_shared<OPCode70>(addr, row, xls_content, this);
+            case 0x71:
+                return std::make_shared<OPCode71>(addr, row, xls_content, this);
+            case 0x72:
+                return std::make_shared<OPCode72>(addr, row, xls_content, this);
+            case 0x73:
+                return std::make_shared<OPCode73>(addr, row, xls_content, this);
+            case 0x74:
+                return std::make_shared<OPCode74>(addr, row, xls_content, this);
+            case 0x75:
+                return std::make_shared<OPCode75>(addr, row, xls_content, this);
+            case 0x76:
+                return std::make_shared<OPCode76>(addr, row, xls_content, this);
+            case 0x77:
+                return std::make_shared<OPCode77>(addr, row, xls_content, this);
+            case 0x78:
+                return std::make_shared<OPCode78>(addr, row, xls_content, this);
+            case 0x79:
+                return std::make_shared<OPCode79>(addr, row, xls_content, this);
+            case 0x7A:
+                return std::make_shared<OPCode7A>(addr, row, xls_content, this);
+            case 0x7B:
+                return std::make_shared<OPCode7B>(addr, row, xls_content, this);
+            case 0x7C:
+                return std::make_shared<OPCode7C>(addr, row, xls_content, this);
+            case 0x7D:
+                return std::make_shared<OPCode7D>(addr, row, xls_content, this);
+            case 0x7E:
+                return std::make_shared<OPCode7E>(addr, row, xls_content, this);
+            case 0x80:
+                return std::make_shared<OPCode80>(addr, row, xls_content, this);
+            case 0x82:
+                return std::make_shared<OPCode82>(addr, row, xls_content, this);
+            case 0x83:
+                return std::make_shared<OPCode83>(addr, row, xls_content, this);
+            case 0x84:
+                return std::make_shared<OPCode84>(addr, row, xls_content, this);
+            case 0x86:
+                return std::make_shared<OPCode86>(addr, row, xls_content, this);
+            case 0x87:
+                return std::make_shared<OPCode87>(addr, row, xls_content, this);
+            case 0x88:
+                return std::make_shared<OPCode88>(addr, row, xls_content, this);
+            case 0x89:
+                return std::make_shared<OPCode89>(addr, row, xls_content, this);
+            case 0x8A:
+                return std::make_shared<OPCode8A>(addr, row, xls_content, this);
+            case 0x8B:
+                return std::make_shared<OPCode8B>(addr, row, xls_content, this);
+            case 0x8C:
+                return std::make_shared<OPCode8C>(addr, row, xls_content, this);
+            case 0x8D:
+                return std::make_shared<OPCode8D>(addr, row, xls_content, this);
+            case 0x8E:
+                return std::make_shared<OPCode8E>(addr, row, xls_content, this);
+            case 0x8F:
+                return std::make_shared<OPCode8F>(addr, row, xls_content, this);
+            case 0x90:
+                return std::make_shared<OPCode90>(addr, row, xls_content, this);
+            case 0x91:
+                return std::make_shared<OPCode91>(addr, row, xls_content, this);
+            case 0x92:
+                return std::make_shared<OPCode92>(addr, row, xls_content, this);
+            case 0x93:
+                return std::make_shared<OPCode93>(addr, row, xls_content, this);
+            case 0x94:
+                return std::make_shared<OPCode94>(addr, row, xls_content, this);
+            case 0x95:
+                return std::make_shared<OPCode95>(addr, row, xls_content, this);
+            case 0x97:
+                return std::make_shared<OPCode97>(addr, row, xls_content, this);
+            case 0x98:
+                return std::make_shared<OPCode98>(addr, row, xls_content, this);
+            case 0x99:
+                return std::make_shared<OPCode99>(addr, row, xls_content, this);
+            case 0x9A:
+                return std::make_shared<OPCode9A>(addr, row, xls_content, this);
+            case 0x9B:
+                return std::make_shared<OPCode9B>(addr, row, xls_content, this);
+            case 0x9C:
+                return std::make_shared<OPCode9C>(addr, row, xls_content, this);
+            case 0x9D:
+                return std::make_shared<OPCode9D>(addr, row, xls_content, this);
+            case 0x9E:
+                return std::make_shared<OPCode9E>(addr, row, xls_content, this);
+            case 0xA0:
+                return std::make_shared<OPCodeA0>(addr, row, xls_content, this);
+            case 0xA1:
+                return std::make_shared<OPCodeA1>(addr, row, xls_content, this);
+            case 0xA3:
+                return std::make_shared<OPCodeA3>(addr, row, xls_content, this);
+            case 0xA4:
+                return std::make_shared<OPCodeA4>(addr, row, xls_content, this);
+            case 0xA6:
+                return std::make_shared<OPCodeA6>(addr, row, xls_content, this);
+            case 0xA8:
+                return std::make_shared<OPCodeA8>(addr, row, xls_content, this);
+            case 0xA9:
+                return std::make_shared<OPCodeA9>(addr, row, xls_content, this);
+            case 0xAA:
+                return std::make_shared<OPCodeAA>(addr, row, xls_content, this);
+            case 0xAB:
+                return std::make_shared<OPCodeAB>(addr, row, xls_content, this);
+            case 0xAC:
+                return std::make_shared<OPCodeAC>(addr, row, xls_content, this);
+            case 0xAD:
+                return std::make_shared<OPCodeAD>(addr, row, xls_content, this);
+            case 0xAE:
+                return std::make_shared<OPCodeAE>(addr, row, xls_content, this);
+            case 0xAF:
+                return std::make_shared<OPCodeAF>(addr, row, xls_content, this);
+            case 0xB1:
+                return std::make_shared<OPCodeB1>(addr, row, xls_content, this);
+            case 0xB2:
+                return std::make_shared<OPCodeB2>(addr, row, xls_content, this);
+            case 0xB3:
+                return std::make_shared<OPCodeB3>(addr, row, xls_content, this);
+            case 0xB4:
+                return std::make_shared<OPCodeB4>(addr, row, xls_content, this);
+            case 0xB5:
+                return std::make_shared<OPCodeB5>(addr, row, xls_content, this);
+            case 0xB6:
+                return std::make_shared<OPCodeB6>(addr, row, xls_content, this);
+            case 0xB7:
+                return std::make_shared<OPCodeB7>(addr, row, xls_content, this);
+            case 0xB8:
+                return std::make_shared<OPCodeB8>(addr, row, xls_content, this);
+            case 0xB9:
+                return std::make_shared<OPCodeB9>(addr, row, xls_content, this);
+            case 0xBA:
+                return std::make_shared<OPCodeBA>(addr, row, xls_content, this);
+            case 0xBB:
+                return std::make_shared<OPCodeBB>(addr, row, xls_content, this);
+            case 0xBC:
+                return std::make_shared<OPCodeBC>(addr, row, xls_content, this);
+            case 0xBD:
+                return std::make_shared<OPCodeBD>(addr, row, xls_content, this);
+            case 0xBE:
+                return std::make_shared<OPCodeBE>(addr, row, xls_content, this);
+            case 0xC0:
+                return std::make_shared<OPCodeC0>(addr, row, xls_content, this);
+            case 0xC1:
+                return std::make_shared<OPCodeC1>(addr, row, xls_content, this);
+            case 0xC2:
+                return std::make_shared<OPCodeC2>(addr, row, xls_content, this);
+            case 0xC3:
+                return std::make_shared<OPCodeC3>(addr, row, xls_content, this);
+            case 0xC4:
+                return std::make_shared<OPCodeC4>(addr, row, xls_content, this);
+            case 0xC5:
+                return std::make_shared<OPCodeC5>(addr, row, xls_content, this);
+            case 0xC6:
+                return std::make_shared<OPCodeC6>(addr, row, xls_content, this);
+            case 0xC7:
+                return std::make_shared<OPCodeC7>(addr, row, xls_content, this);
+            case 0xC8:
+                return std::make_shared<OPCodeC8>(addr, row, xls_content, this);
+            case 0xC9:
+                return std::make_shared<OPCodeC9>(addr, row, xls_content, this);
+                //                case 0xCA: return std::make_shared<OPCodeCA>(addr,row, xls_content,this);
+                //                case 0xCB: return std::make_shared<OPCodeCB>(addr,row, xls_content,this);
+                //                case 0xCC: return std::make_shared<OPCodeCC>(addr,row, xls_content,this);
+            case 0xCD:
+                return std::make_shared<OPCodeCD>(addr, row, xls_content, this);
+            case 0xCE:
+                return std::make_shared<OPCodeCE>(addr, row, xls_content, this);
+            case 0xCF:
+                return std::make_shared<OPCodeCF>(addr, row, xls_content, this);
+            case 0xD0:
+                return std::make_shared<OPCodeD0>(addr, row, xls_content, this);
+            case 0xD1:
+                return std::make_shared<OPCodeD1>(addr, row, xls_content, this);
+            case 0xD2:
+                return std::make_shared<OPCodeD2>(addr, row, xls_content, this);
+            case 0xD3:
+                return std::make_shared<OPCodeD3>(addr, row, xls_content, this);
+            case 0xD4:
+                return std::make_shared<OPCodeD4>(addr, row, xls_content, this);
+            case 0xD5:
+                return std::make_shared<OPCodeD5>(addr, row, xls_content, this);
+            case 0xD6:
+                return std::make_shared<OPCodeD6>(addr, row, xls_content, this);
+            case 0xD7:
+                return std::make_shared<OPCodeD7>(addr, row, xls_content, this);
+            case 0xD8:
+                return std::make_shared<OPCodeD8>(addr, row, xls_content, this);
+            case 0xFA:
+                return std::make_shared<OPCodeFA>(addr, row, xls_content, this);
+            case 256:
+                return std::make_shared<CreateMonsters>(addr, row, xls_content, this);
+            case 257:
+                return std::make_shared<EffectsInstr>(addr, row, xls_content, this);
+            case 258:
+                return std::make_shared<ActionTable>(addr, row, xls_content, this);
+            case 259:
+                return std::make_shared<AlgoTable>(addr, row, xls_content, this);
+            case 260:
+                return std::make_shared<WeaponAttTable>(addr, row, xls_content, this);
+            case 261:
+                return std::make_shared<BreakTable>(addr, row, xls_content, this);
+            case 262:
+                return std::make_shared<SummonTable>(addr, row, xls_content, this);
+            case 263:
+                return std::make_shared<ReactionTable>(addr, row, xls_content, this);
+            case 264:
+                return std::make_shared<PartTable>(addr, row, xls_content, this);
+            case 265:
+                return std::make_shared<AnimeClipTable>(addr, row, xls_content, this);
+            case 266:
+                return std::make_shared<FieldMonsterData>(addr, row, xls_content, this);
+            case 267:
+                return std::make_shared<FieldFollowData>(addr, row, xls_content, this);
+            case 268:
+                return std::make_shared<FC_autoX>(addr, row, xls_content, this);
+            case 269:
+                return std::make_shared<BookData99>(addr, row, xls_content, this);
+            case 270:
+                return std::make_shared<BookDataX>(addr, row, xls_content, this);
+            case 271:
+                return std::make_shared<AddCollision>(addr, row, xls_content, this);
+            case 273:
+                return std::make_shared<AnimeClipData>(addr, row, xls_content, this);
+            case 274:
+                return std::make_shared<StyleName>(addr, row, xls_content, this);
             default:
                 std::stringstream stream;
                 stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << this->SceneName.toStdString();
@@ -7566,8 +8393,7 @@ class CS4Builder : public Builder
         }
     }
 
-
-    QByteArray CreateHeaderBytes(){
+    QByteArray CreateHeaderBytes() {
 
         QByteArray header;
 
@@ -7575,50 +8401,50 @@ class CS4Builder : public Builder
         scene_name_bytes.append('\x0');
         int size_of_scene_name = scene_name_bytes.length();
 
-        int nb_byte_to_add_scene_name = (((int) ceil((float)(size_of_scene_name)/4)))*4 - size_of_scene_name;
+        int nb_byte_to_add_scene_name = (((int)ceil((float)(size_of_scene_name) / 4))) * 4 - size_of_scene_name;
         size_of_scene_name += nb_byte_to_add_scene_name;
         header.append(GetBytesFromInt(0x20));
         header.append(GetBytesFromInt(0x20));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name ));
-        header.append(GetBytesFromInt(FunctionsParsed.size()*4));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name  + FunctionsParsed.size()*4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name));
+        header.append(GetBytesFromInt(FunctionsParsed.size() * 4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4));
         header.append(GetBytesFromInt(FunctionsParsed.size()));
         int length_of_names_section = 0;
-        for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + length_of_names_section));
+        for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++)
+            length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
+        header.append(
+          GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + length_of_names_section));
         header.append(GetBytesFromInt(0xABCDEF00));
         header.append(scene_name_bytes);
-        for (int i = 0; i < nb_byte_to_add_scene_name; i++) header.append('\x0');
+        for (int i = 0; i < nb_byte_to_add_scene_name; i++)
+            header.append('\x0');
 
-        if (FunctionsParsed.size()>0){
+        if (FunctionsParsed.size() > 0) {
             QByteArray position_names;
             QByteArray actual_names;
             int offset_names = 0;
-            for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) {
+            for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++) {
                 header.append(GetBytesFromInt(FunctionsParsed[idx_fun].actual_addr));
                 QByteArray name = FunctionsParsed[idx_fun].name.toUtf8();
                 name.append('\x0');
-                position_names.append(GetBytesFromShort(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + offset_names));
+                position_names.append(
+                  GetBytesFromShort(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + offset_names));
                 actual_names.append(name);
                 offset_names = offset_names + name.size();
-
-
             }
             header.append(position_names);
             header.append(actual_names);
             int multiple = 4;
             if (FunctionsParsed[0].name.startsWith("_")) multiple = 0x10;
-            int nb_byte_to_add = (((int) ceil((float)header.size()/multiple)))*multiple - header.size();
+            int nb_byte_to_add = (((int)ceil((float)header.size() / multiple))) * multiple - header.size();
             QByteArray remaining;
-            for (int i = 0; i < nb_byte_to_add;i++) {
+            for (int i = 0; i < nb_byte_to_add; i++) {
                 remaining.push_back('\x0');
             }
             header.append(remaining);
         }
         return header;
     }
-
 };
-
 
 #endif // CS4INSTRUCTIONSSET_H

--- a/headers/TXInstructionsSet.h
+++ b/headers/TXInstructionsSet.h
@@ -1,175 +1,164 @@
 #ifndef TXINSTRUCTIONSSET_H
 #define TXINSTRUCTIONSSET_H
-#include "headers/utilities.h"
 #include "headers/functions.h"
 #include "headers/translationfile.h"
+#include "headers/utilities.h"
 
 #include <QString>
 
-
-
-class TXTranslationFile : public TranslationFile
-{
-    public:
-    TXTranslationFile():TranslationFile(){}
-
+class TXTranslationFile : public TranslationFile {
+  public:
+    TXTranslationFile()
+      : TranslationFile() {}
 };
-class TXBuilder : public Builder
-{
-    public:
-    TXBuilder(){
+class TXBuilder : public Builder {
+  public:
+    TXBuilder() {}
 
-    }
-
-    QVector<QString> TXUIFiles = {"battle_menu","camp_menu", "camp_menu_v","note_menu","note_menu_v","shop_menu","shop_menu_v","title_menu","title_menu_v"};
-    static void reading_dialog(int &addr, QByteArray &content, Instruction * instr){
+    QVector<QString> TXUIFiles = { "battle_menu", "camp_menu",   "camp_menu_v", "note_menu",   "note_menu_v",
+                                   "shop_menu",   "shop_menu_v", "title_menu",  "title_menu_v" };
+    static void reading_dialog(int& addr, QByteArray& content, Instruction* instr) {
 
         QByteArray current_op_value;
         int addr_ = addr;
 
         bool start_text = false;
         int cnt = 0;
-        do{
+        do {
             unsigned char current_byte = content[addr];
 
-            switch(current_byte){
+            switch (current_byte) {
                 case 0x00:
                     current_op_value.clear();
                     current_op_value[0] = 0;
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     addr++;
                     return;
                 case 0x01:
 
                     if (start_text)
                         current_op_value.push_back(current_byte);
-                    else{
+                    else {
 
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         current_op_value.clear();
                     }
                     addr++;
                     break;
                 case 0x02:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
                     break;
                 case 0x10:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x17:
                 case 0x19:
                     start_text = false;
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
-
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 case 0x11:
                 case 0x12:
-                    if (current_op_value.size()>0) {
-                        instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_op_value.size() > 0) {
+                        instr->AddOperande(operande(addr_, "dialog", current_op_value));
                     }
                     current_op_value.clear();
                     current_op_value.push_back(current_byte);
-                    instr->AddOperande(operande(addr,"byte", current_op_value));
+                    instr->AddOperande(operande(addr, "byte", current_op_value));
                     current_op_value.clear();
                     addr++;
-                    instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 case 0x23:
                     current_op_value.push_back(0x23);
                     addr_ = addr;
                     addr++;
                     current_byte = content[addr];
-                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) ||
-                           (current_byte == 0x42)||(current_byte == 0x48)||(current_byte == 0x56)||(current_byte == 0x4b) ||
-                            (current_byte == 0x6b) || (current_byte == 0x46)) {
+                    if ((((current_byte == 0x45) || (current_byte == 0x65)) || (current_byte == 0x4d)) || (current_byte == 0x42) ||
+                        (current_byte == 0x48) || (current_byte == 0x56) || (current_byte == 0x4b) || (current_byte == 0x6b) ||
+                        (current_byte == 0x46)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
+
+                        if (current_byte != 0x5f) {
+                            if (current_byte == 0x5b) {
+                                do {
+                                    current_op_value.push_back(current_byte);
+                                    addr++;
+                                    current_byte = content[addr];
+                                } while (current_byte != 0x5D);
+                                current_op_value.push_back(current_byte);
+                                addr++;
+                                current_byte = content[addr];
+                            }
+                            break;
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
-
-                              if (current_byte != 0x5f) {
-                                  if (current_byte == 0x5b) {
-                                      do{
-                                          current_op_value.push_back(current_byte);
-                                          addr++;
-                                          current_byte = content[addr];
-                                      }
-                                      while(current_byte!=0x5D);
-                                      current_op_value.push_back(current_byte);
-                                      addr++;
-                                      current_byte = content[addr];
-                                  }
-                                  break;
-                              }
-                              else{
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  current_op_value.push_back(current_byte);
-                                  addr++;
-                                  current_byte = content[addr];
-                                  break;
-                              }
-
-                           }
-                    else if((((current_byte + 0xb7) & 0xdf) == 0)||(current_byte == 0x50)||(current_byte == 0x54)||(current_byte == 0x57)||
-                                 (current_byte == 0x53)||(current_byte == 0x73)||(current_byte == 0x43)||(current_byte == 99)||(current_byte == 0x78)||
-                                 (current_byte == 0x79)||(current_byte == 0x47)||(current_byte == 0x44)||(current_byte == 0x55)||(current_byte == 0x52)) {
-                                 current_op_value.push_back(current_byte);
-                                 addr++;
-                                 current_byte = content[addr];
-                                 break;
+                            current_op_value.push_back(current_byte);
+                            addr++;
+                            current_byte = content[addr];
+                            break;
                         }
+
+                    } else if ((((current_byte + 0xb7) & 0xdf) == 0) || (current_byte == 0x50) || (current_byte == 0x54) ||
+                               (current_byte == 0x57) || (current_byte == 0x53) || (current_byte == 0x73) || (current_byte == 0x43) ||
+                               (current_byte == 99) || (current_byte == 0x78) || (current_byte == 0x79) || (current_byte == 0x47) ||
+                               (current_byte == 0x44) || (current_byte == 0x55) || (current_byte == 0x52)) {
+                        current_op_value.push_back(current_byte);
+                        addr++;
+                        current_byte = content[addr];
                         break;
+                    }
+                    break;
                 default:
-                    if (current_byte < 0x20){
-                        if (current_op_value.size()>0) {
-                            instr->AddOperande(operande(addr_,"dialog", current_op_value));
+                    if (current_byte < 0x20) {
+                        if (current_op_value.size() > 0) {
+                            instr->AddOperande(operande(addr_, "dialog", current_op_value));
                         }
                         start_text = false;
                         current_op_value.clear();
                         current_op_value.push_back(current_byte);
-                        instr->AddOperande(operande(addr,"byte", current_op_value));
+                        instr->AddOperande(operande(addr, "byte", current_op_value));
                         addr++;
                         current_op_value.clear();
-                    }
-                    else {
+                    } else {
                         if (!(start_text)) start_text = true;
 
-                        if ((current_byte < 0xE0)&&(current_byte >= 0xC0)){
+                        if ((current_byte < 0xE0) && (current_byte >= 0xC0)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte >= 0xE0)&&(current_byte <= 0xF7)){
+                        } else if ((current_byte >= 0xE0) && (current_byte <= 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
                             current_byte = content[addr];
@@ -178,12 +167,10 @@ class TXBuilder : public Builder
                             current_byte = content[addr];
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else if ((current_byte > 0xF7)){
+                        } else if ((current_byte > 0xF7)) {
                             current_op_value.push_back(current_byte);
                             addr++;
-                        }
-                        else{
+                        } else {
                             current_op_value.push_back(current_byte);
                             addr++;
                         }
@@ -191,2421 +178,2731 @@ class TXBuilder : public Builder
                     break;
             }
 
-
             cnt++;
-        }
-        while(cnt<9999);
-
+        } while (cnt < 9999);
     }
-    static void fun_1403c90e0(int &addr, QByteArray &content, Instruction * instr, int param){
+    static void fun_1403c90e0(int& addr, QByteArray& content, Instruction* instr, int param) {
         QByteArray control_byte3_arr = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte3_arr));
+        instr->AddOperande(operande(addr, "byte", control_byte3_arr));
         unsigned char control_byte3 = (unsigned char)control_byte3_arr[0];
 
-        if (control_byte3 == '\x11'){
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+        if (control_byte3 == '\x11') {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-        }
-        else if (control_byte3 != '3'){
+        } else if (control_byte3 != '3') {
 
-            if (control_byte3 == '\"'){
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            if (control_byte3 == '\"') {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-            }
-            else if (control_byte3 != 0x44){
+            } else if (control_byte3 != 0x44) {
 
-                if (control_byte3 == 0xDD){
+                if (control_byte3 == 0xDD) {
 
+                    if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                } else if (control_byte3 == 0xFF) {
+                    instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                } else {
+                    if (control_byte3 != 0xEE) {
 
-                    if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                }
-                else if (control_byte3 == 0xFF){
-                    instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                }
-                else{
-                    if (control_byte3 != 0xEE){
-
-                    }
-                    else{
-                        instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    } else {
+                        instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                        instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     }
                 }
 
-
-            }
-            else{
-                instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                if (param!=0)instr->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            } else {
+                instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                if (param != 0) instr->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
 
-        }
-        else{
-            instr->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+        } else {
+            instr->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     }
-    static void sub05(int &addr, QByteArray &content, Instruction * instr){
+    static void sub05(int& addr, QByteArray& content, Instruction* instr) {
         QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        instr->AddOperande(operande(addr,"byte", control_byte));
+        instr->AddOperande(operande(addr, "byte", control_byte));
 
-        while ((int)control_byte[0]!=1){
+        while ((int)control_byte[0] != 1) {
 
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x0:
-                    case 0x24:
-                        instr->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                        break;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x0:
+                case 0x24:
+                    instr->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
 
-                    case 0x1c:{
-                        //the next byte is the OP code for a new instruction
+                case 0x1c: {
+                    // the next byte is the OP code for a new instruction
 
-                        std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content,0);
+                    std::shared_ptr<Instruction> instr2 = instr->Maker->CreateInstructionFromDAT(addr, content, 0);
 
-                        operande op = operande(addr,"instruction", instr2->getBytes());
-                        instr->AddOperande(op);
+                    operande op = operande(addr, "instruction", instr2->getBytes());
+                    instr->AddOperande(op);
 
-
-                        break;
-                    }
-                    case 0x1e:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    case 0x1f:
-                    case 0x20:
-                    case 0x23:
-
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                        break;
-                    case 0x21:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        instr->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    case 0x25:
-                        instr->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    default:
-                        ;
+                    break;
                 }
+                case 0x1e:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                case 0x1f:
+                case 0x20:
+                case 0x23:
 
-                control_byte = ReadSubByteArray(content, addr, 1);
-
-                instr->AddOperande(operande(addr,"byte", control_byte));
-
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x21:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    instr->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                case 0x25:
+                    instr->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                default:;
             }
 
+            control_byte = ReadSubByteArray(content, addr, 1);
+
+            instr->AddOperande(operande(addr, "byte", control_byte));
+        }
     }
-    class CreateMonsters : public Instruction
-    {
-        public:
-        CreateMonsters():Instruction(-1,256,nullptr){}
-        CreateMonsters(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"CreateMonsters", 256,Maker){}
-        CreateMonsters(int addr, Builder *Maker):Instruction(addr,"CreateMonsters", 256, Maker){}
-        CreateMonsters(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"CreateMonsters", 256,Maker){
+    class CreateMonsters : public Instruction {
+      public:
+        CreateMonsters()
+          : Instruction(-1, 256, nullptr) {}
+        CreateMonsters(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int addr, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {}
+        CreateMonsters(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "CreateMonsters", 256, Maker) {
             int initial_addr = addr;
             int max_nb_monsters = 8;
-            if (Maker->goal<addr+0x20){
+            if (Maker->goal < addr + 0x20) {
 
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            int first = ReadIntegerFromByteArray(addr,content);
+            int first = ReadIntegerFromByteArray(addr, content);
 
-            if ((first == -1)&&(addr + 0x20 == Maker->goal)){
+            if ((first == -1) && (addr + 0x20 == Maker->goal)) {
 
-                this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
+                this->AddOperande(
+                  operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
                 Maker->flag_monsters = true;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            int check1 = ReadIntegerFromByteArray(addr,content);
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            int check1 = ReadIntegerFromByteArray(addr, content);
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            int check2 = ReadIntegerFromByteArray(addr,content);
-            if (check1 && check2 != 0){ //bad
+            int check2 = ReadIntegerFromByteArray(addr, content);
+            if (check1 && check2 != 0) { // bad
 
                 addr = initial_addr;
                 Maker->flag_monsters = false;
                 return;
             }
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2))); //0x10
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2))); //0x1A
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4))); //0x1C
-            //0x20
-
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x10
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // 0x1A
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // 0x1C
+            // 0x20
 
             int cnt = 0;
-            do{
-
+            do {
 
                 QByteArray array = ReadSubByteArray(content, addr, 4);
-                first = ReadIntegerFromByteArray(0,array);
-                this->AddOperande(operande(addr,"int", array));
+                first = ReadIntegerFromByteArray(0, array);
+                this->AddOperande(operande(addr, "int", array));
 
                 int counter = 0;
 
-                if (first == -2){
+                if (first == -2) {
 
                     QByteArray array = ReadSubByteArray(content, addr, 4);
-                    this->AddOperande(operande(addr,"int", array));
+                    this->AddOperande(operande(addr, "int", array));
                     max_nb_monsters = 4;
-                }
-                else if (first == -1){
-                    this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x18))); //?? it's empty
+                } else if (first == -1) {
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x18))); //?? it's empty
                     Maker->flag_monsters = true;
                     return;
-                }
-                else max_nb_monsters = 8;
+                } else
+                    max_nb_monsters = 8;
 
-                if (Maker->goal<addr + (0x10)*max_nb_monsters + max_nb_monsters*2){
+                if (Maker->goal < addr + (0x10) * max_nb_monsters + max_nb_monsters * 2) {
 
                     addr = initial_addr;
                     Maker->flag_monsters = false;
                     return;
                 }
 
-                do{
+                do {
                     counter++;
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10-monsters_name.size()-1);
-                    operande fill = operande(addr,"fill", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "fill", remaining);
                     fill.setBytesToFill(0x10);
                     this->AddOperande(fill);
 
-                }
-                while(counter < max_nb_monsters);
+                } while (counter < max_nb_monsters);
 
-                for (int idx_byte = 0; idx_byte < max_nb_monsters; idx_byte++) this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                for (int idx_byte = 0; idx_byte < max_nb_monsters; idx_byte++)
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                if ((unsigned char) content[addr] == 0)this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, max_nb_monsters))); //??
+                if ((unsigned char)content[addr] == 0)
+                    this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, max_nb_monsters))); //??
                 else {
                     QByteArray monsters_name = ReadStringSubByteArray(content, addr);
-                    this->AddOperande(operande(addr,"string", monsters_name));
+                    this->AddOperande(operande(addr, "string", monsters_name));
 
-                    QByteArray remaining = ReadSubByteArray(content, addr, 12-monsters_name.size()-1);
-                    operande fill = operande(addr,"bytearray", remaining);
+                    QByteArray remaining = ReadSubByteArray(content, addr, 12 - monsters_name.size() - 1);
+                    operande fill = operande(addr, "bytearray", remaining);
                     fill.setBytesToFill(12);
                     this->AddOperande(fill);
-
-
                 }
 
-                first = ReadIntegerFromByteArray(addr,content);
+                first = ReadIntegerFromByteArray(addr, content);
 
                 cnt++;
 
-            }
-            while((first != -1)&&(addr != Maker->goal - 4));
+            } while ((first != -1) && (addr != Maker->goal - 4));
             if (addr == Maker->goal - 4) {
-                first = ReadIntegerFromByteArray(addr,content);
-                if (first != 1){
+                first = ReadIntegerFromByteArray(addr, content);
+                if (first != 1) {
                     addr = initial_addr;
                     Maker->flag_monsters = false;
                     return;
-                }
-                else{
+                } else {
                     Maker->flag_monsters = true;
                     return;
                 }
-
             }
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
+            this->AddOperande(
+              operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1C))); //?? we don't forget to take the int as well
             Maker->flag_monsters = true;
         }
-
-
     };
-    class EffectsInstr : public Instruction
-    {
-        public:
-        EffectsInstr():Instruction(-1,257,nullptr){}
-        EffectsInstr(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"EffectsInstr", 257,Maker){}
-        EffectsInstr(int addr, Builder *Maker):Instruction(addr,"EffectsInstr", 257, Maker){}
-        EffectsInstr(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"EffectsInstr", 257,Maker){
-            bool bytes_blocks_remain = Maker->goal >= addr+0x28;
+    class EffectsInstr : public Instruction {
+      public:
+        EffectsInstr()
+          : Instruction(-1, 257, nullptr) {}
+        EffectsInstr(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int addr, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {}
+        EffectsInstr(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "EffectsInstr", 257, Maker) {
+            bool bytes_blocks_remain = Maker->goal >= addr + 0x28;
 
-            while (bytes_blocks_remain){
+            while (bytes_blocks_remain) {
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
+                this->AddOperande(operande(addr, "string", str));
 
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
 
-
-                operande fill = operande(addr,"fill", remaining);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
-                bytes_blocks_remain = Maker->goal >= addr+0x28;
-
+                bytes_blocks_remain = Maker->goal >= addr + 0x28;
             }
-
         }
-
-
     };
-    class ActionTable : public Instruction
-    {
-        public:
-        ActionTable():Instruction(-1,258,nullptr){}
-        ActionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ActionTable", 258,Maker){}
-        ActionTable(int addr, Builder *Maker):Instruction(addr,"ActionTable", 258, Maker){}
-        ActionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ActionTable", 258,Maker){
+    class ActionTable : public Instruction {
+      public:
+        ActionTable()
+          : Instruction(-1, 258, nullptr) {}
+        ActionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ActionTable", 258, Maker) {}
+        ActionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {}
+        ActionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ActionTable", 258, Maker) {
 
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
+            while (cnt < current_byte) {
 
-
-
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-                this->AddOperande(operande(addr,"short", short_bytes));//2
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-46
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-45
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-44
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-43
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-42
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-41
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-40
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-3F
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-3E
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//ebp-3D
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-3C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-38
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-34
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-30
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-2C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-28
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//ebp-24
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+                this->AddOperande(operande(addr, "short", short_bytes));                       // 2
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-46
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-45
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-44
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-43
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-42
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-41
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-40
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-3F
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-3E
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // ebp-3D
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-3C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-38
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-34
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-30
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-2C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-28
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));  // ebp-24
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
 
                 QByteArray str_ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str_));
-                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20-str_.size()-1);
-                operande fill_ = operande(addr,"fill", remaining_);
+                this->AddOperande(operande(addr, "string", str_));
+                QByteArray remaining_ = ReadSubByteArray(content, addr, 0x20 - str_.size() - 1);
+                operande fill_ = operande(addr, "fill", remaining_);
                 fill_.setBytesToFill(0x20);
                 this->AddOperande(fill_);
 
-
                 QByteArray str__ = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str__));
-                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x30-str__.size()-1);
-                operande fill__ = operande(addr,"fill", remaining__);
+                this->AddOperande(operande(addr, "string", str__));
+                QByteArray remaining__ = ReadSubByteArray(content, addr, 0x30 - str__.size() - 1);
+                operande fill__ = operande(addr, "fill", remaining__);
                 fill__.setBytesToFill(0x30);
                 this->AddOperande(fill__);
 
                 cnt++;
-          }
-
-
-        }
-
-
-    };
-    class AddCollision : public Instruction
-    {
-        public:
-        AddCollision():Instruction(-1,271,nullptr){}
-        AddCollision(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AddCollision", 271,Maker){}
-        AddCollision(int addr, Builder *Maker):Instruction(addr,"AddCollision", 271, Maker){}
-        AddCollision(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AddCollision", 271,Maker){
-
-
-            unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            int cnt = 0;
-            while(cnt < current_byte){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                cnt++;
-          }
-
-
-        }
-
-
-    };
-    class ConditionTable : public Instruction
-    {
-        public:
-        ConditionTable():Instruction(-1,272,nullptr){}
-        ConditionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ConditionTable", 272,Maker){}
-        ConditionTable(int addr, Builder *Maker):Instruction(addr,"ConditionTable", 272, Maker){}
-        ConditionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ConditionTable", 272,Maker){
-
-            unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            int cnt = 0;
-            while(cnt < current_byte){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//EBP-52
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-50
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-4C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-48
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-44
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-40
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-3C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-38
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-34
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-30
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-2C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-28
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-24
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-20
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-1C
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-18
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4))); //EBP-14
-                cnt++;
-          }
-
-
-        }
-
-
-    };
-    class AlgoTable : public Instruction //42d177
-    {
-        public:
-        AlgoTable():Instruction(-1,259,nullptr){}
-        AlgoTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AlgoTable", 259,Maker){}
-        AlgoTable(int addr, Builder *Maker):Instruction(addr,"AlgoTable", 259, Maker){}
-        AlgoTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AlgoTable", 259,Maker){
-            int cnt = 0;
-            unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//3
-            while(cnt < current_byte){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
-
-                this->AddOperande(operande(addr,"short", short_bytes));
-
-
-                this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-                if (addr+0x20 > Maker->goal) return;
-                cnt++;
             }
-
-            //this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
-
         }
     };
-    class WeaponAttTable : public Instruction
-    {
-        public:
-        WeaponAttTable():Instruction(-1,260,nullptr){}
-        WeaponAttTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"WeaponAttTable", 260,Maker){}
-        WeaponAttTable(int addr, Builder *Maker):Instruction(addr,"WeaponAttTable", 260, Maker){}
-        WeaponAttTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"WeaponAttTable", 260,Maker){
+    class AddCollision : public Instruction {
+      public:
+        AddCollision()
+          : Instruction(-1, 271, nullptr) {}
+        AddCollision(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AddCollision", 271, Maker) {}
+        AddCollision(int addr, Builder* Maker)
+          : Instruction(addr, "AddCollision", 271, Maker) {}
+        AddCollision(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AddCollision", 271, Maker) {
 
-            this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    class BreakTable : public Instruction
-    {
-        public:
-        BreakTable():Instruction(-1,261,nullptr){}
-        BreakTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BreakTable", 261,Maker){}
-        BreakTable(int addr, Builder *Maker):Instruction(addr,"BreakTable", 261, Maker){}
-        BreakTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BreakTable", 261,Maker){
-            int cnt = 0;
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));//3
-            while(cnt < current_byte){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            int cnt = 0;
+            while (cnt < current_byte) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
                 cnt++;
             }
         }
     };
-    class SummonTable : public Instruction //140142002
-    {
-        public:
-        SummonTable():Instruction(-1,262,nullptr){}
-        SummonTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"SummonTable", 262,Maker){}
-        SummonTable(int addr, Builder *Maker):Instruction(addr,"SummonTable", 262, Maker){}
-        SummonTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"SummonTable", 262,Maker){
+    class ConditionTable : public Instruction {
+      public:
+        ConditionTable()
+          : Instruction(-1, 272, nullptr) {}
+        ConditionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ConditionTable", 272, Maker) {}
+        ConditionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ConditionTable", 272, Maker) {}
+        ConditionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ConditionTable", 272, Maker) {
 
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            while (cnt < current_byte) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // EBP-52
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-50
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-4C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-48
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-44
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-40
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-3C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-38
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-34
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-30
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-2C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-28
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-24
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-20
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-1C
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-18
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));   // EBP-14
+                cnt++;
+            }
+        }
+    };
+    class AlgoTable
+      : public Instruction // 42d177
+    {
+      public:
+        AlgoTable()
+          : Instruction(-1, 259, nullptr) {}
+        AlgoTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AlgoTable", 259, Maker) {}
+        AlgoTable(int addr, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {}
+        AlgoTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AlgoTable", 259, Maker) {
+            int cnt = 0;
+            unsigned char current_byte = content[addr];
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // 3
+            while (cnt < current_byte) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
+
+                this->AddOperande(operande(addr, "short", short_bytes));
+
+                this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 0x1E)));
+                if (addr + 0x20 > Maker->goal) return;
+                cnt++;
+            }
+
+            // this->AddOperande(operande(addr,"bytearray", ReadSubByteArray(content, addr,0x1E)));
+        }
+    };
+    class WeaponAttTable : public Instruction {
+      public:
+        WeaponAttTable()
+          : Instruction(-1, 260, nullptr) {}
+        WeaponAttTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int addr, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {}
+        WeaponAttTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "WeaponAttTable", 260, Maker) {
+
+            this->AddOperande(operande(addr, "bytearray", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    class BreakTable : public Instruction {
+      public:
+        BreakTable()
+          : Instruction(-1, 261, nullptr) {}
+        BreakTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BreakTable", 261, Maker) {}
+        BreakTable(int addr, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {}
+        BreakTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BreakTable", 261, Maker) {
+            int cnt = 0;
+            unsigned char current_byte = content[addr];
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1))); // 3
+            while (cnt < current_byte) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                cnt++;
+            }
+        }
+    };
+    class SummonTable
+      : public Instruction // 140142002
+    {
+      public:
+        SummonTable()
+          : Instruction(-1, 262, nullptr) {}
+        SummonTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "SummonTable", 262, Maker) {}
+        SummonTable(int addr, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {}
+        SummonTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "SummonTable", 262, Maker) {
+
+            unsigned char current_byte = content[addr];
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            int cnt = 0;
+            while (cnt < current_byte) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
                 ushort shrt = ReadShortFromByteArray(0, short_bytes);
-                this->AddOperande(operande(addr,"short", short_bytes));
+                this->AddOperande(operande(addr, "short", short_bytes));
                 if (shrt == 0xFFFF) break;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
                 cnt++;
             }
-
         }
     };
-    class ReactionTable : public Instruction //140142002
+    class ReactionTable
+      : public Instruction // 140142002
     {
-        public:
-        ReactionTable():Instruction(-1,263,nullptr){}
-        ReactionTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"ReactionTable", 263,Maker){}
-        ReactionTable(int addr, Builder *Maker):Instruction(addr,"ReactionTable", 263, Maker){}
-        ReactionTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"ReactionTable", 263,Maker){
+      public:
+        ReactionTable()
+          : Instruction(-1, 263, nullptr) {}
+        ReactionTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "ReactionTable", 263, Maker) {}
+        ReactionTable(int addr, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {}
+        ReactionTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "ReactionTable", 263, Maker) {
             int cnt = 0;
-            ushort current_shrt = ReadShortFromByteArray(addr,content);
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            ushort current_shrt = ReadShortFromByteArray(addr, content);
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            while(cnt < current_shrt){
-                QByteArray short_bytes = ReadSubByteArray(content, addr,2);
+            while (cnt < current_shrt) {
+                QByteArray short_bytes = ReadSubByteArray(content, addr, 2);
 
-                this->AddOperande(operande(addr,"short", short_bytes));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                this->AddOperande(operande(addr, "short", short_bytes));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                 cnt++;
             }
         }
     };
-    class PartTable : public Instruction //14019797c
+    class PartTable
+      : public Instruction // 14019797c
     {
-        public:
-        PartTable():Instruction(-1,264,nullptr){}
-        PartTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"PartTable", 264,Maker){}
-        PartTable(int addr, Builder *Maker):Instruction(addr,"PartTable", 264, Maker){}
-        PartTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"PartTable", 264,Maker){
+      public:
+        PartTable()
+          : Instruction(-1, 264, nullptr) {}
+        PartTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "PartTable", 264, Maker) {}
+        PartTable(int addr, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {}
+        PartTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "PartTable", 264, Maker) {
             unsigned char current_byte = content[addr];
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             int cnt = 0;
-            while(cnt < current_byte){
+            while (cnt < current_byte) {
 
-                QByteArray int_bytes = ReadSubByteArray(content, addr,4);
-                this->AddOperande(operande(addr,"int", int_bytes));
+                QByteArray int_bytes = ReadSubByteArray(content, addr, 4);
+                this->AddOperande(operande(addr, "int", int_bytes));
 
                 QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                operande fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                fill = operande(addr,"fill", remaining);
+                this->AddOperande(operande(addr, "string", str));
+                remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                fill = operande(addr, "fill", remaining);
                 fill.setBytesToFill(0x20);
                 this->AddOperande(fill);
 
                 cnt++;
             }
-
         }
     };
 
-    class AnimeClipTable : public Instruction // from CS3
+    class AnimeClipTable
+      : public Instruction // from CS3
     {
-        public:
-        AnimeClipTable():Instruction(-1,265,nullptr){}
-        AnimeClipTable(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipTable", 265,Maker){}
-        AnimeClipTable(int addr, Builder *Maker):Instruction(addr,"AnimeClipTable", 265, Maker){}
-        AnimeClipTable(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipTable", 265,Maker){
+      public:
+        AnimeClipTable()
+          : Instruction(-1, 265, nullptr) {}
+        AnimeClipTable(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {}
+        AnimeClipTable(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipTable", 265, Maker) {
 
             int first_integer;
             first_integer = ReadIntegerFromByteArray(addr, content);
             std::vector<function>::iterator itt_current_fun = find_function_by_ID(Maker->FunctionsToParse, Maker->idx_current_fun);
-            while(first_integer != 0){
-                itt_current_fun->AddInstruction(std::make_shared<AnimeClipData>(addr, content,Maker));
+            while (first_integer != 0) {
+                itt_current_fun->AddInstruction(std::make_shared<AnimeClipData>(addr, content, Maker));
                 first_integer = ReadIntegerFromByteArray(addr, content);
-
             }
-            QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-            this->AddOperande(operande(addr,"int", first_integer_bytes));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class AnimeClipData : public Instruction
-    {
-        public:
-        AnimeClipData():Instruction(-1,273,nullptr){}
-        AnimeClipData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"AnimeClipData", 273,Maker){}
-        AnimeClipData(int addr, Builder *Maker):Instruction(addr,"AnimeClipData", 273, Maker){}
-        AnimeClipData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"AnimeClipData", 273,Maker){
+    class AnimeClipData : public Instruction {
+      public:
+        AnimeClipData()
+          : Instruction(-1, 273, nullptr) {}
+        AnimeClipData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "AnimeClipData", 273, Maker) {}
+        AnimeClipData(int addr, Builder* Maker)
+          : Instruction(addr, "AnimeClipData", 273, Maker) {}
+        AnimeClipData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "AnimeClipData", 273, Maker) {
 
-
-                QByteArray first_integer_bytes = ReadSubByteArray(content, addr,4);
-                this->AddOperande(operande(addr,"int", first_integer_bytes));
-                QByteArray str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                QByteArray remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                operande fill = operande(addr,"fill", remaining);
-                fill.setBytesToFill((0x20));
-                this->AddOperande(fill);
-                str = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", str));
-                remaining = ReadSubByteArray(content, addr, (0x20)-str.size()-1);
-                fill = operande(addr,"fill", remaining);
-                fill.setBytesToFill((0x20));
-                this->AddOperande(fill);
-
-
-
+            QByteArray first_integer_bytes = ReadSubByteArray(content, addr, 4);
+            this->AddOperande(operande(addr, "int", first_integer_bytes));
+            QByteArray str = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", str));
+            QByteArray remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+            operande fill = operande(addr, "fill", remaining);
+            fill.setBytesToFill((0x20));
+            this->AddOperande(fill);
+            str = ReadStringSubByteArray(content, addr);
+            this->AddOperande(operande(addr, "string", str));
+            remaining = ReadSubByteArray(content, addr, (0x20) - str.size() - 1);
+            fill = operande(addr, "fill", remaining);
+            fill.setBytesToFill((0x20));
+            this->AddOperande(fill);
         }
     };
-    class FieldMonsterData : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
+    class FieldMonsterData
+      : public Instruction // 00000001402613C2 probably trigger only for monsters on the field
     {
-        public:
-        FieldMonsterData():Instruction(-1,266,nullptr){}
-        FieldMonsterData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 266,Maker){}
-        FieldMonsterData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 266, Maker){}
-        FieldMonsterData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 266,Maker){
+      public:
+        FieldMonsterData()
+          : Instruction(-1, 266, nullptr) {}
+        FieldMonsterData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {}
+        FieldMonsterData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 266, Maker) {
 
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FieldFollowData : public Instruction //
+    class FieldFollowData
+      : public Instruction //
     {
-        public:
-        FieldFollowData():Instruction(-1,267,nullptr){}
-        FieldFollowData(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FieldMonsterData", 267,Maker){}
-        FieldFollowData(int addr, Builder *Maker):Instruction(addr,"FieldMonsterData", 267, Maker){}
-        FieldFollowData(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FieldMonsterData", 267,Maker){
+      public:
+        FieldFollowData()
+          : Instruction(-1, 267, nullptr) {}
+        FieldFollowData(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int addr, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {}
+        FieldFollowData(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FieldMonsterData", 267, Maker) {
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    class FC_autoX : public Instruction //
+    class FC_autoX
+      : public Instruction //
     {
-        public:
-        FC_autoX():Instruction(-1,268,nullptr){}
-        FC_autoX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"FC_autoX", 268,Maker){}
-        FC_autoX(int addr, Builder *Maker):Instruction(addr,"FC_autoX", 268, Maker){}
-        FC_autoX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"FC_autoX", 268,Maker){
+      public:
+        FC_autoX()
+          : Instruction(-1, 268, nullptr) {}
+        FC_autoX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "FC_autoX", 268, Maker) {}
+        FC_autoX(int addr, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {}
+        FC_autoX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "FC_autoX", 268, Maker) {
 
             QByteArray things = ReadStringSubByteArray(content, addr);
-            this->AddOperande(operande(addr,"string", things));
+            this->AddOperande(operande(addr, "string", things));
         }
     };
-    class BookData99 : public Instruction //
+    class BookData99
+      : public Instruction //
     {
-        public:
-        BookData99():Instruction(-1,269,nullptr){}
-        BookData99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookData99", 269,Maker){}
-        BookData99(int addr, Builder *Maker):Instruction(addr,"BookData99", 269, Maker){}
-        BookData99(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookData99", 269,Maker){
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+      public:
+        BookData99()
+          : Instruction(-1, 269, nullptr) {}
+        BookData99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookData99", 269, Maker) {}
+        BookData99(int addr, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {}
+        BookData99(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookData99", 269, Maker) {
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    class BookDataX: public Instruction
-    {
-        public:
-        BookDataX():Instruction(-1,270,nullptr){}
-        BookDataX(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"BookDataX", 270,Maker){}
-        BookDataX(int addr, Builder *Maker):Instruction(addr,"BookDataX", 270, Maker){}
-        BookDataX(int &addr, QByteArray &content,Builder *Maker):Instruction(addr,"BookDataX", 270,Maker){
+    class BookDataX : public Instruction {
+      public:
+        BookDataX()
+          : Instruction(-1, 270, nullptr) {}
+        BookDataX(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "BookDataX", 270, Maker) {}
+        BookDataX(int addr, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {}
+        BookDataX(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "BookDataX", 270, Maker) {
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             short control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));//3
-            if (control>0){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", control_short)); // 3
+            if (control > 0) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 QByteArray title = ReadStringSubByteArray(content, addr);
-                this->AddOperande(operande(addr,"string", title));
-                QByteArray remaining = ReadSubByteArray(content, addr, 0x10-title.size()-1);
-                operande fill = operande(addr,"bytearray", remaining);
+                this->AddOperande(operande(addr, "string", title));
+                QByteArray remaining = ReadSubByteArray(content, addr, 0x10 - title.size() - 1);
+                operande fill = operande(addr, "bytearray", remaining);
                 fill.setBytesToFill(0x10);
                 this->AddOperande(fill);
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x12
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x14
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x16
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x18
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1A
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1C
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x1E
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x20
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x22
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));//RCX+0x24
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            }
-            else
-            {
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x12
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x14
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x16
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x18
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1A
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1C
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x1E
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x20
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x22
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2))); // RCX+0x24
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            } else {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
         }
     };
 
-
-    class OPCode0 : public Instruction
-    {
-        public:
-        OPCode0():Instruction(-1,0,nullptr){}
-        OPCode0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Instruction 0", 0,Maker){}
-        OPCode0(int addr, Builder *Maker):Instruction(addr,"Instruction 0", 0, Maker){}
-        OPCode0(int &addr, [[maybe_unused]] QByteArray &content,Builder *Maker):Instruction(addr,"Instruction 0", 0,Maker){
-            addr++;
-
-        }
-
-
-    };
-    class OPCode1 : public Instruction
-    {
-        public:
-        OPCode1():Instruction(-1,1,nullptr){}
-        OPCode1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"Return", 1,Maker){}
-        OPCode1(int addr, Builder *Maker):Instruction(addr,"Return",1,Maker){}
-        OPCode1(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"Return", 1,Maker){
+    class OPCode0 : public Instruction {
+      public:
+        OPCode0()
+          : Instruction(-1, 0, nullptr) {}
+        OPCode0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Instruction 0", 0, Maker) {}
+        OPCode0(int addr, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {}
+        OPCode0(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Instruction 0", 0, Maker) {
             addr++;
         }
-
-
     };
-
-    class UI_OP13: public Instruction{
-    public:
-        UI_OP13():Instruction(-1,0x13,nullptr){}
-        UI_OP13(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x13,Maker){}
-        UI_OP13(int addr, Builder *Maker):Instruction(addr,"???",0x13,Maker){}
-        UI_OP13(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x13,Maker){
-        addr++;
-
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch ((unsigned char) control_byte[0])  {
-
-            case 0x00:{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x01:{
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case 10:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0xb:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0xc:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-
-            case 0x26:
-            case 0xd:{
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0xe:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0xf:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x10:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x11:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x12:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x13:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x14:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x15:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x16:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x17:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x18:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x19:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1B:
-            case 0x1A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x1D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x20:
-            case 0x1F:
-            case 0x1E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x21:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x22:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-
-            case 0x23:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x24:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x25:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x27:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x28:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x29:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2B:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x2E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x30:
-            case 0x2F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x33:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x34:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x35:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x36:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x37:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x3B:
-            case 0x38:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x3A:
-            case 0x39:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x3C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x41:
-            case 0x3D:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x3E:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x3F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x40:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x44:
-            case 0x43:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x65:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                break;
-             }
-            case 0x68:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                break;
-             }
-            case 0x76:
-            case 0x69:
-            case 0x75:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                break;
-             }
-            case 0x6B:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-             }
-            case 0x6A:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-             }
-            case 0x6C:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-             }
-            case 0x70:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                break;
-             }
-            case 0x71:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-             }
-            case 0x72:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-             }
-            case 0x73:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-             }
-
-            case 0x32:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-             }
-            case 0x31:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-             }
-            default:{
-                qFatal("not analyzed yet");
-            }
-            }
-        }
-
-    };
-    //SCENARIO FILES INSTRUCTIONS
-    //0x05
-    class OPCode05: public Instruction{
-    public:
-        OPCode05():Instruction(-1,0x05,nullptr){}
-        OPCode05(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x05,Maker){}
-        OPCode05(int addr, Builder *Maker):Instruction(addr,"???",0x05,Maker){}
-        OPCode05(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x05,Maker){
+    class OPCode1 : public Instruction {
+      public:
+        OPCode1()
+          : Instruction(-1, 1, nullptr) {}
+        OPCode1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "Return", 1, Maker) {}
+        OPCode1(int addr, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {}
+        OPCode1(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "Return", 1, Maker) {
             addr++;
-            sub05(addr, content, this);
-
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr, 4)));
         }
     };
 
-    //0x02
-    class OPCode02: public Instruction{
-    public:
-        OPCode02():Instruction(-1,0x02,nullptr){}
-        OPCode02(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x02,Maker){}
-        OPCode02(int addr, Builder *Maker):Instruction(addr,"???",0x02,Maker){}
-        OPCode02(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x02,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-    //0x03
-    class OPCode03: public Instruction{
-    public:
-        OPCode03():Instruction(-1,0x03,nullptr){}
-        OPCode03(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x03,Maker){}
-        OPCode03(int addr, Builder *Maker):Instruction(addr,"???",0x03,Maker){}
-        OPCode03(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x03,Maker){
+    class UI_OP13 : public Instruction {
+      public:
+        UI_OP13()
+          : Instruction(-1, 0x13, nullptr) {}
+        UI_OP13(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x13, Maker) {}
+        UI_OP13(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {}
+        UI_OP13(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
 
-        }
-    };
-    //0x04
-    class OPCode04: public Instruction{
-        public:
-        OPCode04():Instruction(-1,0x04,nullptr){}
-        OPCode04(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x04,Maker){}
-        OPCode04(int addr, Builder *Maker):Instruction(addr,"???",0x04,Maker){}
-        OPCode04(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x04,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-    };
-    //0x06
-    class OPCode06: public Instruction{
-        public:
-            OPCode06():Instruction(-1,0x06,nullptr){}
-            OPCode06(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x06,Maker){}
-            OPCode06(int addr, Builder *Maker):Instruction(addr,"???",0x06,Maker){}
-            OPCode06(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x06,Maker){
-            addr++;
-            sub05(addr, content, this);
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
 
-            if ((unsigned char) control_byte[0] != 0){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
+                case 0x00: {
 
-                for (unsigned char i = 0; i<(unsigned char)control_byte[0]; i++){
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    break;
+                }
+                case 0x01: {
 
-                    this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
+                    break;
+                }
+                case 10: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0xb: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xc: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+
+                case 0x26:
+                case 0xd: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0xe: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0xf: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x10: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x11: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x13: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x16: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x18: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x19: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1B:
+                case 0x1A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x20:
+                case 0x1F:
+                case 0x1E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x21: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x22: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+
+                case 0x23: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x24: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x25: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x27: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x28: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x29: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x2E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x30:
+                case 0x2F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x33: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x34: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x35: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x36: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x37: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x3B:
+                case 0x38: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x3A:
+                case 0x39: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x3C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x41:
+                case 0x3D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x3E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x3F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x40: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x44:
+                case 0x43: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x65: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x68: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x76:
+                case 0x69:
+                case 0x75: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x6B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x6A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x6C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x70: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x71: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x72: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x73: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+
+                case 0x32: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x31: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                default: {
+                    qFatal("not analyzed yet");
                 }
             }
-            this->AddOperande(operande(addr,"pointer", ReadSubByteArray(content, addr,4)));
-           }
-
-    };
-    //0x07
-    class OPCode07: public Instruction{
-    public:
-        OPCode07():Instruction(-1,0x07,nullptr){}
-        OPCode07(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x07,Maker){}
-        OPCode07(int addr, Builder *Maker):Instruction(addr,"???",0x07,Maker){}
-        OPCode07(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x07,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
         }
-
     };
-    //0x08
-    class OPCode08: public Instruction{
-    public:
-        OPCode08():Instruction(-1,0x08,nullptr){}
-        OPCode08(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x08,Maker){}
-        OPCode08(int addr, Builder *Maker):Instruction(addr,"???",0x08,Maker){}
-        OPCode08(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x08,Maker){
+    // SCENARIO FILES INSTRUCTIONS
+    // 0x05
+    class OPCode05 : public Instruction {
+      public:
+        OPCode05()
+          : Instruction(-1, 0x05, nullptr) {}
+        OPCode05(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x05, Maker) {}
+        OPCode05(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x05, Maker) {}
+        OPCode05(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x05, Maker) {
+            addr++;
+            sub05(addr, content, this);
+
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+
+    // 0x02
+    class OPCode02 : public Instruction {
+      public:
+        OPCode02()
+          : Instruction(-1, 0x02, nullptr) {}
+        OPCode02(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x02, Maker) {}
+        OPCode02(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x02, Maker) {}
+        OPCode02(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x02, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x03
+    class OPCode03 : public Instruction {
+      public:
+        OPCode03()
+          : Instruction(-1, 0x03, nullptr) {}
+        OPCode03(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x03, Maker) {}
+        OPCode03(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x03, Maker) {}
+        OPCode03(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x03, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x04
+    class OPCode04 : public Instruction {
+      public:
+        OPCode04()
+          : Instruction(-1, 0x04, nullptr) {}
+        OPCode04(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x04, Maker) {}
+        OPCode04(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x04, Maker) {}
+        OPCode04(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x04, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x06
+    class OPCode06 : public Instruction {
+      public:
+        OPCode06()
+          : Instruction(-1, 0x06, nullptr) {}
+        OPCode06(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x06, Maker) {}
+        OPCode06(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x06, Maker) {}
+        OPCode06(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x06, Maker) {
+            addr++;
+            sub05(addr, content, this);
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            if ((unsigned char)control_byte[0] != 0) {
+
+                for (unsigned char i = 0; i < (unsigned char)control_byte[0]; i++) {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+                }
+            }
+            this->AddOperande(operande(addr, "pointer", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x07
+    class OPCode07 : public Instruction {
+      public:
+        OPCode07()
+          : Instruction(-1, 0x07, nullptr) {}
+        OPCode07(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x07, Maker) {}
+        OPCode07(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x07, Maker) {}
+        OPCode07(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x07, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x08
+    class OPCode08 : public Instruction {
+      public:
+        OPCode08()
+          : Instruction(-1, 0x08, nullptr) {}
+        OPCode08(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x08, Maker) {}
+        OPCode08(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x08, Maker) {}
+        OPCode08(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x08, Maker) {
             addr++;
             sub05(addr, content, this);
         }
-
     };
-    //0x0A
-    class OPCode0A: public Instruction{
-    public:
-        OPCode0A():Instruction(-1,0x0A,nullptr){}
-        OPCode0A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0A,Maker){}
-        OPCode0A(int addr, Builder *Maker):Instruction(addr,"???",0x0A,Maker){}
-        OPCode0A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0A,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-        sub05(addr, content, this);
-
-        }
-    };
-    //0x0C
-    class OPCode0C: public Instruction{
-    public:
-        OPCode0C():Instruction(-1,0x0C,nullptr){}
-        OPCode0C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0C,Maker){}
-        OPCode0C(int addr, Builder *Maker):Instruction(addr,"???",0x0C,Maker){}
-        OPCode0C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0C,Maker){
+    // 0x0A
+    class OPCode0A : public Instruction {
+      public:
+        OPCode0A()
+          : Instruction(-1, 0x0A, nullptr) {}
+        OPCode0A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0A, Maker) {}
+        OPCode0A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0A, Maker) {}
+        OPCode0A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x0D
-    class OPCode0D: public Instruction{
-    public:
-        OPCode0D():Instruction(-1,0x0D,nullptr){}
-        OPCode0D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0D,Maker){}
-        OPCode0D(int addr, Builder *Maker):Instruction(addr,"???",0x0D,Maker){}
-        OPCode0D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0D,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x0E
-    class OPCode0E: public Instruction{
-    public:
-        OPCode0E():Instruction(-1,0x0E,nullptr){}
-        OPCode0E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0E,Maker){}
-        OPCode0E(int addr, Builder *Maker):Instruction(addr,"???",0x0E,Maker){}
-        OPCode0E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0E,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-       }
-    };
-    //0x0F
-    class OPCode0F: public Instruction{
-    public:
-        OPCode0F():Instruction(-1,0x0F,nullptr){}
-        OPCode0F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x0F,Maker){}
-        OPCode0F(int addr, Builder *Maker):Instruction(addr,"???",0x0F,Maker){}
-        OPCode0F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x0F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x10
-    class OPCode10: public Instruction{
-    public:
-        OPCode10():Instruction(-1,0x10,nullptr){}
-        OPCode10(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x10,Maker){}
-        OPCode10(int addr, Builder *Maker):Instruction(addr,"???",0x10,Maker){}
-        OPCode10(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x10,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x11
-    class OPCode11: public Instruction{
-    public:
-        OPCode11():Instruction(-1,0x11,nullptr){}
-        OPCode11(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x11,Maker){}
-        OPCode11(int addr, Builder *Maker):Instruction(addr,"???",0x11,Maker){}
-        OPCode11(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x11,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x12
-    class OPCode12: public Instruction{
-    public:
-        OPCode12():Instruction(-1,0x12,nullptr){}
-        OPCode12(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x12,Maker){}
-        OPCode12(int addr, Builder *Maker):Instruction(addr,"???",0x12,Maker){}
-        OPCode12(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x12,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             sub05(addr, content, this);
         }
     };
-    //0x13
-    class OPCode13: public Instruction{
-    public:
-        OPCode13():Instruction(-1,0x13,nullptr){}
-        OPCode13(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x13,Maker){}
-        OPCode13(int addr, Builder *Maker):Instruction(addr,"???",0x13,Maker){}
-        OPCode13(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x13,Maker){
+    // 0x0C
+    class OPCode0C : public Instruction {
+      public:
+        OPCode0C()
+          : Instruction(-1, 0x0C, nullptr) {}
+        OPCode0C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0C, Maker) {}
+        OPCode0C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0C, Maker) {}
+        OPCode0C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0C, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));//i think this one is the id of the battle function it triggers
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-        }
-
-    };
-
-    //0x14
-    class OPCode14: public Instruction{
-    public:
-        OPCode14():Instruction(-1,0x14,nullptr){}
-        OPCode14(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x14,Maker){}
-        OPCode14(int addr, Builder *Maker):Instruction(addr,"???",0x14,Maker){}
-        OPCode14(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x14,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        }
-
-    };
-    //0x15
-    class OPCode15: public Instruction{
-    public:
-        OPCode15():Instruction(-1,0x15,nullptr){}
-        OPCode15(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x15,Maker){}
-        OPCode15(int addr, Builder *Maker):Instruction(addr,"???",0x15,Maker){}
-        OPCode15(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x15,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x16
-    class OPCode16: public Instruction{
-    public:
-        OPCode16():Instruction(-1,0x16,nullptr){}
-        OPCode16(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x16,Maker){}
-        OPCode16(int addr, Builder *Maker):Instruction(addr,"???",0x16,Maker){}
-        OPCode16(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x16,Maker){
+    // 0x0D
+    class OPCode0D : public Instruction {
+      public:
+        OPCode0D()
+          : Instruction(-1, 0x0D, nullptr) {}
+        OPCode0D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0D, Maker) {}
+        OPCode0D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {}
+        OPCode0D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-          }
-
-    };
-    //0x17
-    class OPCode17: public Instruction{
-    public:
-        OPCode17():Instruction(-1,0x17,nullptr){}
-        OPCode17(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x17,Maker){}
-        OPCode17(int addr, Builder *Maker):Instruction(addr,"???",0x17,Maker){}
-        OPCode17(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x17,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x18
-    class OPCode18: public Instruction{
-    public:
-        OPCode18():Instruction(-1,0x18,nullptr){}
-        OPCode18(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x18,Maker){}
-        OPCode18(int addr, Builder *Maker):Instruction(addr,"???",0x18,Maker){}
-        OPCode18(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x18,Maker){
+    // 0x0E
+    class OPCode0E : public Instruction {
+      public:
+        OPCode0E()
+          : Instruction(-1, 0x0E, nullptr) {}
+        OPCode0E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0E, Maker) {}
+        OPCode0E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0E, Maker) {}
+        OPCode0E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x0F
+    class OPCode0F : public Instruction {
+      public:
+        OPCode0F()
+          : Instruction(-1, 0x0F, nullptr) {}
+        OPCode0F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x0F, Maker) {}
+        OPCode0F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x0F, Maker) {}
+        OPCode0F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x0F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x10
+    class OPCode10 : public Instruction {
+      public:
+        OPCode10()
+          : Instruction(-1, 0x10, nullptr) {}
+        OPCode10(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x10, Maker) {}
+        OPCode10(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {}
+        OPCode10(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x10, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x11
+    class OPCode11 : public Instruction {
+      public:
+        OPCode11()
+          : Instruction(-1, 0x11, nullptr) {}
+        OPCode11(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x11, Maker) {}
+        OPCode11(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {}
+        OPCode11(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x11, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x12
+    class OPCode12 : public Instruction {
+      public:
+        OPCode12()
+          : Instruction(-1, 0x12, nullptr) {}
+        OPCode12(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x12, Maker) {}
+        OPCode12(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {}
+        OPCode12(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x12, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            sub05(addr, content, this);
+        }
+    };
+    // 0x13
+    class OPCode13 : public Instruction {
+      public:
+        OPCode13()
+          : Instruction(-1, 0x13, nullptr) {}
+        OPCode13(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x13, Maker) {}
+        OPCode13(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {}
+        OPCode13(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x13, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+            this->AddOperande(
+              operande(addr, "int", ReadSubByteArray(content, addr, 4))); // i think this one is the id of the battle function it triggers
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+
+    // 0x14
+    class OPCode14 : public Instruction {
+      public:
+        OPCode14()
+          : Instruction(-1, 0x14, nullptr) {}
+        OPCode14(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x14, Maker) {}
+        OPCode14(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {}
+        OPCode14(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x14, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x15
+    class OPCode15 : public Instruction {
+      public:
+        OPCode15()
+          : Instruction(-1, 0x15, nullptr) {}
+        OPCode15(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x15, Maker) {}
+        OPCode15(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {}
+        OPCode15(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x15, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x16
+    class OPCode16 : public Instruction {
+      public:
+        OPCode16()
+          : Instruction(-1, 0x16, nullptr) {}
+        OPCode16(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x16, Maker) {}
+        OPCode16(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {}
+        OPCode16(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x16, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x17
+    class OPCode17 : public Instruction {
+      public:
+        OPCode17()
+          : Instruction(-1, 0x17, nullptr) {}
+        OPCode17(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x17, Maker) {}
+        OPCode17(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {}
+        OPCode17(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x17, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x18
+    class OPCode18 : public Instruction {
+      public:
+        OPCode18()
+          : Instruction(-1, 0x18, nullptr) {}
+        OPCode18(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x18, Maker) {}
+        OPCode18(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {}
+        OPCode18(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x18, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             reading_dialog(addr, content, this);
         }
-
     };
-    //0x19
-    class OPCode19: public Instruction{
-    public:
-        OPCode19():Instruction(-1,0x19,nullptr){}
-        OPCode19(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x19,Maker){}
-        OPCode19(int addr, Builder *Maker):Instruction(addr,"???",0x19,Maker){}
-        OPCode19(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x19,Maker){
+    // 0x19
+    class OPCode19 : public Instruction {
+      public:
+        OPCode19()
+          : Instruction(-1, 0x19, nullptr) {}
+        OPCode19(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x19, Maker) {}
+        OPCode19(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x19, Maker) {}
+        OPCode19(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x19, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x05:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
             }
         }
-
     };
-    //0x1A
-    class OPCode1A: public Instruction{
-    public:
-        OPCode1A():Instruction(-1,0x1A,nullptr){}
-        OPCode1A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1A,Maker){}
-        OPCode1A(int addr, Builder *Maker):Instruction(addr,"???",0x1A,Maker){}
-        OPCode1A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1A,Maker){
+    // 0x1A
+    class OPCode1A : public Instruction {
+      public:
+        OPCode1A()
+          : Instruction(-1, 0x1A, nullptr) {}
+        OPCode1A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1A, Maker) {}
+        OPCode1A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {}
+        OPCode1A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             reading_dialog(addr, content, this);
         }
-
     };
-    //0x1B
-    class OPCode1B: public Instruction{
-    public:
-        OPCode1B():Instruction(-1,0x1B,nullptr){}
-        OPCode1B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1B,Maker){}
-        OPCode1B(int addr, Builder *Maker):Instruction(addr,"???",0x1B,Maker){}
-        OPCode1B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1B,Maker){
+    // 0x1B
+    class OPCode1B : public Instruction {
+      public:
+        OPCode1B()
+          : Instruction(-1, 0x1B, nullptr) {}
+        OPCode1B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1B, Maker) {}
+        OPCode1B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1B, Maker) {}
+        OPCode1B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x1C
-    class OPCode1C: public Instruction{
-    public:
-        OPCode1C():Instruction(-1,0x1C,nullptr){}
-        OPCode1C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1C,Maker){}
-        OPCode1C(int addr, Builder *Maker):Instruction(addr,"???",0x1C,Maker){}
-        OPCode1C(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1C,Maker){
+    // 0x1C
+    class OPCode1C : public Instruction {
+      public:
+        OPCode1C()
+          : Instruction(-1, 0x1C, nullptr) {}
+        OPCode1C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1C, Maker) {}
+        OPCode1C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1C, Maker) {}
+        OPCode1C(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1C, Maker) {
             addr++;
         }
-
     };
-    //0x1D
-    class OPCode1D: public Instruction{
-    public:
-        OPCode1D():Instruction(-1,0x1D,nullptr){}
-        OPCode1D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1D,Maker){}
-        OPCode1D(int addr, Builder *Maker):Instruction(addr,"???",0x1D,Maker){}
-        OPCode1D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1D,Maker){
+    // 0x1D
+    class OPCode1D : public Instruction {
+      public:
+        OPCode1D()
+          : Instruction(-1, 0x1D, nullptr) {}
+        OPCode1D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1D, Maker) {}
+        OPCode1D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {}
+        OPCode1D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x1E
-    class OPCode1E: public Instruction{
-    public:
-        OPCode1E():Instruction(-1,0x1E,nullptr){}
-        OPCode1E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1E,Maker){}
-        OPCode1E(int addr, Builder *Maker):Instruction(addr,"???",0x1E,Maker){}
-        OPCode1E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1E,Maker){
+    // 0x1E
+    class OPCode1E : public Instruction {
+      public:
+        OPCode1E()
+          : Instruction(-1, 0x1E, nullptr) {}
+        OPCode1E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1E, Maker) {}
+        OPCode1E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {}
+        OPCode1E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x1F
-    class OPCode1F: public Instruction{
-    public:
-        OPCode1F():Instruction(-1,0x1F,nullptr){}
-        OPCode1F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x1F,Maker){}
-        OPCode1F(int addr, Builder *Maker):Instruction(addr,"???",0x1F,Maker){}
-        OPCode1F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x1F,Maker){
+    // 0x1F
+    class OPCode1F : public Instruction {
+      public:
+        OPCode1F()
+          : Instruction(-1, 0x1F, nullptr) {}
+        OPCode1F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x1F, Maker) {}
+        OPCode1F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {}
+        OPCode1F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x1F, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
-        if ((unsigned char)control_byte2[0]<0x4){
-            switch((unsigned char)control_byte[0]) {
+            this->AddOperande(operande(addr, "byte", control_byte2));
+            if ((unsigned char)control_byte2[0] < 0x4) {
+                switch ((unsigned char)control_byte[0]) {
 
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
+                    case 0x00: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    }
 
-                case 0x01:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                }
-                case 0x04:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    break;
-                }
-                case 0x05:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x07:
-                case 0x06:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    case 0x01: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x02: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    }
+                    case 0x04: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        break;
+                    }
+                    case 0x05: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x07:
+                    case 0x06: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    break;
-                }
-                case 0x08:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x09:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x0B:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
+                        break;
+                    }
+                    case 0x08: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    }
+                    case 0x09: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    }
+                    case 0x0B: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
 
-                case 0x0E:
-                case 0x0D:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
+                    case 0x0E:
+                    case 0x0D: {
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        break;
+                    }
                 }
-
-
             }
         }
-
-        }
-
     };
-    //0x20
-    class OPCode20: public Instruction{
-        public:
-        OPCode20():Instruction(-1,0x20,nullptr){}
-        OPCode20(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x20,Maker){}
-        OPCode20(int addr, Builder *Maker):Instruction(addr,"???",0x20,Maker){}
-        OPCode20(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x20,Maker){
+    // 0x20
+    class OPCode20 : public Instruction {
+      public:
+        OPCode20()
+          : Instruction(-1, 0x20, nullptr) {}
+        OPCode20(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x20, Maker) {}
+        OPCode20(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {}
+        OPCode20(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x20, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch ((unsigned char)control_byte[0])  {
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x02:
                 case 0x01:
                 case 0x04:
                 case 0x03:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-
             }
         }
-
-
     };
-    //0x21
-    class OPCode21: public Instruction{
-        public:
-        OPCode21():Instruction(-1,0x21,nullptr){}
-        OPCode21(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x21,Maker){}
-        OPCode21(int addr, Builder *Maker):Instruction(addr,"???",0x21,Maker){}
-        OPCode21(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x21,Maker){
+    // 0x21
+    class OPCode21 : public Instruction {
+      public:
+        OPCode21()
+          : Instruction(-1, 0x21, nullptr) {}
+        OPCode21(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x21, Maker) {}
+        OPCode21(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {}
+        OPCode21(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x21, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            switch ((unsigned char)control_byte[0])  {
-                case 0x00:
-                {
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
-                case 0x01:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-
             }
         }
-
     };
-    //0x22
-    class OPCode22: public Instruction{
-        public:
-        OPCode22():Instruction(-1,0x22,nullptr){}
-        OPCode22(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x22,Maker){}
-        OPCode22(int addr, Builder *Maker):Instruction(addr,"???",0x22,Maker){}
-        OPCode22(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x22,Maker){
+    // 0x22
+    class OPCode22 : public Instruction {
+      public:
+        OPCode22()
+          : Instruction(-1, 0x22, nullptr) {}
+        OPCode22(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x22, Maker) {}
+        OPCode22(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {}
+        OPCode22(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x22, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x23
-    class OPCode23: public Instruction{
-        public:
-        OPCode23():Instruction(-1,0x23,nullptr){}
-        OPCode23(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x23,Maker){}
-        OPCode23(int addr, Builder *Maker):Instruction(addr,"???",0x23,Maker){}
-        OPCode23(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x23,Maker){
+    // 0x23
+    class OPCode23 : public Instruction {
+      public:
+        OPCode23()
+          : Instruction(-1, 0x23, nullptr) {}
+        OPCode23(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x23, Maker) {}
+        OPCode23(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {}
+        OPCode23(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x23, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x24
-    class OPCode24: public Instruction{
-        public:
-        OPCode24():Instruction(-1,0x24,nullptr){}
-        OPCode24(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x24,Maker){}
-        OPCode24(int addr, Builder *Maker):Instruction(addr,"???",0x24,Maker){}
-        OPCode24(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x24,Maker){
+    // 0x24
+    class OPCode24 : public Instruction {
+      public:
+        OPCode24()
+          : Instruction(-1, 0x24, nullptr) {}
+        OPCode24(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x24, Maker) {}
+        OPCode24(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {}
+        OPCode24(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x24, Maker) {
             addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0:
                 case 1:
                 case 2:
                 case 4:
                 case 10:
                 case 0xB:
-                case 5:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 5: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
                 case 7:
-                case 6:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 6: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 9:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 9: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0xE:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0xE: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
-                case 8:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 8: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
-
             }
-
-
         }
-
     };
-    //0x25
-    class OPCode25: public Instruction{
-        public:
-        OPCode25():Instruction(-1,0x25,nullptr){}
-        OPCode25(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x25,Maker){}
-        OPCode25(int addr, Builder *Maker):Instruction(addr,"???",0x25,Maker){}
-        OPCode25(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x25,Maker){
+    // 0x25
+    class OPCode25 : public Instruction {
+      public:
+        OPCode25()
+          : Instruction(-1, 0x25, nullptr) {}
+        OPCode25(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x25, Maker) {}
+        OPCode25(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {}
+        OPCode25(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x25, Maker) {
             addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            switch ((unsigned char)control_byte[0]) {
                 /*case 1:{
                     this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
                     break;
                 }*/
                 case 7:
-                case 8:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 8: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
             }
-
         }
-
     };
-    //0x26
-    class OPCode26: public Instruction{
-        public:
-        OPCode26():Instruction(-1,0x26,nullptr){}
-        OPCode26(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x26,Maker){}
-        OPCode26(int addr, Builder *Maker):Instruction(addr,"???",0x26,Maker){}
-        OPCode26(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x26,Maker){
+    // 0x26
+    class OPCode26 : public Instruction {
+      public:
+        OPCode26()
+          : Instruction(-1, 0x26, nullptr) {}
+        OPCode26(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x26, Maker) {}
+        OPCode26(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {}
+        OPCode26(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x26, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x27
-    class OPCode27: public Instruction{
-        public:
-        OPCode27():Instruction(-1,0x27,nullptr){}
-        OPCode27(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x27,Maker){}
-        OPCode27(int addr, Builder *Maker):Instruction(addr,"???",0x27,Maker){}
-        OPCode27(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x27,Maker){
+    // 0x27
+    class OPCode27 : public Instruction {
+      public:
+        OPCode27()
+          : Instruction(-1, 0x27, nullptr) {}
+        OPCode27(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x27, Maker) {}
+        OPCode27(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {}
+        OPCode27(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x27, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                    break;
-                }
-                case 0x0B:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    break;
-                }
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));;
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 }
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                case 0x17:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
                     break;
                 }
 
-                case 0x12:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x17: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
 
-                case 0x14:{
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+
+                case 0x14: {
                     qFatal("not entirely sure");
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x13:{
+                case 0x13: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x15:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                    break;
-                }
-                case 0xD:
-                {
-
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x15: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                     break;
                 }
-                case 0xE:
-                {
+                case 0xD: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case 0xE: {
+
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
                 case 0x0F:
-                case 0x11:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x11: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-                case 0x10:
-                {
+                case 0x10: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x16:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x16: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x18:{
+                case 0x18: {
                     qFatal("not sureeeeee");
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x19:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x19: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
-                case 0x1A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x1A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
             }
         }
-
     };
-    //0x28
+    // 0x28
     /*class OPCode28: public Instruction{
     public:
         OPCode28():Instruction(-1,0x28,nullptr){}
-        OPCode28(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x28,Maker){}
-        OPCode28(int addr, Builder *Maker):Instruction(addr,"???",0x28,Maker){}
-        OPCode28(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x28,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode28(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x28,Maker){} OPCode28(int addr, Builder *Maker):Instruction(addr,"???",0x28,Maker){} OPCode28(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x28,Maker){ addr++; QByteArray control_byte =
+    ReadSubByteArray(content, addr, 1); this->AddOperande(operande(addr,"byte", control_byte)); switch((unsigned
+    char)control_byte[0]){ case 0x00:{ this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
                 this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
 
@@ -3189,832 +3486,900 @@ class TXBuilder : public Builder
         }
 
     };*/
-    //0x28
-    class OPCode28: public Instruction{
-    public:
-        OPCode28():Instruction(-1,0x28,nullptr){}
-        OPCode28(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x28,Maker){}
-        OPCode28(int addr, Builder *Maker):Instruction(addr,"???",0x28,Maker){}
-        OPCode28(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x28,Maker){
+    // 0x28
+    class OPCode28 : public Instruction {
+      public:
+        OPCode28()
+          : Instruction(-1, 0x28, nullptr) {}
+        OPCode28(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x28, Maker) {}
+        OPCode28(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {}
+        OPCode28(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x28, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x29
-    class OPCode29: public Instruction{
-    public:
-        OPCode29():Instruction(-1,0x29,nullptr){}
-        OPCode29(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x29,Maker){}
-        OPCode29(int addr, Builder *Maker):Instruction(addr,"???",0x29,Maker){}
-        OPCode29(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x29,Maker){
+    // 0x29
+    class OPCode29 : public Instruction {
+      public:
+        OPCode29()
+          : Instruction(-1, 0x29, nullptr) {}
+        OPCode29(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x29, Maker) {}
+        OPCode29(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {}
+        OPCode29(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x29, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x2A
-    class OPCode2A: public Instruction{
-    public:
-        OPCode2A():Instruction(-1,0x2A,nullptr){}
-        OPCode2A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2A,Maker){}
-        OPCode2A(int addr, Builder *Maker):Instruction(addr,"???",0x2A,Maker){}
-        OPCode2A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2A,Maker){
+    // 0x2A
+    class OPCode2A : public Instruction {
+      public:
+        OPCode2A()
+          : Instruction(-1, 0x2A, nullptr) {}
+        OPCode2A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2A, Maker) {}
+        OPCode2A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {}
+        OPCode2A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x2B
-    class OPCode2B: public Instruction{
-    public:
-        OPCode2B():Instruction(-1,0x2B,nullptr){}
-        OPCode2B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2B,Maker){}
-        OPCode2B(int addr, Builder *Maker):Instruction(addr,"???",0x2B,Maker){}
-        OPCode2B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2B,Maker){
+    // 0x2B
+    class OPCode2B : public Instruction {
+      public:
+        OPCode2B()
+          : Instruction(-1, 0x2B, nullptr) {}
+        OPCode2B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2B, Maker) {}
+        OPCode2B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {}
+        OPCode2B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
-
     };
 
-    //0x2C
+    // 0x2C
     /*class OPCode2C: public Instruction{
     public:
         OPCode2C():Instruction(-1,0x2C,nullptr){}
-        OPCode2C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2C,Maker){}
-        OPCode2C(int addr, Builder *Maker):Instruction(addr,"???",0x2C,Maker){}
-        OPCode2C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2C,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+        OPCode2C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x2C,Maker){} OPCode2C(int addr, Builder *Maker):Instruction(addr,"???",0x2C,Maker){} OPCode2C(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x2C,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2))); this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
 
         }
 
     };*/
-    //0x2C
-    class OPCode2C: public Instruction{
-    public:
-        OPCode2C():Instruction(-1,0x2C,nullptr){}
-        OPCode2C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2C,Maker){}
-        OPCode2C(int addr, Builder *Maker):Instruction(addr,"???",0x2C,Maker){}
-        OPCode2C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2C,Maker){
+    // 0x2C
+    class OPCode2C : public Instruction {
+      public:
+        OPCode2C()
+          : Instruction(-1, 0x2C, nullptr) {}
+        OPCode2C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2C, Maker) {}
+        OPCode2C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {}
+        OPCode2C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2C, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-            case 0x02:{
+                case 0x02: {
 
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x14:
-            case 0x03:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x14:
+                case 0x03: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                break;
-            }
-            case 0x04:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x05:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x07:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x08:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x09:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x0B:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0D:
-            case 0x0C:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0E:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0F:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x07: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x08: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x09: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0D:
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case 0x11:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x12:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    break;
+                }
+                case 0x11: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x12: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case 0x13:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                    break;
+                }
+                case 0x13: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x16: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x18:
+                case 0x19: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x1A: {
 
-                break;
-            }
-            case 0x15:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x16:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x17:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x18:
-            case 0x19:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x1A:{
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x1B: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                break;
-            }
-            case 0x1B:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    break;
+                }
+                case 0x1E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                break;
-            }
-            case 0x1E:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x22:
+                case 0x1F: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case 0x22:
-            case 0x1F:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    break;
+                }
+                case 0x21:
+                case 0x20: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case 0x21:
-            case 0x20:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    break;
+                }
+                case 0x24: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                break;
-            }
-            case 0x24:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x25: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
-            }
-            case 0x25:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    break;
+                }
+                case 0x26: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                break;
+                    break;
+                }
             }
-            case 0x26:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                break;
-            }
-
         }
-        }
-
     };
-    //0x2D
-    class OPCode2D: public Instruction{
-    public:
-        OPCode2D():Instruction(-1,0x2D,nullptr){}
-        OPCode2D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2D,Maker){}
-        OPCode2D(int addr, Builder *Maker):Instruction(addr,"???",0x2D,Maker){}
-        OPCode2D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2D,Maker){
+    // 0x2D
+    class OPCode2D : public Instruction {
+      public:
+        OPCode2D()
+          : Instruction(-1, 0x2D, nullptr) {}
+        OPCode2D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2D, Maker) {}
+        OPCode2D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {}
+        OPCode2D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x2E
-    class OPCode2E: public Instruction{
-    public:
-        OPCode2E():Instruction(-1,0x2E,nullptr){}
-        OPCode2E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2E,Maker){}
-        OPCode2E(int addr, Builder *Maker):Instruction(addr,"???",0x2E,Maker){}
-        OPCode2E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2E,Maker){
+    // 0x2E
+    class OPCode2E : public Instruction {
+      public:
+        OPCode2E()
+          : Instruction(-1, 0x2E, nullptr) {}
+        OPCode2E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2E, Maker) {}
+        OPCode2E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {}
+        OPCode2E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            switch((unsigned char)control_byte[0]){
-                case 0x03:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    break;
-                }
-            }
-        }
-
-    };
-    //0x2F
-    class OPCode2F: public Instruction{
-    public:
-        OPCode2F():Instruction(-1,0x2F,nullptr){}
-        OPCode2F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x2F,Maker){}
-        OPCode2F(int addr, Builder *Maker):Instruction(addr,"???",0x2F,Maker){}
-        OPCode2F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x2F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x30
-    class OPCode30: public Instruction{
-    public:
-        OPCode30():Instruction(-1,0x30,nullptr){}
-        OPCode30(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x30,Maker){}
-        OPCode30(int addr, Builder *Maker):Instruction(addr,"???",0x30,Maker){}
-        OPCode30(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x30,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0:{
-
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    break;
-                }
-                case 1:{
-
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    break;
-                }
-                case 2:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    break;
-                }
-                default:{
-                    break;
-                }
-                case 3:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    break;
-                }
-                case 4:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    break;
-                }
-                case 5:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 6:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x03: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
             }
         }
     };
-    //0x31
-    class OPCode31: public Instruction{
-    public:
-        OPCode31():Instruction(-1,0x31,nullptr){}
-        OPCode31(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x31,Maker){}
-        OPCode31(int addr, Builder *Maker):Instruction(addr,"???",0x31,Maker){}
-        OPCode31(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x31,Maker){
+    // 0x2F
+    class OPCode2F : public Instruction {
+      public:
+        OPCode2F()
+          : Instruction(-1, 0x2F, nullptr) {}
+        OPCode2F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x2F, Maker) {}
+        OPCode2F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {}
+        OPCode2F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x2F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x30
+    class OPCode30 : public Instruction {
+      public:
+        OPCode30()
+          : Instruction(-1, 0x30, nullptr) {}
+        OPCode30(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x30, Maker) {}
+        OPCode30(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {}
+        OPCode30(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x30, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0: {
 
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 1: {
 
-        if ((unsigned char)control_byte[0] > 0xFD){
-            if ((unsigned char)control_byte[0] == 0xFE){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 2: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                default: {
+                    break;
+                }
+                case 3: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 4: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 5: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 6: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
             }
-            else if ((unsigned char)control_byte[0] == 0xFF){
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            }
-
-            return;
         }
-
-
-
-        switch ((unsigned char)control_byte[0])  {
-            case 0x00:
-            case 0x14:
-            case 0x32:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-                break;
-            }
-            case 0x33:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x34:
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x35:
-            case 0x03:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x39:
-            case 0x37:
-            case 0x3B:
-            case 0x05:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-
-            case 0x3A:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 100:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case 0x65:
-            {
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x96:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x97:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 4:
-            case 6:
-            case 7:
-            case 8:
-            case 9:
-            case 10:
-            case 0xb:
-            case 0xc:
-            case 0xd:
-            case 0xe:
-            case 0xf:
-            case 0x10:
-            case 0x11:
-            case 0x12:
-            case 0x13:
-            case 0x15:
-            case 0x16:
-            case 0x17:
-            case 0x18:
-            case 0x19:
-            case 0x1a:
-            case 0x1b:
-            case 0x1c:
-            case 0x1d:
-            case 0x1e:
-            case 0x1f:
-            case 0x20:
-            case 0x21:
-            case 0x22:
-            case 0x23:
-            case 0x24:
-            case 0x25:
-            case 0x26:
-            case 0x27:
-            case 0x28:
-            case 0x29:
-            case 0x2a:
-            case 0x2b:
-            case 0x2c:
-            case 0x2d:
-            case 0x2e:
-            case 0x2f:
-            case 0x30:
-            case 0x31:
-            case 0x36:
-            case 0x38:
-            case 0x3c:
-            case 0x3d:
-            case 0x3e:
-            case 0x3f:
-            case 0x40:
-            case 0x41:
-            case 0x42:
-            case 0x43:
-            case 0x44:
-            case 0x45:
-            case 0x46:
-            case 0x47:
-            case 0x48:
-            case 0x49:
-            case 0x4a:
-            case 0x4b:
-            case 0x4c:
-            case 0x4d:
-            case 0x4e:
-            case 0x4f:
-            case 0x50:
-            case 0x51:
-            case 0x52:
-            case 0x53:
-            case 0x54:
-            case 0x55:
-            case 0x56:
-            case 0x57:
-            case 0x58:
-            case 0x59:
-            case 0x5a:
-            case 0x5b:
-            case 0x5c:
-            case 0x5d:
-            case 0x5e:
-            case 0x5f:
-            case 0x60:
-            case 0x61:
-            case 0x62:
-            case 99:
-            case 0x66:
-            case 0x67:
-            case 0x68:
-            case 0x69:
-            case 0x6a:
-            case 0x6b:
-            case 0x6c:
-            case 0x6d:
-            case 0x6e:
-            case 0x6f:
-            case 0x70:
-            case 0x71:
-            case 0x72:
-            case 0x73:
-            case 0x74:
-            case 0x75:
-            case 0x76:
-            case 0x77:
-            case 0x78:
-            case 0x79:
-            case 0x7a:
-            case 0x7b:
-            case 0x7c:
-            case 0x7d:
-            case 0x7e:
-            case 0x7f:
-            case 0x80:
-            case 0x81:
-            case 0x82:
-            case 0x83:
-            case 0x84:
-            case 0x85:
-            case 0x86:
-            case 0x87:
-            case 0x88:
-            case 0x89:
-            case 0x8a:
-            case 0x8b:
-            case 0x8c:
-            case 0x8d:
-            case 0x8e:
-            case 0x8f:
-            case 0x90:
-            case 0x91:
-            case 0x92:
-            case 0x93:
-            case 0x94:
-            case 0x95:
-              break;
-            default:{this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));}
-
-
-        }
-        }
-
     };
-    //0x33
-    class OPCode32: public Instruction{
-    public:
-        OPCode32():Instruction(-1,0x32,nullptr){}
-        OPCode32(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x32,Maker){}
-        OPCode32(int addr, Builder *Maker):Instruction(addr,"???",0x32,Maker){}
-        OPCode32(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x32,Maker){
+    // 0x31
+    class OPCode31 : public Instruction {
+      public:
+        OPCode31()
+          : Instruction(-1, 0x31, nullptr) {}
+        OPCode31(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x31, Maker) {}
+        OPCode31(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {}
+        OPCode31(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x31, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x01:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                break;
+            this->AddOperande(operande(addr, "byte", control_byte));
+
+            if ((unsigned char)control_byte[0] > 0xFD) {
+                if ((unsigned char)control_byte[0] == 0xFE) {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                } else if ((unsigned char)control_byte[0] == 0xFF) {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                }
+
+                return;
             }
-            case 0x02:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00:
+                case 0x14:
+                case 0x32: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x33:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x34:
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x35:
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x39:
+                case 0x37:
+                case 0x3B:
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
 
-                break;
-            }
-            case 0x04:
-            {
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x3A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 100: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x65: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
+                    break;
+                }
+                case 0x96: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x97: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 4:
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 0xb:
+                case 0xc:
+                case 0xd:
+                case 0xe:
+                case 0xf:
+                case 0x10:
+                case 0x11:
+                case 0x12:
+                case 0x13:
+                case 0x15:
+                case 0x16:
+                case 0x17:
+                case 0x18:
+                case 0x19:
+                case 0x1a:
+                case 0x1b:
+                case 0x1c:
+                case 0x1d:
+                case 0x1e:
+                case 0x1f:
+                case 0x20:
+                case 0x21:
+                case 0x22:
+                case 0x23:
+                case 0x24:
+                case 0x25:
+                case 0x26:
+                case 0x27:
+                case 0x28:
+                case 0x29:
+                case 0x2a:
+                case 0x2b:
+                case 0x2c:
+                case 0x2d:
+                case 0x2e:
+                case 0x2f:
+                case 0x30:
+                case 0x31:
+                case 0x36:
+                case 0x38:
+                case 0x3c:
+                case 0x3d:
+                case 0x3e:
+                case 0x3f:
+                case 0x40:
+                case 0x41:
+                case 0x42:
+                case 0x43:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x47:
+                case 0x48:
+                case 0x49:
+                case 0x4a:
+                case 0x4b:
+                case 0x4c:
+                case 0x4d:
+                case 0x4e:
+                case 0x4f:
+                case 0x50:
+                case 0x51:
+                case 0x52:
+                case 0x53:
+                case 0x54:
+                case 0x55:
+                case 0x56:
+                case 0x57:
+                case 0x58:
+                case 0x59:
+                case 0x5a:
+                case 0x5b:
+                case 0x5c:
+                case 0x5d:
+                case 0x5e:
+                case 0x5f:
+                case 0x60:
+                case 0x61:
+                case 0x62:
+                case 99:
+                case 0x66:
+                case 0x67:
+                case 0x68:
+                case 0x69:
+                case 0x6a:
+                case 0x6b:
+                case 0x6c:
+                case 0x6d:
+                case 0x6e:
+                case 0x6f:
+                case 0x70:
+                case 0x71:
+                case 0x72:
+                case 0x73:
+                case 0x74:
+                case 0x75:
+                case 0x76:
+                case 0x77:
+                case 0x78:
+                case 0x79:
+                case 0x7a:
+                case 0x7b:
+                case 0x7c:
+                case 0x7d:
+                case 0x7e:
+                case 0x7f:
+                case 0x80:
+                case 0x81:
+                case 0x82:
+                case 0x83:
+                case 0x84:
+                case 0x85:
+                case 0x86:
+                case 0x87:
+                case 0x88:
+                case 0x89:
+                case 0x8a:
+                case 0x8b:
+                case 0x8c:
+                case 0x8d:
+                case 0x8e:
+                case 0x8f:
+                case 0x90:
+                case 0x91:
+                case 0x92:
+                case 0x93:
+                case 0x94:
+                case 0x95:
+                    break;
+                default: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                }
             }
         }
+    };
+    // 0x33
+    class OPCode32 : public Instruction {
+      public:
+        OPCode32()
+          : Instruction(-1, 0x32, nullptr) {}
+        OPCode32(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x32, Maker) {}
+        OPCode32(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {}
+        OPCode32(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x32, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+            }
         }
-
     };
-    //0x33
-    class OPCode33: public Instruction{
-    public:
-        OPCode33():Instruction(-1,0x33,nullptr){}
-        OPCode33(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x33,Maker){}
-        OPCode33(int addr, Builder *Maker):Instruction(addr,"???",0x33,Maker){}
-        OPCode33(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x33,Maker){
+    // 0x33
+    class OPCode33 : public Instruction {
+      public:
+        OPCode33()
+          : Instruction(-1, 0x33, nullptr) {}
+        OPCode33(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x33, Maker) {}
+        OPCode33(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {}
+        OPCode33(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x33, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
-    //0x34
-    class OPCode34: public Instruction{
-    public:
-        OPCode34():Instruction(-1,0x34,nullptr){}
-        OPCode34(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x34,Maker){}
-        OPCode34(int addr, Builder *Maker):Instruction(addr,"???",0x34,Maker){}
-        OPCode34(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x34,Maker){
+    // 0x34
+    class OPCode34 : public Instruction {
+      public:
+        OPCode34()
+          : Instruction(-1, 0x34, nullptr) {}
+        OPCode34(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x34, Maker) {}
+        OPCode34(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {}
+        OPCode34(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x34, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-       }
-
-    };
-    //0x35
-    class OPCode35: public Instruction{
-    public:
-        OPCode35():Instruction(-1,0x35,nullptr){}
-        OPCode35(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x35,Maker){}
-        OPCode35(int addr, Builder *Maker):Instruction(addr,"???",0x35,Maker){}
-        OPCode35(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x35,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x36
-    class OPCode36: public Instruction{
-    public:
-        OPCode36():Instruction(-1,0x36,nullptr){}
-        OPCode36(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x36,Maker){}
-        OPCode36(int addr, Builder *Maker):Instruction(addr,"???",0x36,Maker){}
-        OPCode36(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x36,Maker){
+    // 0x35
+    class OPCode35 : public Instruction {
+      public:
+        OPCode35()
+          : Instruction(-1, 0x35, nullptr) {}
+        OPCode35(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x35, Maker) {}
+        OPCode35(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {}
+        OPCode35(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x35, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x36
+    class OPCode36 : public Instruction {
+      public:
+        OPCode36()
+          : Instruction(-1, 0x36, nullptr) {}
+        OPCode36(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x36, Maker) {}
+        OPCode36(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {}
+        OPCode36(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x36, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
             short second_arg = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            if ((second_arg == -0x1fe)||(second_arg == -0x1fd)){
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            if ((second_arg == -0x1fe) || (second_arg == -0x1fd)) {
+                this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
             }
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            if (second_arg == -0x1fc){
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            if (second_arg == -0x1fc) {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
             }
         }
-
     };
-    //0x37
-    class OPCode37: public Instruction{
-    public:
-        OPCode37():Instruction(-1,0x37,nullptr){}
-        OPCode37(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x37,Maker){}
-        OPCode37(int addr, Builder *Maker):Instruction(addr,"???",0x37,Maker){}
-        OPCode37(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x37,Maker){
+    // 0x37
+    class OPCode37 : public Instruction {
+      public:
+        OPCode37()
+          : Instruction(-1, 0x37, nullptr) {}
+        OPCode37(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x37, Maker) {}
+        OPCode37(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {}
+        OPCode37(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x37, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x38
-    class OPCode38: public Instruction{
-    public:
-        OPCode38():Instruction(-1,0x38,nullptr){}
-        OPCode38(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x38,Maker){}
-        OPCode38(int addr, Builder *Maker):Instruction(addr,"???",0x38,Maker){}
-        OPCode38(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x38,Maker){
+    // 0x38
+    class OPCode38 : public Instruction {
+      public:
+        OPCode38()
+          : Instruction(-1, 0x38, nullptr) {}
+        OPCode38(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x38, Maker) {}
+        OPCode38(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {}
+        OPCode38(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x38, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-       }
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
     };
-    //0x39
-    class OPCode39: public Instruction{
-    public:
-        OPCode39():Instruction(-1,0x39,nullptr){}
-        OPCode39(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x39,Maker){}
-        OPCode39(int addr, Builder *Maker):Instruction(addr,"???",0x39,Maker){}
-        OPCode39(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x39,Maker){
+    // 0x39
+    class OPCode39 : public Instruction {
+      public:
+        OPCode39()
+          : Instruction(-1, 0x39, nullptr) {}
+        OPCode39(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x39, Maker) {}
+        OPCode39(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {}
+        OPCode39(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x39, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch(code){
-                case 0xFF:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch (code) {
+                case 0xFF: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x0C:
@@ -4022,123 +4387,139 @@ class TXBuilder : public Builder
                 case 0x0A:
                 case 0x69:
                 case 0x05:
-                case 0xFE:{
+                case 0xFE: {
                     break;
                 }
-                default:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                default: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
             }
-
-       }
-
-    };
-    //0x3A
-    class OPCode3A: public Instruction{
-    public:
-        OPCode3A():Instruction(-1,0x3A,nullptr){}
-        OPCode3A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3A,Maker){}
-        OPCode3A(int addr, Builder *Maker):Instruction(addr,"???",0x3A,Maker){}
-        OPCode3A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3A,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
         }
-
     };
-    //0x3B
-    class OPCode3B: public Instruction{
-    public:
-        OPCode3B():Instruction(-1,0x3B,nullptr){}
-        OPCode3B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3B,Maker){}
-        OPCode3B(int addr, Builder *Maker):Instruction(addr,"???",0x3B,Maker){}
-        OPCode3B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3B,Maker){
+    // 0x3A
+    class OPCode3A : public Instruction {
+      public:
+        OPCode3A()
+          : Instruction(-1, 0x3A, nullptr) {}
+        OPCode3A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3A, Maker) {}
+        OPCode3A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {}
+        OPCode3A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x3C
+    // 0x3B
+    class OPCode3B : public Instruction {
+      public:
+        OPCode3B()
+          : Instruction(-1, 0x3B, nullptr) {}
+        OPCode3B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3B, Maker) {}
+        OPCode3B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {}
+        OPCode3B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x3C
 
-
-    class OPCode3C: public Instruction{
-        public:
-        OPCode3C():Instruction(-1,0x3C,nullptr){}
-        OPCode3C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3C,Maker){}
-        OPCode3C(int addr, Builder *Maker):Instruction(addr,"???",0x3C,Maker){}
-        OPCode3C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3C,Maker){
+    class OPCode3C : public Instruction {
+      public:
+        OPCode3C()
+          : Instruction(-1, 0x3C, nullptr) {}
+        OPCode3C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3C, Maker) {}
+        OPCode3C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {}
+        OPCode3C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3C, Maker) {
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
             QByteArray control_short2 = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short2));
+            this->AddOperande(operande(addr, "short", control_short2));
             QByteArray control_short3 = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short3));
+            this->AddOperande(operande(addr, "short", control_short3));
             ushort short1 = ReadShortFromByteArray(0, control_short);
             QByteArray control_short4 = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short4));
+            this->AddOperande(operande(addr, "short", control_short4));
 
-            if (short1 == 1){
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            if (short1 == 1) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
             }
-
-
         }
-
     };
-    //0x3D
-    class OPCode3D: public Instruction{
-    public:
-        OPCode3D():Instruction(-1,0x3D,nullptr){}
-        OPCode3D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3D,Maker){}
-        OPCode3D(int addr, Builder *Maker):Instruction(addr,"???",0x3D,Maker){}
-        OPCode3D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3D,Maker){
+    // 0x3D
+    class OPCode3D : public Instruction {
+      public:
+        OPCode3D()
+          : Instruction(-1, 0x3D, nullptr) {}
+        OPCode3D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3D, Maker) {}
+        OPCode3D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {}
+        OPCode3D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3D, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x3E
-    class OPCode3E: public Instruction{
-    public:
-        OPCode3E():Instruction(-1,0x3E,nullptr){}
-        OPCode3E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3E,Maker){}
-        OPCode3E(int addr, Builder *Maker):Instruction(addr,"???",0x3E,Maker){}
-        OPCode3E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3E,Maker){
+    // 0x3E
+    class OPCode3E : public Instruction {
+      public:
+        OPCode3E()
+          : Instruction(-1, 0x3E, nullptr) {}
+        OPCode3E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3E, Maker) {}
+        OPCode3E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {}
+        OPCode3E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x3F
-    class OPCode3F: public Instruction{
-    public:
-        OPCode3F():Instruction(-1,0x3F,nullptr){}
-        OPCode3F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x3F,Maker){}
-        OPCode3F(int addr, Builder *Maker):Instruction(addr,"???",0x3F,Maker){}
-        OPCode3F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x3F,Maker){
+    // 0x3F
+    class OPCode3F : public Instruction {
+      public:
+        OPCode3F()
+          : Instruction(-1, 0x3F, nullptr) {}
+        OPCode3F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x3F, Maker) {}
+        OPCode3F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {}
+        OPCode3F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x3F, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x09:
                 case 0x0A:
                 case 0x0B:
@@ -4148,225 +4529,251 @@ class TXBuilder : public Builder
                 case 0x04:
                 case 0x10:
                 case 0x13:
-                case 0x00:{
+                case 0x00: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x08:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x08: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x0D:{
-                    for (int i = 0; i < 0x18; i++) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x0D: {
+                    for (int i = 0; i < 0x18; i++)
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x1A:
                 case 0x0E:
-                case 0x16:
-                {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x16: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x19:{
+                case 0x19: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-
+            }
         }
-        }
-
     };
-    //0x40
-   class OPCode40: public Instruction{
-    public:
-        OPCode40():Instruction(-1,0x40,nullptr){}
-        OPCode40(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x40,Maker){}
-        OPCode40(int addr, Builder *Maker):Instruction(addr,"???",0x40,Maker){}
-        OPCode40(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x40,Maker){
+    // 0x40
+    class OPCode40 : public Instruction {
+      public:
+        OPCode40()
+          : Instruction(-1, 0x40, nullptr) {}
+        OPCode40(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x40, Maker) {}
+        OPCode40(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {}
+        OPCode40(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x40, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x41
-    class OPCode41: public Instruction{
-    public:
-        OPCode41():Instruction(-1,0x41,nullptr){}
-        OPCode41(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x41,Maker){}
-        OPCode41(int addr, Builder *Maker):Instruction(addr,"???",0x41,Maker){}
-        OPCode41(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x41,Maker){
+    // 0x41
+    class OPCode41 : public Instruction {
+      public:
+        OPCode41()
+          : Instruction(-1, 0x41, nullptr) {}
+        OPCode41(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x41, Maker) {}
+        OPCode41(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x41, Maker) {}
+        OPCode41(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x41, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
 
-    //0x42
-    class OPCode42: public Instruction{
-    public:
-        OPCode42():Instruction(-1,0x42,nullptr){}
-        OPCode42(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x42,Maker){}
-        OPCode42(int addr, Builder *Maker):Instruction(addr,"???",0x42,Maker){}
-        OPCode42(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x42,Maker){
+    // 0x42
+    class OPCode42 : public Instruction {
+      public:
+        OPCode42()
+          : Instruction(-1, 0x42, nullptr) {}
+        OPCode42(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x42, Maker) {}
+        OPCode42(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {}
+        OPCode42(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x42, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
 
-    //0x43
-    class OPCode43: public Instruction{
-    public:
-        OPCode43():Instruction(-1,0x43,nullptr){}
-        OPCode43(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x43,Maker){}
-        OPCode43(int addr, Builder *Maker):Instruction(addr,"???",0x43,Maker){}
-        OPCode43(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x43,Maker){
+    // 0x43
+    class OPCode43 : public Instruction {
+      public:
+        OPCode43()
+          : Instruction(-1, 0x43, nullptr) {}
+        OPCode43(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x43, Maker) {}
+        OPCode43(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {}
+        OPCode43(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x43, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x44
-    class OPCode44: public Instruction{
-    public:
-        OPCode44():Instruction(-1,0x44,nullptr){}
-        OPCode44(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x44,Maker){}
-        OPCode44(int addr, Builder *Maker):Instruction(addr,"???",0x44,Maker){}
-        OPCode44(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x44,Maker){
+    // 0x44
+    class OPCode44 : public Instruction {
+      public:
+        OPCode44()
+          : Instruction(-1, 0x44, nullptr) {}
+        OPCode44(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x44, Maker) {}
+        OPCode44(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x44, Maker) {}
+        OPCode44(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x44, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
 
-                case 0x00:{
+                case 0x00: {
 
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case 0x03:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x03: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
                 case 0x04:
-                case 0x05:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;}
-                case 0x06:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x07:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x06: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x07: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-                case 0x08:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x08: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-
-
             }
         }
-
     };
 
-    //0x45
-    class OPCode45: public Instruction{
-    public:
-        OPCode45():Instruction(-1,0x45,nullptr){}
-        OPCode45(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x45,Maker){}
-        OPCode45(int addr, Builder *Maker):Instruction(addr,"???",0x45,Maker){}
-        OPCode45(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x45,Maker){
+    // 0x45
+    class OPCode45 : public Instruction {
+      public:
+        OPCode45()
+          : Instruction(-1, 0x45, nullptr) {}
+        OPCode45(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x45, Maker) {}
+        OPCode45(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x45, Maker) {}
+        OPCode45(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x45, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    class OPCode46: public Instruction{
-        public:
-            OPCode46():Instruction(-1,0x46,nullptr){}
-            OPCode46(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x46,Maker){}
-            OPCode46(int addr, Builder *Maker):Instruction(addr,"???",0x46,Maker){}
-            OPCode46(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x46,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 3:
-                    case 1:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 2:{
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
+    class OPCode46 : public Instruction {
+      public:
+        OPCode46()
+          : Instruction(-1, 0x46, nullptr) {}
+        OPCode46(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x46, Maker) {}
+        OPCode46(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x46, Maker) {}
+        OPCode46(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x46, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 3:
+                case 1: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 2: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 }
             }
-        };
+        }
+    };
 
-
-
-    //0x47
+    // 0x47
     /*class OPCode47: public Instruction{
     public:
         OPCode47():Instruction(-1,0x47,nullptr){}
-        OPCode47(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x47,Maker){}
-        OPCode47(int addr, Builder *Maker):Instruction(addr,"???",0x47,Maker){}
-        OPCode47(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x47,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+        OPCode47(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x47,Maker){} OPCode47(int addr, Builder *Maker):Instruction(addr,"???",0x47,Maker){} OPCode47(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x47,Maker){ addr++; this->AddOperande(operande(addr,"float",
+    ReadSubByteArray(content, addr,4))); this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
@@ -4375,43 +4782,48 @@ class TXBuilder : public Builder
         }
 
     };*/
-    //0x47
-    class OPCode47: public Instruction{
-    public:
-        OPCode47():Instruction(-1,0x47,nullptr){}
-        OPCode47(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x47,Maker){}
-        OPCode47(int addr, Builder *Maker):Instruction(addr,"???",0x47,Maker){}
-        OPCode47(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x47,Maker){
+    // 0x47
+    class OPCode47 : public Instruction {
+      public:
+        OPCode47()
+          : Instruction(-1, 0x47, nullptr) {}
+        OPCode47(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x47, Maker) {}
+        OPCode47(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {}
+        OPCode47(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x47, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x48
-    class OPCode48: public Instruction{
-    public:
-        OPCode48():Instruction(-1,0x48,nullptr){}
-        OPCode48(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x48,Maker){}
-        OPCode48(int addr, Builder *Maker):Instruction(addr,"???",0x48,Maker){}
-        OPCode48(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x48,Maker){
+    // 0x48
+    class OPCode48 : public Instruction {
+      public:
+        OPCode48()
+          : Instruction(-1, 0x48, nullptr) {}
+        OPCode48(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x48, Maker) {}
+        OPCode48(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {}
+        OPCode48(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x48, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-           }
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
     };
-    //0x49
+    // 0x49
     /*class OPCode49: public Instruction{
     public:
         OPCode49():Instruction(-1,0x49,nullptr){}
-        OPCode49(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x49,Maker){}
-        OPCode49(int addr, Builder *Maker):Instruction(addr,"???",0x49,Maker){}
-        OPCode49(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x49,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+        OPCode49(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x49,Maker){} OPCode49(int addr, Builder *Maker):Instruction(addr,"???",0x49,Maker){} OPCode49(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x49,Maker){ addr++; QByteArray control_byte =
+    ReadSubByteArray(content, addr, 1); this->AddOperande(operande(addr,"byte", control_byte)); switch((unsigned
+    char)control_byte[0]){
 
             case 0x0A:
             case 0x05:
@@ -4597,781 +5009,794 @@ class TXBuilder : public Builder
         }
 
     };*/
-    class OPCode49: public Instruction{
-        public:
-            OPCode49():Instruction(-1,0x49,nullptr){}
-            OPCode49(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x49,Maker){}
-            OPCode49(int addr, Builder *Maker):Instruction(addr,"???",0x49,Maker){}
-            OPCode49(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x49,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
+    class OPCode49 : public Instruction {
+      public:
+        OPCode49()
+          : Instruction(-1, 0x49, nullptr) {}
+        OPCode49(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x49, Maker) {}
+        OPCode49(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x49, Maker) {}
+        OPCode49(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x49, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
-                    case 0x00:{
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x01:{
-
-                        QByteArray str = ReadStringSubByteArray(content, addr);
-                        this->AddOperande(operande(addr,"string", str));
-
-                        QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                        operande fill = operande(addr,"fill", remaining);
-                        fill.setBytesToFill(0x20);
-                        this->AddOperande(fill);
-                        break;
-                    }
-                    case 0x0A:
-                    case 0x04:
-                    case 0x02:
-                    case 0x03:{ //Here, not entirely sure, doesn't seem to be used tho. Example I found has 0x20 zeros.
-                        QByteArray str = ReadStringSubByteArray(content, addr);
-                        this->AddOperande(operande(addr,"string", str));
-
-                        QByteArray remaining = ReadSubByteArray(content, addr, 0x20-str.size()-1);
-                        operande fill = operande(addr,"fill", remaining);
-                        fill.setBytesToFill(0x20);
-                        this->AddOperande(fill);
-                        break;
-                    }
-                    case 0x0B:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x0D:
-                    {
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    }
-                    case 0x0E:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    }
-                    case 0x14:
-                    {
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-
-                        break;
-                    }
-                    case 0x15:
-                    {
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                        break;
-                    }
-                    case 0x17:
-                    {
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    }
-                    case 0x18:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        break;
-                    }
-                    case 0x19:
-                    {
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    }
-                    case 0x1A:
-                    case 0x1B:
-                    case 0x3D:
-                    {
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    }
-                    case 0x1C:
-                    {
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    }
-                    case 0x21:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    }
-                    case 0x28:
-                    case 0x24:
-                    case 0x23:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x29:
-                    {
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        qFatal("not sure here");
-                        break;
-                    }
-                    case 0x2B:
-                    {
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        qFatal("not sure here");
-                        break;
-                    }
-                    case 0x34:
-                    case 0x30:
-                    {
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        break;
-                    }
-                    case 0x33:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x35:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        break;
-                    }
-                    case 0x38:
-                    {
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    }
-                    case 0x40:
-                    case 0x39:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                        break;
-                    }
-                    case 0x3A:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    }
-                    case 0x3B:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,1)));
-
-
-                        break;
-                    }
-                    case 0x3C:
-                    {
-
-                        qFatal("not sure here");
-
-                        break;
-                    }
-                    case 0x3E:
-                    {
-
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                    }
-                    case 0x44:
-                    {
-
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    }
-                    case 0x45:
-                    case 0x46:
-                    {
-
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    }
-                    case 0x47:
-                    {
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x48:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                        break;
-                    }
-
-
-
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
                 }
+                case 0x01: {
 
+                    QByteArray str = ReadStringSubByteArray(content, addr);
+                    this->AddOperande(operande(addr, "string", str));
+
+                    QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                    operande fill = operande(addr, "fill", remaining);
+                    fill.setBytesToFill(0x20);
+                    this->AddOperande(fill);
+                    break;
+                }
+                case 0x0A:
+                case 0x04:
+                case 0x02:
+                case 0x03: { // Here, not entirely sure, doesn't seem to be used tho. Example I found has 0x20 zeros.
+                    QByteArray str = ReadStringSubByteArray(content, addr);
+                    this->AddOperande(operande(addr, "string", str));
+
+                    QByteArray remaining = ReadSubByteArray(content, addr, 0x20 - str.size() - 1);
+                    operande fill = operande(addr, "fill", remaining);
+                    fill.setBytesToFill(0x20);
+                    this->AddOperande(fill);
+                    break;
+                }
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0D: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x0E: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x15: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x17: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x18: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x19: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x1A:
+                case 0x1B:
+                case 0x3D: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x1C: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x21: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x28:
+                case 0x24:
+                case 0x23: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x29: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    qFatal("not sure here");
+                    break;
+                }
+                case 0x2B: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    qFatal("not sure here");
+                    break;
+                }
+                case 0x34:
+                case 0x30: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x33: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x35: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
+                case 0x38: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x40:
+                case 0x39: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x3A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x3B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x3C: {
+
+                    qFatal("not sure here");
+
+                    break;
+                }
+                case 0x3E: {
+
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
+                case 0x44: {
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x45:
+                case 0x46: {
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x47: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x48: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
+                    break;
+                }
             }
+        }
+    };
 
-        };
-
-    //0x4A
-    class OPCode4A: public Instruction{
-    public:
-        OPCode4A():Instruction(-1,0x4A,nullptr){}
-        OPCode4A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4A,Maker){}
-        OPCode4A(int addr, Builder *Maker):Instruction(addr,"???",0x4A,Maker){}
-        OPCode4A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4A,Maker){
+    // 0x4A
+    class OPCode4A : public Instruction {
+      public:
+        OPCode4A()
+          : Instruction(-1, 0x4A, nullptr) {}
+        OPCode4A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4A, Maker) {}
+        OPCode4A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4A, Maker) {}
+        OPCode4A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x4B
-    class OPCode4B: public Instruction{
-    public:
-        OPCode4B():Instruction(-1,0x4B,nullptr){}
-        OPCode4B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4B,Maker){}
-        OPCode4B(int addr, Builder *Maker):Instruction(addr,"???",0x4B,Maker){}
-        OPCode4B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4B,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        }
-
-    };
-    //0x4C
-    class OPCode4C: public Instruction{
-    public:
-        OPCode4C():Instruction(-1,0x4C,nullptr){}
-        OPCode4C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4C,Maker){}
-        OPCode4C(int addr, Builder *Maker):Instruction(addr,"???",0x4C,Maker){}
-        OPCode4C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4C,Maker){
+    // 0x4B
+    class OPCode4B : public Instruction {
+      public:
+        OPCode4B()
+          : Instruction(-1, 0x4B, nullptr) {}
+        OPCode4B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4B, Maker) {}
+        OPCode4B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4B, Maker) {}
+        OPCode4B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4B, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x4D
-    class OPCode4D: public Instruction{
-    public:
-        OPCode4D():Instruction(-1,0x4D,nullptr){}
-        OPCode4D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4D,Maker){}
-        OPCode4D(int addr, Builder *Maker):Instruction(addr,"???",0x4D,Maker){}
-        OPCode4D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4D,Maker){
+    // 0x4C
+    class OPCode4C : public Instruction {
+      public:
+        OPCode4C()
+          : Instruction(-1, 0x4C, nullptr) {}
+        OPCode4C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4C, Maker) {}
+        OPCode4C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4C, Maker) {}
+        OPCode4C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4C, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
-
     };
-    //0x4F
+    // 0x4D
+    class OPCode4D : public Instruction {
+      public:
+        OPCode4D()
+          : Instruction(-1, 0x4D, nullptr) {}
+        OPCode4D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4D, Maker) {}
+        OPCode4D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4D, Maker) {}
+        OPCode4D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
+    };
+    // 0x4F
     /*class OPCode4F: public Instruction{
     public:
         OPCode4F():Instruction(-1,0x4F,nullptr){}
-        OPCode4F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4F,Maker){}
-        OPCode4F(int addr, Builder *Maker):Instruction(addr,"???",0x4F,Maker){}
-        OPCode4F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+        OPCode4F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x4F,Maker){} OPCode4F(int addr, Builder *Maker):Instruction(addr,"???",0x4F,Maker){} OPCode4F(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x4F,Maker){ addr++; this->AddOperande(operande(addr,"byte",
+    ReadSubByteArray(content, addr, 1)));
         }
 
     };*/
-    //0x4F
-    class OPCode4F: public Instruction{
-    public:
-        OPCode4F():Instruction(-1,0x4F,nullptr){}
-        OPCode4F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x4F,Maker){}
-        OPCode4F(int addr, Builder *Maker):Instruction(addr,"???",0x4F,Maker){}
-        OPCode4F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x4F,Maker){
+    // 0x4F
+    class OPCode4F : public Instruction {
+      public:
+        OPCode4F()
+          : Instruction(-1, 0x4F, nullptr) {}
+        OPCode4F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x4F, Maker) {}
+        OPCode4F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x4F, Maker) {}
+        OPCode4F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x4F, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x50
-    class OPCode50: public Instruction{
-    public:
-        OPCode50():Instruction(-1,0x50,nullptr){}
-        OPCode50(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x50,Maker){}
-        OPCode50(int addr, Builder *Maker):Instruction(addr,"???",0x50,Maker){}
-        OPCode50(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x50,Maker){
+    // 0x50
+    class OPCode50 : public Instruction {
+      public:
+        OPCode50()
+          : Instruction(-1, 0x50, nullptr) {}
+        OPCode50(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x50, Maker) {}
+        OPCode50(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x50, Maker) {}
+        OPCode50(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x50, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
             sub05(addr, content, this);
-       }
-
-    };
-    //0x51
-    class OPCode51: public Instruction{
-        public:
-            OPCode51():Instruction(-1,0x51,nullptr){}
-            OPCode51(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x51,Maker){}
-            OPCode51(int addr, Builder *Maker):Instruction(addr,"???",0x51,Maker){}
-            OPCode51(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x51,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            }
-
-    };
-    //0x52
-    class OPCode52: public Instruction{
-    public:
-        OPCode52():Instruction(-1,0x52,nullptr){}
-        OPCode52(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x52,Maker){}
-        OPCode52(int addr, Builder *Maker):Instruction(addr,"???",0x52,Maker){}
-        OPCode52(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x52,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
-
     };
-    //0x53
-    class OPCode53: public Instruction{
-    public:
-        OPCode53():Instruction(-1,0x53,nullptr){}
-        OPCode53(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x53,Maker){}
-        OPCode53(int addr, Builder *Maker):Instruction(addr,"???",0x53,Maker){}
-        OPCode53(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x53,Maker){
+    // 0x51
+    class OPCode51 : public Instruction {
+      public:
+        OPCode51()
+          : Instruction(-1, 0x51, nullptr) {}
+        OPCode51(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x51, Maker) {}
+        OPCode51(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x51, Maker) {}
+        OPCode51(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x51, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x52
+    class OPCode52 : public Instruction {
+      public:
+        OPCode52()
+          : Instruction(-1, 0x52, nullptr) {}
+        OPCode52(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x52, Maker) {}
+        OPCode52(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x52, Maker) {}
+        OPCode52(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x52, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x53
+    class OPCode53 : public Instruction {
+      public:
+        OPCode53()
+          : Instruction(-1, 0x53, nullptr) {}
+        OPCode53(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x53, Maker) {}
+        OPCode53(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x53, Maker) {}
+        OPCode53(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x53, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            if ((unsigned char) control_byte[0] == 0){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            if ((unsigned char)control_byte[0] == 0) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             }
         }
-
     };
-    //0x55
-    class OPCode55: public Instruction{
-    public:
-        OPCode55():Instruction(-1,0x55,nullptr){}
-        OPCode55(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x55,Maker){}
-        OPCode55(int addr, Builder *Maker):Instruction(addr,"???",0x55,Maker){}
-        OPCode55(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x55,Maker){
+    // 0x55
+    class OPCode55 : public Instruction {
+      public:
+        OPCode55()
+          : Instruction(-1, 0x55, nullptr) {}
+        OPCode55(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x55, Maker) {}
+        OPCode55(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x55, Maker) {}
+        OPCode55(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x55, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
-       }
-
-    };
-    //0x56
-    class OPCode56: public Instruction{
-    public:
-        OPCode56():Instruction(-1,0x56,nullptr){}
-        OPCode56(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x56,Maker){}
-        OPCode56(int addr, Builder *Maker):Instruction(addr,"???",0x56,Maker){}
-        OPCode56(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x56,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    //0x57
-    class OPCode57: public Instruction{
-    public:
-        OPCode57():Instruction(-1,0x57,nullptr){}
-        OPCode57(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x57,Maker){}
-        OPCode57(int addr, Builder *Maker):Instruction(addr,"???",0x57,Maker){}
-        OPCode57(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x57,Maker){
+    // 0x56
+    class OPCode56 : public Instruction {
+      public:
+        OPCode56()
+          : Instruction(-1, 0x56, nullptr) {}
+        OPCode56(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x56, Maker) {}
+        OPCode56(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x56, Maker) {}
+        OPCode56(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x56, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x57
+    class OPCode57 : public Instruction {
+      public:
+        OPCode57()
+          : Instruction(-1, 0x57, nullptr) {}
+        OPCode57(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x57, Maker) {}
+        OPCode57(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x57, Maker) {}
+        OPCode57(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x57, Maker) {
             addr++;
         }
-
     };
-    //0x58
-    class OPCode58: public Instruction{
-    public:
-        OPCode58():Instruction(-1,0x58,nullptr){}
-        OPCode58(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x58,Maker){}
-        OPCode58(int addr, Builder *Maker):Instruction(addr,"???",0x58,Maker){}
-        OPCode58(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x58,Maker){
+    // 0x58
+    class OPCode58 : public Instruction {
+      public:
+        OPCode58()
+          : Instruction(-1, 0x58, nullptr) {}
+        OPCode58(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x58, Maker) {}
+        OPCode58(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x58, Maker) {}
+        OPCode58(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x58, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x59
+    // 0x59
     /*class OPCode59: public Instruction{
     public:
         OPCode59():Instruction(-1,0x59,nullptr){}
-        OPCode59(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x59,Maker){}
-        OPCode59(int addr, Builder *Maker):Instruction(addr,"???",0x59,Maker){}
-        OPCode59(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x59,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode59(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x59,Maker){} OPCode59(int addr, Builder *Maker):Instruction(addr,"???",0x59,Maker){} OPCode59(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x59,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2)));
 
         }
 
     };*/
-    //0x5A
-    class OPCode5A: public Instruction{
-    public:
-        OPCode5A():Instruction(-1,0x5A,nullptr){}
-        OPCode5A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5A,Maker){}
-        OPCode5A(int addr, Builder *Maker):Instruction(addr,"???",0x5A,Maker){}
-        OPCode5A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5A,Maker){
+    // 0x5A
+    class OPCode5A : public Instruction {
+      public:
+        OPCode5A()
+          : Instruction(-1, 0x5A, nullptr) {}
+        OPCode5A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5A, Maker) {}
+        OPCode5A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5A, Maker) {}
+        OPCode5A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5A, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
             }
         }
-
     };
-    //0x5B
-    class OPCode5B: public Instruction{
-    public:
-        OPCode5B():Instruction(-1,0x5B,nullptr){}
-        OPCode5B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5B,Maker){}
-        OPCode5B(int addr, Builder *Maker):Instruction(addr,"???",0x5B,Maker){}
-        OPCode5B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5B,Maker){
+    // 0x5B
+    class OPCode5B : public Instruction {
+      public:
+        OPCode5B()
+          : Instruction(-1, 0x5B, nullptr) {}
+        OPCode5B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5B, Maker) {}
+        OPCode5B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5B, Maker) {}
+        OPCode5B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5B, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x06:
                 case 0x04:
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
             }
         }
-
     };
-    //0x5D
-   /* class OPCode5D: public Instruction{
-    public:
-        OPCode5D():Instruction(-1,0x5D,nullptr){}
-        OPCode5D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5D,Maker){}
-        OPCode5D(int addr, Builder *Maker):Instruction(addr,"???",0x5D,Maker){}
-        OPCode5D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5D,Maker){
+    // 0x5D
+    /* class OPCode5D: public Instruction{
+     public:
+         OPCode5D():Instruction(-1,0x5D,nullptr){}
+         OPCode5D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+     0x5D,Maker){} OPCode5D(int addr, Builder *Maker):Instruction(addr,"???",0x5D,Maker){} OPCode5D(int &addr,
+     QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5D,Maker){ addr++; QByteArray control_byte =
+     ReadSubByteArray(content, addr, 1); this->AddOperande(operande(addr,"byte", control_byte));
+             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+         switch((unsigned char)control_byte[0]){
+             case 0x01:
+             case 0x00:{
+                 this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                 break;
+             }
+         }
+         }
+
+     };*/
+    // 0x5E
+    class OPCode5D : public Instruction {
+      public:
+        OPCode5D()
+          : Instruction(-1, 0x5D, nullptr) {}
+        OPCode5D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5D, Maker) {}
+        OPCode5D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {}
+        OPCode5D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5D, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x01:
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-        }
-        }
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-    };*/
-    //0x5E
-    class OPCode5D: public Instruction{
-    public:
-        OPCode5D():Instruction(-1,0x5D,nullptr){}
-        OPCode5D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5D,Maker){}
-        OPCode5D(int addr, Builder *Maker):Instruction(addr,"???",0x5D,Maker){}
-        OPCode5D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5D,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-            switch((unsigned char)control_byte[0]){
+            switch ((unsigned char)control_byte[0]) {
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x04:
                 case 0x03:
-                case 0x02:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
 
-
-
-                case '\a':{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case '\a': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case '\b':{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case '\b': {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
-                case '\v':{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case '\v': {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
                 case 0x0D:
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
-                case 0x0E:
-               {
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x0E: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-                case 0x0F:
-               {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x10:
-               {
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x10: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
-                case 0x11:
-               {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x11: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x12:
-               {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-                case 0x14:
-               {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x14: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x15:
-               {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x15: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-                case 0x16:
-               {
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x16: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x17:
-               {
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
-                    break;
-                }
-                case 0x18:
-               {
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x17: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
+                case 0x18: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-
+                    break;
+                }
             }
         }
-
     };
-    //0x5E
-    class OPCode5E: public Instruction{
-    public:
-        OPCode5E():Instruction(-1,0x5E,nullptr){}
-        OPCode5E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5E,Maker){}
-        OPCode5E(int addr, Builder *Maker):Instruction(addr,"???",0x5E,Maker){}
-        OPCode5E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5E,Maker){
+    // 0x5E
+    class OPCode5E : public Instruction {
+      public:
+        OPCode5E()
+          : Instruction(-1, 0x5E, nullptr) {}
+        OPCode5E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5E, Maker) {}
+        OPCode5E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {}
+        OPCode5E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5E, Maker) {
             addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x03:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
 
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
                 case 0x0C:
                 case 0x0B:
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x04:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));;
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    ;
                     break;
                 }
 
                 case 0x05:
-                case 0x06:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x06: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
             }
         }
-
     };
 
-    //0x5F
+    // 0x5F
     /*class OPCode5F: public Instruction{
     public:
         OPCode5F():Instruction(-1,0x5F,nullptr){}
-        OPCode5F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5F,Maker){}
-        OPCode5F(int addr, Builder *Maker):Instruction(addr,"???",0x5F,Maker){}
-        OPCode5F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5F,Maker){
-            addr++;
+        OPCode5F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x5F,Maker){} OPCode5F(int addr, Builder *Maker):Instruction(addr,"???",0x5F,Maker){} OPCode5F(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x5F,Maker){ addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
             this->AddOperande(operande(addr,"byte", control_byte));
@@ -5443,68 +5868,69 @@ class TXBuilder : public Builder
         }
 
     };*/
-    //0x5F
-    class OPCode5F: public Instruction{
-    public:
-        OPCode5F():Instruction(-1,0x5F,nullptr){}
-        OPCode5F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x5F,Maker){}
-        OPCode5F(int addr, Builder *Maker):Instruction(addr,"???",0x5F,Maker){}
-        OPCode5F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x5F,Maker){
+    // 0x5F
+    class OPCode5F : public Instruction {
+      public:
+        OPCode5F()
+          : Instruction(-1, 0x5F, nullptr) {}
+        OPCode5F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x5F, Maker) {}
+        OPCode5F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x5F, Maker) {}
+        OPCode5F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x5F, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x00:
-                case 0x03:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x03: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x04:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x04: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
-                 }
-                case 0x05:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
-                 }
-
+                }
             }
         }
-
     };
-    //0x61
+    // 0x61
     /*class OPCode61: public Instruction{
     public:
         OPCode61():Instruction(-1,0x61,nullptr){}
-        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x61,Maker){}
-        OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){}
-        OPCode61(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){
-            addr++;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x61,Maker){} OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){} OPCode61(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){ addr++; this->AddOperande(operande(addr,"byte",
+    ReadSubByteArray(content, addr, 1)));; this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
         this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
@@ -5512,508 +5938,551 @@ class TXBuilder : public Builder
         }
 
     };*/
-    //0x60
-    class OPCode60: public Instruction{
-    public:
-        OPCode60():Instruction(-1,0x60,nullptr){}
-        OPCode60(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x60,Maker){}
-        OPCode60(int addr, Builder *Maker):Instruction(addr,"???",0x60,Maker){}
-        OPCode60(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x60,Maker){
+    // 0x60
+    class OPCode60 : public Instruction {
+      public:
+        OPCode60()
+          : Instruction(-1, 0x60, nullptr) {}
+        OPCode60(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x60, Maker) {}
+        OPCode60(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {}
+        OPCode60(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x60, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x61
-    class OPCode61: public Instruction{
-    public:
-        OPCode61():Instruction(-1,0x61,nullptr){}
-        OPCode61(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x61,Maker){}
-        OPCode61(int addr, Builder *Maker):Instruction(addr,"???",0x61,Maker){}
-        OPCode61(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x61,Maker){
+    // 0x61
+    class OPCode61 : public Instruction {
+      public:
+        OPCode61()
+          : Instruction(-1, 0x61, nullptr) {}
+        OPCode61(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x61, Maker) {}
+        OPCode61(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {}
+        OPCode61(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x61, Maker) {
             addr++;
 
-
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x63
-    class OPCode63: public Instruction{
-    public:
-        OPCode63():Instruction(-1,0x63,nullptr){}
-        OPCode63(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x63,Maker){}
-        OPCode63(int addr, Builder *Maker):Instruction(addr,"???",0x63,Maker){}
-        OPCode63(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x63,Maker){
+    // 0x63
+    class OPCode63 : public Instruction {
+      public:
+        OPCode63()
+          : Instruction(-1, 0x63, nullptr) {}
+        OPCode63(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x63, Maker) {}
+        OPCode63(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x63, Maker) {}
+        OPCode63(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x63, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x64
-    class OPCode64: public Instruction{
-    public:
-        OPCode64():Instruction(-1,0x64,nullptr){}
-        OPCode64(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x64,Maker){}
-        OPCode64(int addr, Builder *Maker):Instruction(addr,"???",0x64,Maker){}
-        OPCode64(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x64,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            switch((unsigned char)control_byte[0]){
-                case 0x11:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    break;
-                }
-                case 0x14:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    break;
-                }
-                case 0x16:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    break;
-                }
-            }
-
-        }
-
-    };
-    //0x65
-    class OPCode65: public Instruction{
-    public:
-        OPCode65():Instruction(-1,0x65,nullptr){}
-        OPCode65(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x65,Maker){}
-        OPCode65(int addr, Builder *Maker):Instruction(addr,"???",0x65,Maker){}
-        OPCode65(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x65,Maker){
+    // 0x64
+    class OPCode64 : public Instruction {
+      public:
+        OPCode64()
+          : Instruction(-1, 0x64, nullptr) {}
+        OPCode64(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x64, Maker) {}
+        OPCode64(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {}
+        OPCode64(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x64, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x11: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0x16: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
             }
-            case 0x09:
-            case 0x04:
-            case 0x0C:
-            {
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
-                break;
-            }
-            case 0x08:
-            case 0x07:
-            case 0x0B:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-
-            case 0x05:
-            case 0x03:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-            case 0x06:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                break;
-            }
-
         }
-
-        }
-
     };
-
-    //0x66
-    class OPCode66: public Instruction{
-    public:
-        OPCode66():Instruction(-1,0x66,nullptr){}
-        OPCode66(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x66,Maker){}
-        OPCode66(int addr, Builder *Maker):Instruction(addr,"???",0x66,Maker){}
-        OPCode66(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x66,Maker){
+    // 0x65
+    class OPCode65 : public Instruction {
+      public:
+        OPCode65()
+          : Instruction(-1, 0x65, nullptr) {}
+        OPCode65(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x65, Maker) {}
+        OPCode65(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {}
+        OPCode65(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x65, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
 
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case 0x09:
+                case 0x04:
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+
+                    break;
+                }
+                case 0x08:
+                case 0x07:
+                case 0x0B:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+
+                case 0x05:
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x06: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+            }
         }
-
     };
-    //0x68
-    class OPCode67: public Instruction{
-    public:
-        OPCode67():Instruction(-1,0x67,nullptr){}
-        OPCode67(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x67,Maker){}
-        OPCode67(int addr, Builder *Maker):Instruction(addr,"???",0x67,Maker){}
-        OPCode67(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x67,Maker){
+
+    // 0x66
+    class OPCode66 : public Instruction {
+      public:
+        OPCode66()
+          : Instruction(-1, 0x66, nullptr) {}
+        OPCode66(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x66, Maker) {}
+        OPCode66(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {}
+        OPCode66(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x66, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x68
+    class OPCode67 : public Instruction {
+      public:
+        OPCode67()
+          : Instruction(-1, 0x67, nullptr) {}
+        OPCode67(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x67, Maker) {}
+        OPCode67(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {}
+        OPCode67(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x67, Maker) {
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_short));
+            this->AddOperande(operande(addr, "short", control_short));
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            switch(code){
+            switch (code) {
                 case 0x02:
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
 
                     break;
                 }
                 case 0x03:
-                case 0x04:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                case 0x04: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    ;
                     break;
                 }
             }
-
-
         }
-
     };
-    //0x68
-    class OPCode68: public Instruction{
-    public:
-        OPCode68():Instruction(-1,0x68,nullptr){}
-        OPCode68(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x68,Maker){}
-        OPCode68(int addr, Builder *Maker):Instruction(addr,"???",0x68,Maker){}
-        OPCode68(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x68,Maker){
+    // 0x68
+    class OPCode68 : public Instruction {
+      public:
+        OPCode68()
+          : Instruction(-1, 0x68, nullptr) {}
+        OPCode68(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x68, Maker) {}
+        OPCode68(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {}
+        OPCode68(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x68, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-                break;
-            }
-            case 0x00:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-
-                break;
+                    break;
+                }
             }
         }
-        }
-
     };
-    //0x69
-    class OPCode69: public Instruction{
-    public:
-        OPCode69():Instruction(-1,0x69,nullptr){}
-        OPCode69(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x69,Maker){}
-        OPCode69(int addr, Builder *Maker):Instruction(addr,"???",0x69,Maker){}
-        OPCode69(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x69,Maker){
+    // 0x69
+    class OPCode69 : public Instruction {
+      public:
+        OPCode69()
+          : Instruction(-1, 0x69, nullptr) {}
+        OPCode69(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x69, Maker) {}
+        OPCode69(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {}
+        OPCode69(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x69, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-            case 0x00:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-                break;
+                    break;
+                }
+
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x14: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
             }
-
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x14:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-
-
-
         }
-        }
-
     };
-    //0x6A
-   class OPCode6A: public Instruction{
-        public:
-            OPCode6A():Instruction(-1,0x6A,nullptr){}
-            OPCode6A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6A,Maker){}
-            OPCode6A(int addr, Builder *Maker):Instruction(addr,"???",0x6A,Maker){}
-            OPCode6A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6A,Maker){
+    // 0x6A
+    class OPCode6A : public Instruction {
+      public:
+        OPCode6A()
+          : Instruction(-1, 0x6A, nullptr) {}
+        OPCode6A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6A, Maker) {}
+        OPCode6A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {}
+        OPCode6A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6A, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
+            this->AddOperande(operande(addr, "byte", control_byte2));
 
-            if ((unsigned char)control_byte2[0] < 4){
-                switch ((unsigned char)control_byte[0])  {
-                    case 0x00:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                        break;
-                    }
-
-                    case 0x01:{
-                        //reading_dialog(addr, content, this);
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        break;
-                    }
-                    case 0x02:{
-
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-                        break;
-                    }
-                    case 0x04:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            if ((unsigned char)control_byte2[0] < 4) {
+                switch ((unsigned char)control_byte[0]) {
+                    case 0x00: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                         break;
                     }
-                    case 0x05:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+
+                    case 0x01: {
+                        // reading_dialog(addr, content, this);
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        break;
+                    }
+                    case 0x02: {
+
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+                        break;
+                    }
+                    case 0x04: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        ;
+
+                        break;
+                    }
+                    case 0x05: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                         break;
                     }
                     case 0x09:
                     case 0x07:
-                    case 0x06:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    case 0x06: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                         break;
                     }
-
-
-
                 }
             }
-
         }
-
     };
-    //0x6B
-    class OPCode6B: public Instruction{
-    public:
-        OPCode6B():Instruction(-1,0x6B,nullptr){}
-        OPCode6B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6B,Maker){}
-        OPCode6B(int addr, Builder *Maker):Instruction(addr,"???",0x6B,Maker){}
-        OPCode6B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6B,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+    // 0x6B
+    class OPCode6B : public Instruction {
+      public:
+        OPCode6B()
+          : Instruction(-1, 0x6B, nullptr) {}
+        OPCode6B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6B, Maker) {}
+        OPCode6B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6B, Maker) {}
+        OPCode6B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));;
-        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
-
     };
-    //0x6C
-    class OPCode6C: public Instruction{
-    public:
-        OPCode6C():Instruction(-1,0x6C,nullptr){}
-        OPCode6C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6C,Maker){}
-        OPCode6C(int addr, Builder *Maker):Instruction(addr,"???",0x6C,Maker){}
-        OPCode6C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6C,Maker){
-        addr++;
+    // 0x6C
+    class OPCode6C : public Instruction {
+      public:
+        OPCode6C()
+          : Instruction(-1, 0x6C, nullptr) {}
+        OPCode6C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6C, Maker) {}
+        OPCode6C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {}
+        OPCode6C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6C, Maker) {
+            addr++;
 
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x6D
-    class OPCode6D: public Instruction{
-    public:
-        OPCode6D():Instruction(-1,0x6D,nullptr){}
-        OPCode6D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6D,Maker){}
-        OPCode6D(int addr, Builder *Maker):Instruction(addr,"???",0x6D,Maker){}
-        OPCode6D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6D,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-        switch((unsigned char)control_byte[0]){
-            case 0x01:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
-            }
-        }
-        }
-
-    };
-    //0x6E
-    class OPCode6E: public Instruction{
-    public:
-        OPCode6E():Instruction(-1,0x6E,nullptr){}
-        OPCode6E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6E,Maker){}
-        OPCode6E(int addr, Builder *Maker):Instruction(addr,"???",0x6E,Maker){}
-        OPCode6E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6E,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        switch((unsigned char)control_byte[0]){
-            case 0x05:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x0C:{
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                break;
+    // 0x6D
+    class OPCode6D : public Instruction {
+      public:
+        OPCode6D()
+          : Instruction(-1, 0x6D, nullptr) {}
+        OPCode6D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6D, Maker) {}
+        OPCode6D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6D, Maker) {}
+        OPCode6D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6D, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
             }
         }
-        }
-
     };
-    //0x6F
-    class OPCode6F: public Instruction{
-        public:
-        OPCode6F():Instruction(-1,0x6F,nullptr){}
-        OPCode6F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x6F,Maker){}
-        OPCode6F(int addr, Builder *Maker):Instruction(addr,"???",0x6F,Maker){}
-        OPCode6F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x6F,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x00:{
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
+    // 0x6E
+    class OPCode6E : public Instruction {
+      public:
+        OPCode6E()
+          : Instruction(-1, 0x6E, nullptr) {}
+        OPCode6E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6E, Maker) {}
+        OPCode6E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {}
+        OPCode6E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6E, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    break;
+                }
             }
-            case 0x02:
-            case 0x01:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+        }
+    };
+    // 0x6F
+    class OPCode6F : public Instruction {
+      public:
+        OPCode6F()
+          : Instruction(-1, 0x6F, nullptr) {}
+        OPCode6F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x6F, Maker) {}
+        OPCode6F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x6F, Maker) {}
+        OPCode6F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x6F, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
 
-                break;
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x02:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
             }
         }
-        }
-
     };
-    //0x70
-    class OPCode70: public Instruction{
-        public:
-        OPCode70():Instruction(-1,0x70,nullptr){}
-        OPCode70(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x70,Maker){}
-        OPCode70(int addr, Builder *Maker):Instruction(addr,"???",0x70,Maker){}
-        OPCode70(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x70,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        unsigned char code = control_byte[0];
-        if (code == 0x01){
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+    // 0x70
+    class OPCode70 : public Instruction {
+      public:
+        OPCode70()
+          : Instruction(-1, 0x70, nullptr) {}
+        OPCode70(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x70, Maker) {}
+        OPCode70(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {}
+        OPCode70(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x70, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x01) {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                ;
+            }
         }
-        }
-
     };
-    //0x71
+    // 0x71
     /*class OPCode72: public Instruction{
     public:
         OPCode72():Instruction(-1,0x72,nullptr){}
-        OPCode72(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x72,Maker){}
-        OPCode72(int addr, Builder *Maker):Instruction(addr,"???",0x72,Maker){}
-        OPCode72(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x72,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        unsigned char code = control_byte[0];
-        if (code == 0x00){
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+        OPCode72(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x72,Maker){} OPCode72(int addr, Builder *Maker):Instruction(addr,"???",0x72,Maker){} OPCode72(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x72,Maker){ addr++; QByteArray control_byte =
+    ReadSubByteArray(content, addr, 1); this->AddOperande(operande(addr,"byte", control_byte)); unsigned char code =
+    control_byte[0]; if (code == 0x00){ this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
@@ -6025,191 +6494,206 @@ class TXBuilder : public Builder
         }
 
     };*/
-    //0x72
-    class OPCode72: public Instruction{
-    public:
-        OPCode72():Instruction(-1,0x72,nullptr){}
-        OPCode72(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x72,Maker){}
-        OPCode72(int addr, Builder *Maker):Instruction(addr,"???",0x72,Maker){}
-        OPCode72(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x72,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+    // 0x72
+    class OPCode72 : public Instruction {
+      public:
+        OPCode72()
+          : Instruction(-1, 0x72, nullptr) {}
+        OPCode72(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x72, Maker) {}
+        OPCode72(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {}
+        OPCode72(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x72, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x73
+    // 0x73
 
-   class OPCode73: public Instruction{
-    public:
-        OPCode73():Instruction(-1,0x73,nullptr){}
-        OPCode73(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x73,Maker){}
-        OPCode73(int addr, Builder *Maker):Instruction(addr,"???",0x73,Maker){}
-        OPCode73(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x73,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x03:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
+    class OPCode73 : public Instruction {
+      public:
+        OPCode73()
+          : Instruction(-1, 0x73, nullptr) {}
+        OPCode73(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x73, Maker) {}
+        OPCode73(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {}
+        OPCode73(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x73, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x03: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case 0xFF:
+                case 0x06:
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x05: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x07: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0xFD:
+                case 0xFE:
+                case 0xFC: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x00:
+                case 0x01:
+                case 0x08:
+                case 0x09: {
+                    break;
+                }
+                default: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
             }
-            case 0xFF:
-            case 0x06:
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                break;
-            }
-            case 0x04:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x05:{
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x07:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0xFD:
-            case 0xFE:
-            case 0xFC:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-            case 0x00:
-            case 0x01:
-            case 0x08:
-            case 0x09:{
-                break;}
-            default:{
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-                break;
-            }
-
-
-
         }
-        }
-
     };
-    //0x74
-    class OPCode74: public Instruction{
-    public:
-        OPCode74():Instruction(-1,0x74,nullptr){}
-        OPCode74(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x74,Maker){}
-        OPCode74(int addr, Builder *Maker):Instruction(addr,"???",0x74,Maker){}
-        OPCode74(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x74,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x00:{
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                break;
+    // 0x74
+    class OPCode74 : public Instruction {
+      public:
+        OPCode74()
+          : Instruction(-1, 0x74, nullptr) {}
+        OPCode74(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x74, Maker) {}
+        OPCode74(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {}
+        OPCode74(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x74, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    break;
+                }
             }
         }
-        }
-
     };
-    //0x75
-    class OPCode75: public Instruction{
-    public:
-        OPCode75():Instruction(-1,0x75,nullptr){}
-        OPCode75(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x75,Maker){}
-        OPCode75(int addr, Builder *Maker):Instruction(addr,"???",0x75,Maker){}
-        OPCode75(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x75,Maker){
-        addr++;
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+    // 0x75
+    class OPCode75 : public Instruction {
+      public:
+        OPCode75()
+          : Instruction(-1, 0x75, nullptr) {}
+        OPCode75(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x75, Maker) {}
+        OPCode75(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x75, Maker) {}
+        OPCode75(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x75, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x78
-    class OPCode78: public Instruction{
-        public:
-            OPCode78():Instruction(-1,0x78,nullptr){}
-            OPCode78(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x78,Maker){}
-            OPCode78(int addr, Builder *Maker):Instruction(addr,"???",0x78,Maker){}
-            OPCode78(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x78,Maker){
+    // 0x78
+    class OPCode78 : public Instruction {
+      public:
+        OPCode78()
+          : Instruction(-1, 0x78, nullptr) {}
+        OPCode78(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x78, Maker) {}
+        OPCode78(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {}
+        OPCode78(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x78, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-            }
-
-    };
-    //0x79
-
-    class OPCode79: public Instruction{
-    public:
-        OPCode79():Instruction(-1,0x79,nullptr){}
-        OPCode79(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x79,Maker){}
-        OPCode79(int addr, Builder *Maker):Instruction(addr,"???",0x79,Maker){}
-        OPCode79(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x79,Maker){
-        addr++;
-        QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-        this->AddOperande(operande(addr,"byte", control_byte));
-        switch((unsigned char)control_byte[0]){
-            case 0x03:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                return;
-                break;
-            }
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-        this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-        }
-
     };
-    //0x7A
-    class OPCode7A: public Instruction{
-    public:
-        OPCode7A():Instruction(-1,0x7A,nullptr){}
-        OPCode7A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7A,Maker){}
-        OPCode7A(int addr, Builder *Maker):Instruction(addr,"???",0x7A,Maker){}
-        OPCode7A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7A,Maker){
+    // 0x79
+
+    class OPCode79 : public Instruction {
+      public:
+        OPCode79()
+          : Instruction(-1, 0x79, nullptr) {}
+        OPCode79(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x79, Maker) {}
+        OPCode79(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {}
+        OPCode79(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x79, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    return;
+                    break;
+                }
+            }
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
-
     };
-    //0x7B
+    // 0x7A
+    class OPCode7A : public Instruction {
+      public:
+        OPCode7A()
+          : Instruction(-1, 0x7A, nullptr) {}
+        OPCode7A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7A, Maker) {}
+        OPCode7A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {}
+        OPCode7A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7A, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x7B
     /*class OPCode7B: public Instruction{
     public:
         OPCode7B():Instruction(-1,0x7B,nullptr){}
-        OPCode7B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7B,Maker){}
-        OPCode7B(int addr, Builder *Maker):Instruction(addr,"???",0x7B,Maker){}
-        OPCode7B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7B,Maker){
-            addr++;
+        OPCode7B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x7B,Maker){} OPCode7B(int addr, Builder *Maker):Instruction(addr,"???",0x7B,Maker){} OPCode7B(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x7B,Maker){ addr++;
 
             this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
             this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
@@ -6217,674 +6701,759 @@ class TXBuilder : public Builder
 
     };*/
 
-    //0x7B
-    class OPCode7B: public Instruction{
-    public:
-        OPCode7B():Instruction(-1,0x7B,nullptr){}
-        OPCode7B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7B,Maker){}
-        OPCode7B(int addr, Builder *Maker):Instruction(addr,"???",0x7B,Maker){}
-        OPCode7B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7B,Maker){
+    // 0x7B
+    class OPCode7B : public Instruction {
+      public:
+        OPCode7B()
+          : Instruction(-1, 0x7B, nullptr) {}
+        OPCode7B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7B, Maker) {}
+        OPCode7B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {}
+        OPCode7B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7B, Maker) {
             addr++;
 
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
-
     };
-    //0x7D
-    class OPCode7D: public Instruction{
-    public:
-        OPCode7D():Instruction(-1,0x7D,nullptr){}
-        OPCode7D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7D,Maker){}
-        OPCode7D(int addr, Builder *Maker):Instruction(addr,"???",0x7D,Maker){}
-        OPCode7D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7D,Maker){
+    // 0x7D
+    class OPCode7D : public Instruction {
+      public:
+        OPCode7D()
+          : Instruction(-1, 0x7D, nullptr) {}
+        OPCode7D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7D, Maker) {}
+        OPCode7D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7D, Maker) {}
+        OPCode7D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7D, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
-
     };
-    //0x7E
-    class OPCode7E: public Instruction{
-    public:
-        OPCode7E():Instruction(-1,0x7E,nullptr){}
-        OPCode7E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7E,Maker){}
-        OPCode7E(int addr, Builder *Maker):Instruction(addr,"???",0x7E,Maker){}
-        OPCode7E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7E,Maker){
+    // 0x7E
+    class OPCode7E : public Instruction {
+      public:
+        OPCode7E()
+          : Instruction(-1, 0x7E, nullptr) {}
+        OPCode7E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7E, Maker) {}
+        OPCode7E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {}
+        OPCode7E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7E, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-
-    };
-    //0x7F
-    class OPCode7F: public Instruction{
-    public:
-        OPCode7F():Instruction(-1,0x7F,nullptr){}
-        OPCode7F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x7F,Maker){}
-        OPCode7F(int addr, Builder *Maker):Instruction(addr,"???",0x7F,Maker){}
-        OPCode7F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x7F,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch(control_byte[0]){
-            case 0x01   :
-            case 0x00:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                break;
-            }
-            case 0x02:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-                break;
-            }
-            case 0x03:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case -2:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                break;
-            }
-            case -1:{
-
-                break;
-            }
-            default:{
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            }
-
-
-        }
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x80
-    class OPCode80: public Instruction{
-    public:
-        OPCode80():Instruction(-1,0x80,nullptr){}
-        OPCode80(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x80,Maker){}
-        OPCode80(int addr, Builder *Maker):Instruction(addr,"???",0x80,Maker){}
-        OPCode80(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x80,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-        }
-    };
-    //0x81
-    class OPCode81: public Instruction{
-    public:
-        OPCode81():Instruction(-1,0x81,nullptr){}
-        OPCode81(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x81,Maker){}
-        OPCode81(int addr, Builder *Maker):Instruction(addr,"???",0x81,Maker){}
-        OPCode81(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x81,Maker){
+    // 0x7F
+    class OPCode7F : public Instruction {
+      public:
+        OPCode7F()
+          : Instruction(-1, 0x7F, nullptr) {}
+        OPCode7F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x7F, Maker) {}
+        OPCode7F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x7F, Maker) {}
+        OPCode7F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x7F, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch (control_byte[0]) {
+                case 0x01:
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    break;
+                }
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case -2: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+                case -1: {
+
+                    break;
+                }
+                default: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                }
+            }
+        }
+    };
+    // 0x80
+    class OPCode80 : public Instruction {
+      public:
+        OPCode80()
+          : Instruction(-1, 0x80, nullptr) {}
+        OPCode80(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x80, Maker) {}
+        OPCode80(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {}
+        OPCode80(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x80, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
+    };
+    // 0x81
+    class OPCode81 : public Instruction {
+      public:
+        OPCode81()
+          : Instruction(-1, 0x81, nullptr) {}
+        OPCode81(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x81, Maker) {}
+        OPCode81(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x81, Maker) {}
+        OPCode81(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x81, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            if (code == 0x00) this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            else if (code == 0x03) this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
+            if (code == 0x00)
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            else if (code == 0x03)
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x82
+    // 0x82
     /*class OPCode82: public Instruction{
     public:
         OPCode82():Instruction(-1,0x82,nullptr){}
-        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x82,Maker){}
-        OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){}
-        OPCode82(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x82,Maker){} OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){} OPCode82(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2))); this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
     };*/
-    //0x82
-    class OPCode82: public Instruction{
-    public:
-        OPCode82():Instruction(-1,0x82,nullptr){}
-        OPCode82(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x82,Maker){}
-        OPCode82(int addr, Builder *Maker):Instruction(addr,"???",0x82,Maker){}
-        OPCode82(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x82,Maker){
+    // 0x82
+    class OPCode82 : public Instruction {
+      public:
+        OPCode82()
+          : Instruction(-1, 0x82, nullptr) {}
+        OPCode82(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x82, Maker) {}
+        OPCode82(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {}
+        OPCode82(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x82, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x83
-    class OPCode83: public Instruction{
-    public:
-        OPCode83():Instruction(-1,0x83,nullptr){}
-        OPCode83(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x83,Maker){}
-        OPCode83(int addr, Builder *Maker):Instruction(addr,"???",0x83,Maker){}
-        OPCode83(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x83,Maker){
+    // 0x83
+    class OPCode83 : public Instruction {
+      public:
+        OPCode83()
+          : Instruction(-1, 0x83, nullptr) {}
+        OPCode83(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x83, Maker) {}
+        OPCode83(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {}
+        OPCode83(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x83, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
-
-       }
-    };
-    //0x84
-    class OPCode84: public Instruction{
-    public:
-        OPCode84():Instruction(-1,0x84,nullptr){}
-        OPCode84(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x84,Maker){}
-        OPCode84(int addr, Builder *Maker):Instruction(addr,"???",0x84,Maker){}
-        OPCode84(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x84,Maker){
-            addr++;
-
-
-       }
-    };
-    //0x85
-    class OPCode85: public Instruction{
-    public:
-        OPCode85():Instruction(-1,0x85,nullptr){}
-        OPCode85(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x85,Maker){}
-        OPCode85(int addr, Builder *Maker):Instruction(addr,"???",0x85,Maker){}
-        OPCode85(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x85,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x86
-    class OPCode86: public Instruction{
-    public:
-        OPCode86():Instruction(-1,0x86,nullptr){}
-        OPCode86(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x86,Maker){}
-        OPCode86(int addr, Builder *Maker):Instruction(addr,"???",0x86,Maker){}
-        OPCode86(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x86,Maker){
+    // 0x84
+    class OPCode84 : public Instruction {
+      public:
+        OPCode84()
+          : Instruction(-1, 0x84, nullptr) {}
+        OPCode84(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x84, Maker) {}
+        OPCode84(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {}
+        OPCode84(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x84, Maker) {
+            addr++;
+        }
+    };
+    // 0x85
+    class OPCode85 : public Instruction {
+      public:
+        OPCode85()
+          : Instruction(-1, 0x85, nullptr) {}
+        OPCode85(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x85, Maker) {}
+        OPCode85(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x85, Maker) {}
+        OPCode85(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x85, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x86
+    class OPCode86 : public Instruction {
+      public:
+        OPCode86()
+          : Instruction(-1, 0x86, nullptr) {}
+        OPCode86(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x86, Maker) {}
+        OPCode86(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x86, Maker) {}
+        OPCode86(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x86, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch ((unsigned char)control_byte[0])  {
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x04:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                case 0x04: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x0B:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x63:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x63: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x64:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x64: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x3:{
+                case 0x3: {
 
                     break;
                 }
-
             }
         }
     };
-    //0x87
-    class OPCode87: public Instruction{
-    public:
-        OPCode87():Instruction(-1,0x87,nullptr){}
-        OPCode87(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x87,Maker){}
-        OPCode87(int addr, Builder *Maker):Instruction(addr,"???",0x87,Maker){}
-        OPCode87(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x87,Maker){
+    // 0x87
+    class OPCode87 : public Instruction {
+      public:
+        OPCode87()
+          : Instruction(-1, 0x87, nullptr) {}
+        OPCode87(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x87, Maker) {}
+        OPCode87(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x87, Maker) {}
+        OPCode87(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x87, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x88
-    class OPCode88: public Instruction{
-    public:
-        OPCode88():Instruction(-1,0x88,nullptr){}
-        OPCode88(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x88,Maker){}
-        OPCode88(int addr, Builder *Maker):Instruction(addr,"???",0x88,Maker){}
-        OPCode88(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x88,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            unsigned char code = control_byte[0];
-            if (code == 0x00){
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            }
-
-
-        }
-    };
-
-    //0x89
-    class OPCode89: public Instruction{
-    public:
-        OPCode89():Instruction(-1,0x89,nullptr){}
-        OPCode89(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x89,Maker){}
-        OPCode89(int addr, Builder *Maker):Instruction(addr,"???",0x89,Maker){}
-        OPCode89(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x89,Maker){
+    // 0x88
+    class OPCode88 : public Instruction {
+      public:
+        OPCode88()
+          : Instruction(-1, 0x88, nullptr) {}
+        OPCode88(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x88, Maker) {}
+        OPCode88(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x88, Maker) {}
+        OPCode88(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x88, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            if ((code == 0x00)||(code == 0x14)){
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            }
-            else if (code == 0x0A){
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
             }
         }
     };
-    //0x8A
-    class OPCode8A: public Instruction{
-    public:
-        OPCode8A():Instruction(-1,0x8A,nullptr){}
-        OPCode8A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8A,Maker){}
-        OPCode8A(int addr, Builder *Maker):Instruction(addr,"???",0x8A,Maker){}
-        OPCode8A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8A,Maker){
+
+    // 0x89
+    class OPCode89 : public Instruction {
+      public:
+        OPCode89()
+          : Instruction(-1, 0x89, nullptr) {}
+        OPCode89(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x89, Maker) {}
+        OPCode89(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x89, Maker) {}
+        OPCode89(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x89, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             unsigned char code = control_byte[0];
-            if (code == 0x00){
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            if ((code == 0x00) || (code == 0x14)) {
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            } else if (code == 0x0A) {
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             }
         }
     };
-    //0x8C
-    class OPCode8C: public Instruction{
-    public:
-        OPCode8C():Instruction(-1,0x8C,nullptr){}
-        OPCode8C(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8C,Maker){}
-        OPCode8C(int addr, Builder *Maker):Instruction(addr,"???",0x8C,Maker){}
-        OPCode8C(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8C,Maker){
+    // 0x8A
+    class OPCode8A : public Instruction {
+      public:
+        OPCode8A()
+          : Instruction(-1, 0x8A, nullptr) {}
+        OPCode8A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8A, Maker) {}
+        OPCode8A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8A, Maker) {}
+        OPCode8A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            unsigned char code = control_byte[0];
+            if (code == 0x00) {
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            }
         }
     };
-    //0x8D
+    // 0x8C
+    class OPCode8C : public Instruction {
+      public:
+        OPCode8C()
+          : Instruction(-1, 0x8C, nullptr) {}
+        OPCode8C(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8C, Maker) {}
+        OPCode8C(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8C, Maker) {}
+        OPCode8C(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8C, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+        }
+    };
+    // 0x8D
     /*class OPCode8D: public Instruction{
     public:
         OPCode8D():Instruction(-1,0x8D,nullptr){}
-        OPCode8D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8D,Maker){}
-        OPCode8D(int addr, Builder *Maker):Instruction(addr,"???",0x8D,Maker){}
-        OPCode8D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8D,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode8D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x8D,Maker){} OPCode8D(int addr, Builder *Maker):Instruction(addr,"???",0x8D,Maker){} OPCode8D(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x8D,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2)));
 
         }
     };*/
-    //0x8D
-    class OPCode8D: public Instruction{
-    public:
-        OPCode8D():Instruction(-1,0x8D,nullptr){}
-        OPCode8D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8D,Maker){}
-        OPCode8D(int addr, Builder *Maker):Instruction(addr,"???",0x8D,Maker){}
-        OPCode8D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8D,Maker){
+    // 0x8D
+    class OPCode8D : public Instruction {
+      public:
+        OPCode8D()
+          : Instruction(-1, 0x8D, nullptr) {}
+        OPCode8D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8D, Maker) {}
+        OPCode8D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8D, Maker) {}
+        OPCode8D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8D, Maker) {
             addr++;
             QByteArray control_short = ReadSubByteArray(content, addr, 2);
             short control = ReadShortFromByteArray(0, control_short);
-            this->AddOperande(operande(addr,"short", control_short));
-            switch (control){
+            this->AddOperande(operande(addr, "short", control_short));
+            switch (control) {
                 case 0x02:
-                case 0x01:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x03:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    break;
-                }
-            }
-        }
-    };
-    //0x8E
-    class OPCode8E: public Instruction{
-    public:
-        OPCode8E():Instruction(-1,0x8E,nullptr){}
-        OPCode8E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8E,Maker){}
-        OPCode8E(int addr, Builder *Maker):Instruction(addr,"???",0x8E,Maker){}
-        OPCode8E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8E,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-        }
-    };
-    //0x8F
-    class OPCode8F: public Instruction{
-    public:
-        OPCode8F():Instruction(-1,0x8F,nullptr){}
-        OPCode8F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x8F,Maker){}
-        OPCode8F(int addr, Builder *Maker):Instruction(addr,"???",0x8F,Maker){}
-        OPCode8F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x8F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-        }
-    };
-    //0x90
-    class OPCode90: public Instruction{
-    public:
-        OPCode90():Instruction(-1,0x90,nullptr){}
-        OPCode90(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x90,Maker){}
-        OPCode90(int addr, Builder *Maker):Instruction(addr,"???",0x90,Maker){}
-        OPCode90(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x90,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
             }
         }
     };
-    //0x91
-    class OPCode91: public Instruction{
-    public:
-        OPCode91():Instruction(-1,0x91,nullptr){}
-        OPCode91(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x91,Maker){}
-        OPCode91(int addr, Builder *Maker):Instruction(addr,"???",0x91,Maker){}
-        OPCode91(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x91,Maker){
+    // 0x8E
+    class OPCode8E : public Instruction {
+      public:
+        OPCode8E()
+          : Instruction(-1, 0x8E, nullptr) {}
+        OPCode8E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8E, Maker) {}
+        OPCode8E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8E, Maker) {}
+        OPCode8E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
+    };
+    // 0x8F
+    class OPCode8F : public Instruction {
+      public:
+        OPCode8F()
+          : Instruction(-1, 0x8F, nullptr) {}
+        OPCode8F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x8F, Maker) {}
+        OPCode8F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x8F, Maker) {}
+        OPCode8F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x8F, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
+    };
+    // 0x90
+    class OPCode90 : public Instruction {
+      public:
+        OPCode90()
+          : Instruction(-1, 0x90, nullptr) {}
+        OPCode90(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x90, Maker) {}
+        OPCode90(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x90, Maker) {}
+        OPCode90(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x90, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+
+                    break;
+                }
+            }
+        }
+    };
+    // 0x91
+    class OPCode91 : public Instruction {
+      public:
+        OPCode91()
+          : Instruction(-1, 0x91, nullptr) {}
+        OPCode91(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x91, Maker) {}
+        OPCode91(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x91, Maker) {}
+        OPCode91(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x91, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
             }
         }
     };
 
-    //0x92
-    class OPCode92: public Instruction{
-    public:
-        OPCode92():Instruction(-1,0x92,nullptr){}
-        OPCode92(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x92,Maker){}
-        OPCode92(int addr, Builder *Maker):Instruction(addr,"???",0x92,Maker){}
-        OPCode92(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x92,Maker){
+    // 0x92
+    class OPCode92 : public Instruction {
+      public:
+        OPCode92()
+          : Instruction(-1, 0x92, nullptr) {}
+        OPCode92(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x92, Maker) {}
+        OPCode92(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x92, Maker) {}
+        OPCode92(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x92, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            ;
         }
     };
 
-    //0x93
-    class OPCode93: public Instruction{
-    public:
-        OPCode93():Instruction(-1,0x93,nullptr){}
-        OPCode93(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x93,Maker){}
-        OPCode93(int addr, Builder *Maker):Instruction(addr,"???",0x93,Maker){}
-        OPCode93(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x93,Maker){
+    // 0x93
+    class OPCode93 : public Instruction {
+      public:
+        OPCode93()
+          : Instruction(-1, 0x93, nullptr) {}
+        OPCode93(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x93, Maker) {}
+        OPCode93(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x93, Maker) {}
+        OPCode93(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x93, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             QByteArray control_byte2 = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte2));
-            if ((unsigned char)control_byte2[0] == 1){
-                switch((unsigned char)control_byte[0]){
-                    case 0x01:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte2));
+            if ((unsigned char)control_byte2[0] == 1) {
+                switch ((unsigned char)control_byte[0]) {
+                    case 0x01: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                         break;
                     }
-                    case 0x03:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    case 0x03: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                         break;
                     }
-                    case 0x05:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    case 0x05: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                         break;
                     }
-                    case 0x08:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    case 0x08: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                         break;
                     }
-                    case 0x0D:{
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+                    case 0x0D: {
+                        this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                         break;
                     }
-                    case 0x10:{
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    case 0x10: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                         break;
                     }
                     case 0x14:
-                    case 0x12:{
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                    case 0x12: {
+                        this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                         break;
                     }
-                    case 0x17:{
-                        this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    case 0x17: {
+                        this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
 
                         break;
                     }
                 }
             }
-
         }
     };
-    //0x94
-    class OPCode94: public Instruction{
-    public:
-        OPCode94():Instruction(-1,0x94,nullptr){}
-        OPCode94(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x94,Maker){}
-        OPCode94(int addr, Builder *Maker):Instruction(addr,"???",0x94,Maker){}
-        OPCode94(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x94,Maker){
+    // 0x94
+    class OPCode94 : public Instruction {
+      public:
+        OPCode94()
+          : Instruction(-1, 0x94, nullptr) {}
+        OPCode94(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x94, Maker) {}
+        OPCode94(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x94, Maker) {}
+        OPCode94(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x94, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x95
-    class OPCode95: public Instruction{
-    public:
-        OPCode95():Instruction(-1,0x95,nullptr){}
-        OPCode95(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x95,Maker){}
-        OPCode95(int addr, Builder *Maker):Instruction(addr,"???",0x95,Maker){}
-        OPCode95(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x95,Maker){
+    // 0x95
+    class OPCode95 : public Instruction {
+      public:
+        OPCode95()
+          : Instruction(-1, 0x95, nullptr) {}
+        OPCode95(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x95, Maker) {}
+        OPCode95(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x95, Maker) {}
+        OPCode95(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x95, Maker) {
             addr++;
-
         }
     };
-    //0x96
-    class OPCode96: public Instruction{
-    public:
-        OPCode96():Instruction(-1,0x96,nullptr){}
-        OPCode96(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x96,Maker){}
-        OPCode96(int addr, Builder *Maker):Instruction(addr,"???",0x96,Maker){}
-        OPCode96(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x96,Maker){
+    // 0x96
+    class OPCode96 : public Instruction {
+      public:
+        OPCode96()
+          : Instruction(-1, 0x96, nullptr) {}
+        OPCode96(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x96, Maker) {}
+        OPCode96(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x96, Maker) {}
+        OPCode96(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x96, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x97
-    class OPCode97: public Instruction{
-    public:
-        OPCode97():Instruction(-1,0x97,nullptr){}
-        OPCode97(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x97,Maker){}
-        OPCode97(int addr, Builder *Maker):Instruction(addr,"???",0x97,Maker){}
-        OPCode97(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x97,Maker){
+    // 0x97
+    class OPCode97 : public Instruction {
+      public:
+        OPCode97()
+          : Instruction(-1, 0x97, nullptr) {}
+        OPCode97(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x97, Maker) {}
+        OPCode97(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x97, Maker) {}
+        OPCode97(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x97, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x98
+    // 0x98
     /*class OPCode98: public Instruction{
     public:
         OPCode98():Instruction(-1,0x98,nullptr){}
-        OPCode98(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x98,Maker){}
-        OPCode98(int addr, Builder *Maker):Instruction(addr,"???",0x98,Maker){}
-        OPCode98(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x98,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode98(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x98,Maker){} OPCode98(int addr, Builder *Maker):Instruction(addr,"???",0x98,Maker){} OPCode98(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x98,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr,2))); this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
         }
     };*/
-    //0x99
-    class OPCode99: public Instruction{
-    public:
-        OPCode99():Instruction(-1,0x99,nullptr){}
-        OPCode99(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x99,Maker){}
-        OPCode99(int addr, Builder *Maker):Instruction(addr,"???",0x99,Maker){}
-        OPCode99(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x99,Maker){
+    // 0x99
+    class OPCode99 : public Instruction {
+      public:
+        OPCode99()
+          : Instruction(-1, 0x99, nullptr) {}
+        OPCode99(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x99, Maker) {}
+        OPCode99(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x99, Maker) {}
+        OPCode99(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x99, Maker) {
             addr++;
-
         }
     };
-    //0x9A
-    class OPCode9A: public Instruction{
-    public:
-        OPCode9A():Instruction(-1,0x9A,nullptr){}
-        OPCode9A(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9A,Maker){}
-        OPCode9A(int addr, Builder *Maker):Instruction(addr,"???",0x9A,Maker){}
-        OPCode9A(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9A,Maker){
+    // 0x9A
+    class OPCode9A : public Instruction {
+      public:
+        OPCode9A()
+          : Instruction(-1, 0x9A, nullptr) {}
+        OPCode9A(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9A, Maker) {}
+        OPCode9A(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9A, Maker) {}
+        OPCode9A(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9A, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0x9B
+    // 0x9B
     /*class OPCode9B: public Instruction{
     public:
         OPCode9B():Instruction(-1,0x9B,nullptr){}
-        OPCode9B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9B,Maker){}
-        OPCode9B(int addr, Builder *Maker):Instruction(addr,"???",0x9B,Maker){}
-        OPCode9B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9B,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x01:
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode9B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x9B,Maker){} OPCode9B(int addr, Builder *Maker):Instruction(addr,"???",0x9B,Maker){} OPCode9B(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x9B,Maker){ addr++; QByteArray control_byte =
+    ReadSubByteArray(content, addr, 1); this->AddOperande(operande(addr,"byte", control_byte)); switch((unsigned
+    char)control_byte[0]){ case 0x01: case 0x02:{ this->AddOperande(operande(addr,"short", ReadSubByteArray(content,
+    addr,2))); this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
                     this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
 
 
@@ -6904,53 +7473,62 @@ class TXBuilder : public Builder
             }
         }
     };*/
-    //0x9B
-    class OPCode9B: public Instruction{
-        public:
-            OPCode9B():Instruction(-1,0x9B, nullptr){}
-            OPCode9B(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9B,Maker){}
-            OPCode9B(int addr, Builder *Maker):Instruction(addr,"???",0x9B,Maker){}
-            OPCode9B(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9B,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+    // 0x9B
+    class OPCode9B : public Instruction {
+      public:
+        OPCode9B()
+          : Instruction(-1, 0x9B, nullptr) {}
+        OPCode9B(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9B, Maker) {}
+        OPCode9B(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9B, Maker) {}
+        OPCode9B(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9B, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x9D
-    class OPCode9D: public Instruction{
-        public:
-            OPCode9D():Instruction(-1,0x9D,nullptr){}
-            OPCode9D(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9D,Maker){}
-            OPCode9D(int addr, Builder *Maker):Instruction(addr,"???",0x9D,Maker){}
-            OPCode9D(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9D,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+    // 0x9D
+    class OPCode9D : public Instruction {
+      public:
+        OPCode9D()
+          : Instruction(-1, 0x9D, nullptr) {}
+        OPCode9D(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9D, Maker) {}
+        OPCode9D(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9D, Maker) {}
+        OPCode9D(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9D, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0x9E
-    class OPCode9E: public Instruction{
-        public:
-            OPCode9E():Instruction(-1,0x9E,nullptr){}
-            OPCode9E(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9E,Maker){}
-            OPCode9E(int addr, Builder *Maker):Instruction(addr,"???",0x9E,Maker){}
-            OPCode9E(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9E,Maker){
-                addr++;
-                this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+    // 0x9E
+    class OPCode9E : public Instruction {
+      public:
+        OPCode9E()
+          : Instruction(-1, 0x9E, nullptr) {}
+        OPCode9E(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9E, Maker) {}
+        OPCode9E(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9E, Maker) {}
+        OPCode9E(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9E, Maker) {
+            addr++;
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    //0x9F
+    // 0x9F
     /*class OPCode9F: public Instruction{
     public:
         OPCode9F():Instruction(-1,0x9F,nullptr){}
-        OPCode9F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9F,Maker){}
-        OPCode9F(int addr, Builder *Maker):Instruction(addr,"???",0x9F,Maker){}
-        OPCode9F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9F,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCode9F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0x9F,Maker){} OPCode9F(int addr, Builder *Maker):Instruction(addr,"???",0x9F,Maker){} OPCode9F(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0x9F,Maker){ addr++; this->AddOperande(operande(addr,"byte",
+    ReadSubByteArray(content, addr, 1)));; this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
             this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
@@ -6971,196 +7549,207 @@ class TXBuilder : public Builder
 
         }
     };*/
-    //0x9F
-    class OPCode9F: public Instruction{
-    public:
-        OPCode9F():Instruction(-1,0x9F,nullptr){}
-        OPCode9F(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0x9F,Maker){}
-        OPCode9F(int addr, Builder *Maker):Instruction(addr,"???",0x9F,Maker){}
-        OPCode9F(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0x9F,Maker){
+    // 0x9F
+    class OPCode9F : public Instruction {
+      public:
+        OPCode9F()
+          : Instruction(-1, 0x9F, nullptr) {}
+        OPCode9F(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0x9F, Maker) {}
+        OPCode9F(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0x9F, Maker) {}
+        OPCode9F(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0x9F, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    //0xA0
-    class OPCodeA0: public Instruction{
-    public:
-        OPCodeA0():Instruction(-1,0xA0,nullptr){}
-        OPCodeA0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA0,Maker){}
-        OPCodeA0(int addr, Builder *Maker):Instruction(addr,"???",0xA0,Maker){}
-        OPCodeA0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA0,Maker){
+    // 0xA0
+    class OPCodeA0 : public Instruction {
+      public:
+        OPCodeA0()
+          : Instruction(-1, 0xA0, nullptr) {}
+        OPCodeA0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA0, Maker) {}
+        OPCodeA0(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA0, Maker) {}
+        OPCodeA0(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA0, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
                 case 0x00:
-                case 0x04:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
                 case 0x02:
-                case 0x05:
-                {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x05: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    break;
+                }
+                case 0x03: {
+
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
+            }
+        }
+    };
+    // 0xA1
+    class OPCodeA1 : public Instruction {
+      public:
+        OPCodeA1()
+          : Instruction(-1, 0xA1, nullptr) {}
+        OPCodeA1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA1, Maker) {}
+        OPCodeA1(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA1, Maker) {}
+        OPCodeA1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA1, Maker) {
+            addr++;
+            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+
                     break;
                 }
                 case 0x03:
-                {
+                case 0x04:
+                case 0x02:
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-
             }
         }
     };
-    //0xA1
-    class OPCodeA1: public Instruction{
-        public:
-            OPCodeA1():Instruction(-1,0xA1,nullptr){}
-            OPCodeA1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA1,Maker){}
-            OPCodeA1(int addr, Builder *Maker):Instruction(addr,"???",0xA1,Maker){}
-            OPCodeA1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA1,Maker){
-                addr++;
-                QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-                this->AddOperande(operande(addr,"byte", control_byte));
-                switch((unsigned char)control_byte[0]){
-                    case 0x00:
-                    {
-                        this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
 
-                        break;
-                    }
-                    case 0x03:
-                    case 0x04:
-                    case 0x02:
-                    case 0x01:
-                    {
-                        this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-                        break;
-                    }
-
-
-                }
-            }
-        };
-
-    //0xA2
-    class OPCodeA2: public Instruction{
-    public:
-        OPCodeA2():Instruction(-1,0xA2,nullptr){}
-        OPCodeA2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA2,Maker){}
-        OPCodeA2(int addr, Builder *Maker):Instruction(addr,"???",0xA2,Maker){}
-        OPCodeA2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA2,Maker){
+    // 0xA2
+    class OPCodeA2 : public Instruction {
+      public:
+        OPCodeA2()
+          : Instruction(-1, 0xA2, nullptr) {}
+        OPCodeA2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA2, Maker) {}
+        OPCodeA2(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA2, Maker) {}
+        OPCodeA2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA2, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    //0xA3
+    // 0xA3
     /*class OPCodeA3: public Instruction{
     public:
         OPCodeA3():Instruction(-1,0xA3,nullptr){}
-        OPCodeA3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA3,Maker){}
-        OPCodeA3(int addr, Builder *Maker):Instruction(addr,"???",0xA3,Maker){}
-        OPCodeA3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA3,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+        OPCodeA3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0xA3,Maker){} OPCodeA3(int addr, Builder *Maker):Instruction(addr,"???",0xA3,Maker){} OPCodeA3(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0xA3,Maker){ addr++; this->AddOperande(operande(addr,"byte",
+    ReadSubByteArray(content, addr,1))); this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
         }
     };*/
-    //0xA3
-    class OPCodeA3: public Instruction{
-    public:
-        OPCodeA3():Instruction(-1,0xA3,nullptr){}
-        OPCodeA3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA3,Maker){}
-        OPCodeA3(int addr, Builder *Maker):Instruction(addr,"???",0xA3,Maker){}
-        OPCodeA3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA3,Maker){
+    // 0xA3
+    class OPCodeA3 : public Instruction {
+      public:
+        OPCodeA3()
+          : Instruction(-1, 0xA3, nullptr) {}
+        OPCodeA3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA3, Maker) {}
+        OPCodeA3(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA3, Maker) {}
+        OPCodeA3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA3, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
-
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0xA4
-    class OPCodeA4: public Instruction{
-    public:
-        OPCodeA4():Instruction(-1,0xA4,nullptr){}
-        OPCodeA4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA4,Maker){}
-        OPCodeA4(int addr, Builder *Maker):Instruction(addr,"???",0xA4,Maker){}
-        OPCodeA4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA4,Maker){
+    // 0xA4
+    class OPCodeA4 : public Instruction {
+      public:
+        OPCodeA4()
+          : Instruction(-1, 0xA4, nullptr) {}
+        OPCodeA4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA4, Maker) {}
+        OPCodeA4(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA4, Maker) {}
+        OPCodeA4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA4, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    //0xA6
+    // 0xA6
     /*class OPCodeA6: public Instruction{
     public:
         OPCodeA6():Instruction(-1,0xA6,nullptr){}
-        OPCodeA6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA6,Maker){}
-        OPCodeA6(int addr, Builder *Maker):Instruction(addr,"???",0xA6,Maker){}
-        OPCodeA6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA6,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
+        OPCodeA6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0xA6,Maker){} OPCodeA6(int addr, Builder *Maker):Instruction(addr,"???",0xA6,Maker){} OPCodeA6(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0xA6,Maker){ addr++; QByteArray control_byte =
+    ReadSubByteArray(content, addr, 1); this->AddOperande(operande(addr,"byte", control_byte)); switch((unsigned
+    char)control_byte[0]){
 
 
                 case 0x03:
@@ -7175,195 +7764,219 @@ class TXBuilder : public Builder
             }
         }
     };*/
-    //0xA6
-    class OPCodeA6: public Instruction{
-    public:
-        OPCodeA6():Instruction(-1,0xA6,nullptr){}
-        OPCodeA6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA6,Maker){}
-        OPCodeA6(int addr, Builder *Maker):Instruction(addr,"???",0xA6,Maker){}
-        OPCodeA6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA6,Maker){
+    // 0xA6
+    class OPCodeA6 : public Instruction {
+      public:
+        OPCodeA6()
+          : Instruction(-1, 0xA6, nullptr) {}
+        OPCodeA6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA6, Maker) {}
+        OPCodeA6(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA6, Maker) {}
+        OPCodeA6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA6, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0xA7
-    class OPCodeA7: public Instruction{
-    public:
-        OPCodeA7():Instruction(-1,0xA7,nullptr){}
-        OPCodeA7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA7,Maker){}
-        OPCodeA7(int addr, Builder *Maker):Instruction(addr,"???",0xA7,Maker){}
-        OPCodeA7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA7,Maker){
+    // 0xA7
+    class OPCodeA7 : public Instruction {
+      public:
+        OPCodeA7()
+          : Instruction(-1, 0xA7, nullptr) {}
+        OPCodeA7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA7, Maker) {}
+        OPCodeA7(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA7, Maker) {}
+        OPCodeA7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA7, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0xA8
-    class OPCodeA8: public Instruction{
-    public:
-        OPCodeA8():Instruction(-1,0xA8,nullptr){}
-        OPCodeA8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA8,Maker){}
-        OPCodeA8(int addr, Builder *Maker):Instruction(addr,"???",0xA8,Maker){}
-        OPCodeA8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA8,Maker){
+    // 0xA8
+    class OPCodeA8 : public Instruction {
+      public:
+        OPCodeA8()
+          : Instruction(-1, 0xA8, nullptr) {}
+        OPCodeA8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA8, Maker) {}
+        OPCodeA8(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA8, Maker) {}
+        OPCodeA8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA8, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0xA9
-    class OPCodeA9: public Instruction{
-    public:
-        OPCodeA9():Instruction(-1,0xA9,nullptr){}
-        OPCodeA9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xA9,Maker){}
-        OPCodeA9(int addr, Builder *Maker):Instruction(addr,"???",0xA9,Maker){}
-        OPCodeA9(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xA9,Maker){
+    // 0xA9
+    class OPCodeA9 : public Instruction {
+      public:
+        OPCodeA9()
+          : Instruction(-1, 0xA9, nullptr) {}
+        OPCodeA9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xA9, Maker) {}
+        OPCodeA9(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xA9, Maker) {}
+        OPCodeA9(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xA9, Maker) {
             addr++;
         }
     };
-    //0xAA
-    class OPCodeAA: public Instruction{
-    public:
-        OPCodeAA():Instruction(-1,0xAA,nullptr){}
-        OPCodeAA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAA,Maker){}
-        OPCodeAA(int addr, Builder *Maker):Instruction(addr,"???",0xAA,Maker){}
-        OPCodeAA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAA,Maker){
+    // 0xAA
+    class OPCodeAA : public Instruction {
+      public:
+        OPCodeAA()
+          : Instruction(-1, 0xAA, nullptr) {}
+        OPCodeAA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAA, Maker) {}
+        OPCodeAA(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAA, Maker) {}
+        OPCodeAA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAA, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0xAB
-    class OPCodeAB: public Instruction{
-    public:
-        OPCodeAB():Instruction(-1,0xAB,nullptr){}
-        OPCodeAB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAB,Maker){}
-        OPCodeAB(int addr, Builder *Maker):Instruction(addr,"???",0xAB,Maker){}
-        OPCodeAB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAB,Maker){
+    // 0xAB
+    class OPCodeAB : public Instruction {
+      public:
+        OPCodeAB()
+          : Instruction(-1, 0xAB, nullptr) {}
+        OPCodeAB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAB, Maker) {}
+        OPCodeAB(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAB, Maker) {}
+        OPCodeAB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAB, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    //0xAC
-    class OPCodeAC: public Instruction{
-    public:
-        OPCodeAC():Instruction(-1,0xAC,nullptr){}
-        OPCodeAC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAC,Maker){}
-        OPCodeAC(int addr, Builder *Maker):Instruction(addr,"???",0xAC,Maker){}
-        OPCodeAC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAC,Maker){
+    // 0xAC
+    class OPCodeAC : public Instruction {
+      public:
+        OPCodeAC()
+          : Instruction(-1, 0xAC, nullptr) {}
+        OPCodeAC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAC, Maker) {}
+        OPCodeAC(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAC, Maker) {}
+        OPCodeAC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAC, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-
-
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0xAD
-    class OPCodeAD: public Instruction{
-    public:
-        OPCodeAD():Instruction(-1,0xAD,nullptr){}
-        OPCodeAD(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAD,Maker){}
-        OPCodeAD(int addr, Builder *Maker):Instruction(addr,"???",0xAD,Maker){}
-        OPCodeAD(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAD,Maker){
+    // 0xAD
+    class OPCodeAD : public Instruction {
+      public:
+        OPCodeAD()
+          : Instruction(-1, 0xAD, nullptr) {}
+        OPCodeAD(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAD, Maker) {}
+        OPCodeAD(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAD, Maker) {}
+        OPCodeAD(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAD, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
         }
     };
-    //0xAE
-    class OPCodeAE: public Instruction{
-    public:
-        OPCodeAE():Instruction(-1,0xAE,nullptr){}
-        OPCodeAE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAE,Maker){}
-        OPCodeAE(int addr, Builder *Maker):Instruction(addr,"???",0xAE,Maker){}
-        OPCodeAE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAE,Maker){
+    // 0xAE
+    class OPCodeAE : public Instruction {
+      public:
+        OPCodeAE()
+          : Instruction(-1, 0xAE, nullptr) {}
+        OPCodeAE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAE, Maker) {}
+        OPCodeAE(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAE, Maker) {}
+        OPCodeAE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAE, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-
-
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0xAF
-    class OPCodeAF: public Instruction{
-    public:
-        OPCodeAF():Instruction(-1,0xAF,nullptr){}
-        OPCodeAF(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xAF,Maker){}
-        OPCodeAF(int addr, Builder *Maker):Instruction(addr,"???",0xAF,Maker){}
-        OPCodeAF(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xAF,Maker){
+    // 0xAF
+    class OPCodeAF : public Instruction {
+      public:
+        OPCodeAF()
+          : Instruction(-1, 0xAF, nullptr) {}
+        OPCodeAF(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xAF, Maker) {}
+        OPCodeAF(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xAF, Maker) {}
+        OPCodeAF(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xAF, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-            switch((unsigned char)control_byte[0]){
-                case 0x65:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x65: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x66:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x66: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-                case 0x67:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x67: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x69:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                case 0x69: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
             }
-
-
         }
     };
-    //0xB0
+    // 0xB0
     /*class OPCodeB0: public Instruction{
     public:
         OPCodeB0():Instruction(-1,0xB0,nullptr){}
-        OPCodeB0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB0,Maker){}
-        OPCodeB0(int addr, Builder *Maker):Instruction(addr,"???",0xB0,Maker){}
-        OPCodeB0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB0,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+        OPCodeB0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0xB0,Maker){} OPCodeB0(int addr, Builder *Maker):Instruction(addr,"???",0xB0,Maker){} OPCodeB0(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0xB0,Maker){ addr++; QByteArray control_byte =
+    ReadSubByteArray(content, addr, 1); this->AddOperande(operande(addr,"byte", control_byte)); switch((unsigned
+    char)control_byte[0]){ case 0x02:{ this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
                     break;
                 }
             }
@@ -7372,203 +7985,209 @@ class TXBuilder : public Builder
 
         }
     };*/
-    //0xB0
-    class OPCodeB0: public Instruction{
-    public:
-        OPCodeB0():Instruction(-1,0xB0,nullptr){}
-        OPCodeB0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB0,Maker){}
-        OPCodeB0(int addr, Builder *Maker):Instruction(addr,"???",0xB0,Maker){}
-        OPCodeB0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB0,Maker){
+    // 0xB0
+    class OPCodeB0 : public Instruction {
+      public:
+        OPCodeB0()
+          : Instruction(-1, 0xB0, nullptr) {}
+        OPCodeB0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB0, Maker) {}
+        OPCodeB0(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB0, Maker) {}
+        OPCodeB0(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB0, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr,2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
         }
     };
-    //0xB1
-    class OPCodeB1: public Instruction{
-    public:
-        OPCodeB1():Instruction(-1,0xB1,nullptr){}
-        OPCodeB1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB1,Maker){}
-        OPCodeB1(int addr, Builder *Maker):Instruction(addr,"???",0xB1,Maker){}
-        OPCodeB1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB1,Maker){
+    // 0xB1
+    class OPCodeB1 : public Instruction {
+      public:
+        OPCodeB1()
+          : Instruction(-1, 0xB1, nullptr) {}
+        OPCodeB1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB1, Maker) {}
+        OPCodeB1(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB1, Maker) {}
+        OPCodeB1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB1, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x04:
-                case 0x03:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x03: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x06:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x06: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x0A:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x0D:
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x0E:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x0E: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x0F:{
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
             }
         }
     };
-    //0xB2
-    class OPCodeB2: public Instruction{
-    public:
-        OPCodeB2():Instruction(-1,0xB2,nullptr){}
-        OPCodeB2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB2,Maker){}
-        OPCodeB2(int addr, Builder *Maker):Instruction(addr,"???",0xB2,Maker){}
-        OPCodeB2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB2,Maker){
+    // 0xB2
+    class OPCodeB2 : public Instruction {
+      public:
+        OPCodeB2()
+          : Instruction(-1, 0xB2, nullptr) {}
+        OPCodeB2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB2, Maker) {}
+        OPCodeB2(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB2, Maker) {}
+        OPCodeB2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB2, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
 
-            switch((unsigned char)control_byte[0]){
-                case 0x01:{ //this one is REALLY strange. two times I found that they added two missing floats (or int)
-                    //in the files, the executable doesn't parse them right, not sure what to do
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x01: { // this one is REALLY strange. two times I found that they added two missing floats (or
+                             // int)
+                    // in the files, the executable doesn't parse them right, not sure what to do
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
-                    //these might need to be removed
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
+                    // these might need to be removed
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-                case 0x02:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x02: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
                 case 0x0A:
-                case 0x0B:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x0B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x0C:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr,1)));
+                case 0x0C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
-                case 0x0D:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x0D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-                    break;
-                }
-                case 0x0F:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-                case 0x12:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x12: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
             }
-
-
-
         }
     };
 
-    //0xB3
+    // 0xB3
     /*class OPCodeB3: public Instruction{
     public:
         OPCodeB3():Instruction(-1,0xB3,nullptr){}
-        OPCodeB3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB3,Maker){}
-        OPCodeB3(int addr, Builder *Maker):Instruction(addr,"???",0xB3,Maker){}
-        OPCodeB3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB3,Maker){
-            addr++;
-            QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    break;
+        OPCodeB3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0xB3,Maker){} OPCodeB3(int addr, Builder *Maker):Instruction(addr,"???",0xB3,Maker){} OPCodeB3(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0xB3,Maker){ addr++; QByteArray control_byte =
+    ReadSubByteArray(content, addr, 1); this->AddOperande(operande(addr,"byte", control_byte)); switch((unsigned
+    char)control_byte[0]){ case 0x00:{ this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content,
+    addr))); break;
                 }
                 case 0x01:{
                     this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
@@ -7592,34 +8211,33 @@ class TXBuilder : public Builder
 
         }
     };*/
-    //0xB3
-    class OPCodeB3: public Instruction{
-    public:
-        OPCodeB3():Instruction(-1,0xB3,nullptr){}
-        OPCodeB3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB3,Maker){}
-        OPCodeB3(int addr, Builder *Maker):Instruction(addr,"???",0xB3,Maker){}
-        OPCodeB3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB3,Maker){
+    // 0xB3
+    class OPCodeB3 : public Instruction {
+      public:
+        OPCodeB3()
+          : Instruction(-1, 0xB3, nullptr) {}
+        OPCodeB3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB3, Maker) {}
+        OPCodeB3(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB3, Maker) {}
+        OPCodeB3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB3, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-
-
+            this->AddOperande(operande(addr, "byte", control_byte));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0xB5
+    // 0xB5
     /*class OPCodeB5: public Instruction{
     public:
         OPCodeB5():Instruction(-1,0xB5,nullptr){}
-        OPCodeB5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB5,Maker){}
-        OPCodeB5(int addr, Builder *Maker):Instruction(addr,"???",0xB5,Maker){}
-        OPCodeB5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB5,Maker){
-            addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+        OPCodeB5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???",
+    0xB5,Maker){} OPCodeB5(int addr, Builder *Maker):Instruction(addr,"???",0xB5,Maker){} OPCodeB5(int &addr, QByteArray
+    &content, Builder *Maker):Instruction(addr,"???", 0xB5,Maker){ addr++; this->AddOperande(operande(addr,"short",
+    ReadSubByteArray(content, addr, 2))); this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
             this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
             this->AddOperande(operande(addr,"byte", control_byte));
@@ -7629,223 +8247,228 @@ class TXBuilder : public Builder
 
         }
     };*/
-    //0xB5
-    class OPCodeB5: public Instruction{
-    public:
-        OPCodeB5():Instruction(-1,0xB5,nullptr){}
-        OPCodeB5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB5,Maker){}
-        OPCodeB5(int addr, Builder *Maker):Instruction(addr,"???",0xB5,Maker){}
-        OPCodeB5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB5,Maker){
+    // 0xB5
+    class OPCodeB5 : public Instruction {
+      public:
+        OPCodeB5()
+          : Instruction(-1, 0xB5, nullptr) {}
+        OPCodeB5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB5, Maker) {}
+        OPCodeB5(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB5, Maker) {}
+        OPCodeB5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB5, Maker) {
             addr++;
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            ushort control = ReadShortFromByteArray(0,control_ba);
-            this->AddOperande(operande(addr,"short", control_ba));
-            switch(control){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+            ushort control = ReadShortFromByteArray(0, control_ba);
+            this->AddOperande(operande(addr, "short", control_ba));
+            switch (control) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
-                case 100:{
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                case 100: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
             }
         }
     };
-    //0xB6
-    class OPCodeB6: public Instruction{
-    public:
-        OPCodeB6():Instruction(-1,0xB6,nullptr){}
-        OPCodeB6(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB6,Maker){}
-        OPCodeB6(int addr, Builder *Maker):Instruction(addr,"???",0xB6,Maker){}
-        OPCodeB6(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB6,Maker){
+    // 0xB6
+    class OPCodeB6 : public Instruction {
+      public:
+        OPCodeB6()
+          : Instruction(-1, 0xB6, nullptr) {}
+        OPCodeB6(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB6, Maker) {}
+        OPCodeB6(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB6, Maker) {}
+        OPCodeB6(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB6, Maker) {
             addr++;
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            ushort control = ReadShortFromByteArray(0,control_ba);
-            this->AddOperande(operande(addr,"short", control_ba));
+            ushort control = ReadShortFromByteArray(0, control_ba);
+            this->AddOperande(operande(addr, "short", control_ba));
             QByteArray control_ba2 = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_ba2));
-            switch(control){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", control_ba2));
+            switch (control) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
                 case 0x06:
-                case 0x05:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
             }
         }
     };
-    //0xB7
-    class OPCodeB7: public Instruction{
-    public:
-        OPCodeB7():Instruction(-1,0xB7,nullptr){}
-        OPCodeB7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB7,Maker){}
-        OPCodeB7(int addr, Builder *Maker):Instruction(addr,"???",0xB7,Maker){}
-        OPCodeB7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB7,Maker){
+    // 0xB7
+    class OPCodeB7 : public Instruction {
+      public:
+        OPCodeB7()
+          : Instruction(-1, 0xB7, nullptr) {}
+        OPCodeB7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB7, Maker) {}
+        OPCodeB7(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB7, Maker) {}
+        OPCodeB7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB7, Maker) {
             addr++;
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            ushort control = ReadShortFromByteArray(0,control_ba);
-            this->AddOperande(operande(addr,"short", control_ba));
-            switch(control){
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+            ushort control = ReadShortFromByteArray(0, control_ba);
+            this->AddOperande(operande(addr, "short", control_ba));
+            switch (control) {
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 default: {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
             }
         }
     };
-    //0xB8
-    class OPCodeB8: public Instruction{
-    public:
-        OPCodeB8():Instruction(-1,0xB8,nullptr){}
-        OPCodeB8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB8,Maker){}
-        OPCodeB8(int addr, Builder *Maker):Instruction(addr,"???",0xB8,Maker){}
-        OPCodeB8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB8,Maker){
+    // 0xB8
+    class OPCodeB8 : public Instruction {
+      public:
+        OPCodeB8()
+          : Instruction(-1, 0xB8, nullptr) {}
+        OPCodeB8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB8, Maker) {}
+        OPCodeB8(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB8, Maker) {}
+        OPCodeB8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB8, Maker) {
             addr++;
 
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_ba));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr,4)));
-
-
-
+            this->AddOperande(operande(addr, "short", control_ba));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
         }
     };
-    //0xB9
-    class OPCodeB9: public Instruction{
-    public:
-        OPCodeB9():Instruction(-1,0xB9,nullptr){}
-        OPCodeB9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xB9,Maker){}
-        OPCodeB9(int addr, Builder *Maker):Instruction(addr,"???",0xB9,Maker){}
-        OPCodeB9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xB9,Maker){
+    // 0xB9
+    class OPCodeB9 : public Instruction {
+      public:
+        OPCodeB9()
+          : Instruction(-1, 0xB9, nullptr) {}
+        OPCodeB9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xB9, Maker) {}
+        OPCodeB9(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xB9, Maker) {}
+        OPCodeB9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xB9, Maker) {
             addr++;
 
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            ushort control = ReadShortFromByteArray(0,control_ba);
-            this->AddOperande(operande(addr,"short", control_ba));
+            ushort control = ReadShortFromByteArray(0, control_ba);
+            this->AddOperande(operande(addr, "short", control_ba));
 
-            switch(control){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+            switch (control) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
 
-                case 0x02:
-                {
+                case 0x02: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-                    break;
-                }
-                case 0x03:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
-                case 0x04:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-                case 0x05:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                case 0x04: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-                case 0x07:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x05: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-                case 0x09:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x07: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+
+                    break;
+                }
+                case 0x09: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
                 case 0x2C:
-                case 0x0F:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x0F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-                case 0x14:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
+                case 0x14: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-                case 0x15:
-                {
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x15: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x16:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x16: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x18:
 
                 {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
@@ -7853,16 +8476,16 @@ class TXBuilder : public Builder
 
                 {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
@@ -7870,11 +8493,10 @@ class TXBuilder : public Builder
 
                 {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
@@ -7882,10 +8504,9 @@ class TXBuilder : public Builder
 
                 {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
@@ -7893,404 +8514,365 @@ class TXBuilder : public Builder
 
                 {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
 
                     break;
                 }
-            case 0x0E:
-            {
+                case 0x0E: {
 
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                break;
-            }
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    break;
+                }
 
                 case 0x2E:
                 case 0x1A:
                 case 0x1B:
-                case 0x17:
-                {
+                case 0x17: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x1D:
-                case 0x1E:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x1E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x1F:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x1F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x20:
-                case 0x24:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x24: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x21:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x21: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x22:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x22: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x23:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x23: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x27:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                case 0x27: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x29:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x29: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x2A:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x2A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x2B:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x2B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x2D:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x2D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x30:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x30: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x31:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x31: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x32:
-                {
+                case 0x32: {
 
                     break;
                 }
-                case 0x36:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x36: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x34:
-                case 0x38:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x38: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
 
-                case 0x39:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x39: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x37:
-                case 0x3B:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x3B: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x3C:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x3C: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x3D:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x3D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x3E:
-                {
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x3E: {
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x3F:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x3F: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x19:
                 case 0x40:
-                case 0x28:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                case 0x28: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x42:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x42: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x41:
-                case 0x43:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x43: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x44:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x44: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x45:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x45: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
                 case 0x46:
-                case 0x4A:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x4A: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
                 case 0x3A:
-                case 0x48:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x48: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x47:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x47: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x49:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x49: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x54:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+                case 0x54: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                default:{
+                default: {
                     qFatal("not analyzed yet");
                 }
-
             }
-
-
-
         }
     };
-    //0xBA
-    class OPCodeBA: public Instruction{
-    public:
-        OPCodeBA():Instruction(-1,0xBA,nullptr){}
-        OPCodeBA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xBA,Maker){}
-        OPCodeBA(int addr, Builder *Maker):Instruction(addr,"???",0xBA,Maker){}
-        OPCodeBA(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xBA,Maker){
+    // 0xBA
+    class OPCodeBA : public Instruction {
+      public:
+        OPCodeBA()
+          : Instruction(-1, 0xBA, nullptr) {}
+        OPCodeBA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xBA, Maker) {}
+        OPCodeBA(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xBA, Maker) {}
+        OPCodeBA(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xBA, Maker) {
             addr++;
 
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            ushort control = ReadShortFromByteArray(0,control_ba);
-            this->AddOperande(operande(addr,"short", control_ba));
+            ushort control = ReadShortFromByteArray(0, control_ba);
+            this->AddOperande(operande(addr, "short", control_ba));
 
-            switch(control){
+            switch (control) {
                 case 0x01:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
 
                 case 0x02:
 
                 {
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
 
-                case 0x06:
-                {
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x06: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
                 case 0x40:
-                case 0x41:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x41: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
 
-                case 0x9:
-                {
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x9: {
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x0A:
-                {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x0A: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
 
                     break;
                 }
-
             }
-
-
-
         }
     };
-    //0xBB
-    class OPCodeBB: public Instruction{
-    public:
-        OPCodeBB():Instruction(-1,0xBB,nullptr){}
-        OPCodeBB(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xBB,Maker){}
-        OPCodeBB(int addr, Builder *Maker):Instruction(addr,"???",0xBB,Maker){}
-        OPCodeBB(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xBB,Maker){
+    // 0xBB
+    class OPCodeBB : public Instruction {
+      public:
+        OPCodeBB()
+          : Instruction(-1, 0xBB, nullptr) {}
+        OPCodeBB(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xBB, Maker) {}
+        OPCodeBB(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xBB, Maker) {}
+        OPCodeBB(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xBB, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
         }
     };
-    class OPCodeBC: public Instruction{
-    public:
-        OPCodeBC():Instruction(-1,0xBC,nullptr){}
-        OPCodeBC(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xBC,Maker){}
-        OPCodeBC(int addr, Builder *Maker):Instruction(addr,"???",0xBC,Maker){}
-        OPCodeBC(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xBC,Maker){
+    class OPCodeBC : public Instruction {
+      public:
+        OPCodeBC()
+          : Instruction(-1, 0xBC, nullptr) {}
+        OPCodeBC(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xBC, Maker) {}
+        OPCodeBC(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xBC, Maker) {}
+        OPCodeBC(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xBC, Maker) {
             addr++;
 
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            ushort control = ReadShortFromByteArray(0,control_ba);
-            this->AddOperande(operande(addr,"short", control_ba));
+            ushort control = ReadShortFromByteArray(0, control_ba);
+            this->AddOperande(operande(addr, "short", control_ba));
 
-            switch(control){
+            switch (control) {
                 case 0x08:
                 case 0x07:
                 case 0x2E:
                 case 0x3A:
                 case 0x3C:
                 case 0x3F:
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x01:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x01: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x02:
                 case 0x3B:
-                case 0x3D:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x3D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x18:
                 case 0x15:
                 case 0x14:
-                case 0x03:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x03: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x40:
-                case 0x41:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x41: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
                 case 0x17:
@@ -8304,479 +8886,675 @@ class TXBuilder : public Builder
                 case 0x48:
                 case 0x49:
                 case 0x4A:
-                case 0x4D:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                case 0x4D: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
-                case 0x1E:
-                {
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"string", ReadStringSubByteArray(content, addr)));
+                case 0x1E: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "string", ReadStringSubByteArray(content, addr)));
                     break;
                 }
                 case 0x2D:
                 case 0x44:
                 case 0x45:
                 case 0x5B:
-                case 0x5F:
-                {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x5F: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-                case 0x35:
-                {
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-                    this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
+                case 0x35: {
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+                    this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
                     break;
                 }
-
             }
-
-
-
         }
     };
-    class OPCodeBE: public Instruction{
-    public:
-        OPCodeBE():Instruction(-1,0xBE,nullptr){}
-        OPCodeBE(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xBE,Maker){}
-        OPCodeBE(int addr, Builder *Maker):Instruction(addr,"???",0xBE,Maker){}
-        OPCodeBE(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xBE,Maker){
+    class OPCodeBE : public Instruction {
+      public:
+        OPCodeBE()
+          : Instruction(-1, 0xBE, nullptr) {}
+        OPCodeBE(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xBE, Maker) {}
+        OPCodeBE(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xBE, Maker) {}
+        OPCodeBE(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xBE, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            }
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
     };
-    class OPCodeBF: public Instruction{
-    public:
-        OPCodeBF():Instruction(-1,0xBF,nullptr){}
-        OPCodeBF(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xBF,Maker){}
-        OPCodeBF(int addr, Builder *Maker):Instruction(addr,"???",0xBF,Maker){}
-        OPCodeBF(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xBF,Maker){
+    class OPCodeBF : public Instruction {
+      public:
+        OPCodeBF()
+          : Instruction(-1, 0xBF, nullptr) {}
+        OPCodeBF(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xBF, Maker) {}
+        OPCodeBF(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xBF, Maker) {}
+        OPCodeBF(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xBF, Maker) {
             addr++;
 
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr, 4)));
-            }
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
+        }
     };
-    class OPCodeC0: public Instruction{
-    public:
-        OPCodeC0():Instruction(-1,0xC0,nullptr){}
-        OPCodeC0(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC0,Maker){}
-        OPCodeC0(int addr, Builder *Maker):Instruction(addr,"???",0xC0,Maker){}
-        OPCodeC0(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC0,Maker){
+    class OPCodeC0 : public Instruction {
+      public:
+        OPCodeC0()
+          : Instruction(-1, 0xC0, nullptr) {}
+        OPCodeC0(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC0, Maker) {}
+        OPCodeC0(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC0, Maker) {}
+        OPCodeC0(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC0, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-            }
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
     };
-    class OPCodeC1: public Instruction{
-    public:
-        OPCodeC1():Instruction(-1,0xC1,nullptr){}
-        OPCodeC1(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC1,Maker){}
-        OPCodeC1(int addr, Builder *Maker):Instruction(addr,"???",0xC1,Maker){}
-        OPCodeC1(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC1,Maker){
+    class OPCodeC1 : public Instruction {
+      public:
+        OPCodeC1()
+          : Instruction(-1, 0xC1, nullptr) {}
+        OPCodeC1(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC1, Maker) {}
+        OPCodeC1(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC1, Maker) {}
+        OPCodeC1(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC1, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-
-            }
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+        }
     };
-    class OPCodeC2: public Instruction{
-    public:
-        OPCodeC2():Instruction(-1,0xC2,nullptr){}
-        OPCodeC2(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC2,Maker){}
-        OPCodeC2(int addr, Builder *Maker):Instruction(addr,"???",0xC2,Maker){}
-        OPCodeC2(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC2,Maker){
+    class OPCodeC2 : public Instruction {
+      public:
+        OPCodeC2()
+          : Instruction(-1, 0xC2, nullptr) {}
+        OPCodeC2(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC2, Maker) {}
+        OPCodeC2(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC2, Maker) {}
+        OPCodeC2(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC2, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-            }
-
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
     };
-    class OPCodeC3: public Instruction{
-    public:
-        OPCodeC3():Instruction(-1,0xC3,nullptr){}
-        OPCodeC3(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC3,Maker){}
-        OPCodeC3(int addr, Builder *Maker):Instruction(addr,"???",0xC3,Maker){}
-        OPCodeC3(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC3,Maker){
+    class OPCodeC3 : public Instruction {
+      public:
+        OPCodeC3()
+          : Instruction(-1, 0xC3, nullptr) {}
+        OPCodeC3(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC3, Maker) {}
+        OPCodeC3(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC3, Maker) {}
+        OPCodeC3(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC3, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
-                    this->AddOperande(operande(addr,"float", ReadSubByteArray(content, addr, 4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
+                    this->AddOperande(operande(addr, "float", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
                 case 0x02:
-                case 0x01:{
+                case 0x01: {
                     break;
                 }
-                default:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                default: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                 }
             }
-            }
-
+        }
     };
-    class OPCodeC4: public Instruction{
-    public:
-        OPCodeC4():Instruction(-1,0xC4,nullptr){}
-        OPCodeC4(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC4,Maker){}
-        OPCodeC4(int addr, Builder *Maker):Instruction(addr,"???",0xC4,Maker){}
-        OPCodeC4(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC4,Maker){
+    class OPCodeC4 : public Instruction {
+      public:
+        OPCodeC4()
+          : Instruction(-1, 0xC4, nullptr) {}
+        OPCodeC4(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC4, Maker) {}
+        OPCodeC4(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC4, Maker) {}
+        OPCodeC4(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC4, Maker) {
             addr++;
-            this->AddOperande(operande(addr,"byte", ReadSubByteArray(content, addr, 1)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-            this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-
-            }
-
+            this->AddOperande(operande(addr, "byte", ReadSubByteArray(content, addr, 1)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+        }
     };
-    class OPCodeC5: public Instruction{
-    public:
-        OPCodeC5():Instruction(-1,0xC5,nullptr){}
-        OPCodeC5(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC5,Maker){}
-        OPCodeC5(int addr, Builder *Maker):Instruction(addr,"???",0xC5,Maker){}
-        OPCodeC5(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC5,Maker){
+    class OPCodeC5 : public Instruction {
+      public:
+        OPCodeC5()
+          : Instruction(-1, 0xC5, nullptr) {}
+        OPCodeC5(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC5, Maker) {}
+        OPCodeC5(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC5, Maker) {}
+        OPCodeC5(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC5, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
 
                     break;
                 }
-
             }
-            }
-
+        }
     };
-    class OPCodeC7: public Instruction{
-    public:
-        OPCodeC7():Instruction(-1,0xC7,nullptr){}
-        OPCodeC7(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC7,Maker){}
-        OPCodeC7(int addr, Builder *Maker):Instruction(addr,"???",0xC7,Maker){}
-        OPCodeC7(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC7,Maker){
+    class OPCodeC7 : public Instruction {
+      public:
+        OPCodeC7()
+          : Instruction(-1, 0xC7, nullptr) {}
+        OPCodeC7(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC7, Maker) {}
+        OPCodeC7(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC7, Maker) {}
+        OPCodeC7(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC7, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-
-            }
-
+            this->AddOperande(operande(addr, "byte", control_byte));
+        }
     };
-    class OPCodeC8: public Instruction{
-    public:
-        OPCodeC8():Instruction(-1,0xC8,nullptr){}
-        OPCodeC8(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC8,Maker){}
-        OPCodeC8(int addr, Builder *Maker):Instruction(addr,"???",0xC8,Maker){}
-        OPCodeC8(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC8,Maker){
+    class OPCodeC8 : public Instruction {
+      public:
+        OPCodeC8()
+          : Instruction(-1, 0xC8, nullptr) {}
+        OPCodeC8(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC8, Maker) {}
+        OPCodeC8(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC8, Maker) {}
+        OPCodeC8(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC8, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
+            this->AddOperande(operande(addr, "byte", control_byte));
             QByteArray control_ba = ReadSubByteArray(content, addr, 2);
-            this->AddOperande(operande(addr,"short", control_ba));
-
-            }
-
+            this->AddOperande(operande(addr, "short", control_ba));
+        }
     };
-    class OPCodeC9: public Instruction{
-    public:
-        OPCodeC9():Instruction(-1,0xC9,nullptr){}
-        OPCodeC9(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xC9,Maker){}
-        OPCodeC9(int addr, Builder *Maker):Instruction(addr,"???",0xC9,Maker){}
-        OPCodeC9(int &addr, QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xC9,Maker){
+    class OPCodeC9 : public Instruction {
+      public:
+        OPCodeC9()
+          : Instruction(-1, 0xC9, nullptr) {}
+        OPCodeC9(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xC9, Maker) {}
+        OPCodeC9(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xC9, Maker) {}
+        OPCodeC9(int& addr, QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xC9, Maker) {
             addr++;
             QByteArray control_byte = ReadSubByteArray(content, addr, 1);
-            this->AddOperande(operande(addr,"byte", control_byte));
-            switch((unsigned char)control_byte[0]){
-                case 0x00:{
-                    this->AddOperande(operande(addr,"int", ReadSubByteArray(content, addr,4)));
+            this->AddOperande(operande(addr, "byte", control_byte));
+            switch ((unsigned char)control_byte[0]) {
+                case 0x00: {
+                    this->AddOperande(operande(addr, "int", ReadSubByteArray(content, addr, 4)));
                     break;
                 }
-                case 0x01:{
+                case 0x01: {
 
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
-                    this->AddOperande(operande(addr,"short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
+                    this->AddOperande(operande(addr, "short", ReadSubByteArray(content, addr, 2)));
                     break;
                 }
             }
-            }
-
+        }
     };
-    class OPCodeCA: public Instruction{
-    public:
-        OPCodeCA():Instruction(-1,0xCA,nullptr){}
-        OPCodeCA(int &addr, int idx_row, QXlsx::Document &doc,Builder *Maker):Instruction(addr, idx_row, doc,"???", 0xCA,Maker){}
-        OPCodeCA(int addr, Builder *Maker):Instruction(addr,"???",0xCA,Maker){}
-        OPCodeCA(int &addr, [[maybe_unused]] QByteArray &content, Builder *Maker):Instruction(addr,"???", 0xCA,Maker){
+    class OPCodeCA : public Instruction {
+      public:
+        OPCodeCA()
+          : Instruction(-1, 0xCA, nullptr) {}
+        OPCodeCA(int& addr, int idx_row, QXlsx::Document& doc, Builder* Maker)
+          : Instruction(addr, idx_row, doc, "???", 0xCA, Maker) {}
+        OPCodeCA(int addr, Builder* Maker)
+          : Instruction(addr, "???", 0xCA, Maker) {}
+        OPCodeCA(int& addr, [[maybe_unused]] QByteArray& content, Builder* Maker)
+          : Instruction(addr, "???", 0xCA, Maker) {
             addr++;
-            }
-
+        }
     };
-    std::shared_ptr<Instruction> CreateInstructionFromDAT(int &addr, QByteArray &dat_content, int function_type){
-        int OP = (dat_content[addr]&0xFF);
-        //qDebug() << "OP :" << hex << OP << " at " << addr;
+    std::shared_ptr<Instruction> CreateInstructionFromDAT(int& addr, QByteArray& dat_content, int function_type) {
+        int OP = (dat_content[addr] & 0xFF);
+        // qDebug() << "OP :" << hex << OP << " at " << addr;
         int i = TXUIFiles.indexOf(SceneName);
-        if ((i != -1)&&(OP == 0x13)) return std::make_shared<UI_OP13>(addr,dat_content,this); //UI files have a special 0x13 instruction
+        if ((i != -1) && (OP == 0x13))
+            return std::make_shared<UI_OP13>(addr, dat_content, this); // UI files have a special 0x13 instruction
 
-        if (function_type == 0){ //the function is read with OPCodes
+        if (function_type == 0) { // the function is read with OPCodes
 
-            switch(OP){
-                case 0x00: return std::make_shared<OPCode0>(addr,dat_content,this);
-                case 0x01: return std::make_shared<OPCode1>(addr,dat_content,this);
-                case 0x02: return std::make_shared<OPCode02>(addr,dat_content,this);
-                case 0x03: return std::make_shared<OPCode03>(addr,dat_content,this);
-                case 0x04: return std::make_shared<OPCode04>(addr,dat_content,this);
-                case 0x05: return std::make_shared<OPCode05>(addr,dat_content,this);
-                case 0x06: return std::make_shared<OPCode06>(addr,dat_content,this);
-                case 0x07: return std::make_shared<OPCode07>(addr,dat_content,this);
-                case 0x08: return std::make_shared<OPCode08>(addr,dat_content,this);
-                case 0x0A: return std::make_shared<OPCode0A>(addr,dat_content,this);
-                case 0x0C: return std::make_shared<OPCode0C>(addr,dat_content,this);
-                case 0x0D: return std::make_shared<OPCode0D>(addr,dat_content,this);
-                case 0x0E: return std::make_shared<OPCode0E>(addr,dat_content,this);
-                case 0x0F: return std::make_shared<OPCode0F>(addr,dat_content,this);
-                case 0x10: return std::make_shared<OPCode10>(addr,dat_content,this);
-                case 0x11: return std::make_shared<OPCode11>(addr,dat_content,this);
-                case 0x12: return std::make_shared<OPCode12>(addr,dat_content,this);
-                case 0x13: return std::make_shared<OPCode13>(addr,dat_content,this);
-                case 0x14: return std::make_shared<OPCode14>(addr,dat_content,this);
-                case 0x15: return std::make_shared<OPCode15>(addr,dat_content,this);
-                case 0x16: return std::make_shared<OPCode16>(addr,dat_content,this);
-                case 0x17: return std::make_shared<OPCode17>(addr,dat_content,this);
-                case 0x18: return std::make_shared<OPCode18>(addr,dat_content,this);
-                case 0x19: return std::make_shared<OPCode19>(addr,dat_content,this);
-                case 0x1A: return std::make_shared<OPCode1A>(addr,dat_content,this);
-                case 0x1B: return std::make_shared<OPCode1B>(addr,dat_content,this);
-                case 0x1C: return std::make_shared<OPCode1C>(addr,dat_content,this);
-                case 0x1D: return std::make_shared<OPCode1D>(addr,dat_content,this);
-                case 0x1E: return std::make_shared<OPCode1E>(addr,dat_content,this);
-                case 0x1F: return std::make_shared<OPCode1F>(addr,dat_content,this);
-                case 0x20: return std::make_shared<OPCode20>(addr,dat_content,this);
-//                case 0x21: return std::make_shared<OPCode21>(addr,dat_content,this);
-                case 0x22: return std::make_shared<OPCode22>(addr,dat_content,this);
-                case 0x23: return std::make_shared<OPCode23>(addr,dat_content,this);
-                case 0x24: return std::make_shared<OPCode24>(addr,dat_content,this);
-                case 0x25: return std::make_shared<OPCode25>(addr,dat_content,this);
-                case 0x26: return std::make_shared<OPCode26>(addr,dat_content,this);
-                case 0x27: return std::make_shared<OPCode27>(addr,dat_content,this);
-                case 0x28: return std::make_shared<OPCode28>(addr,dat_content,this);
-                case 0x29: return std::make_shared<OPCode29>(addr,dat_content,this);
-                case 0x2A: return std::make_shared<OPCode2A>(addr,dat_content,this);
-                case 0x2B: return std::make_shared<OPCode2B>(addr,dat_content,this);
-                case 0x2C: return std::make_shared<OPCode2C>(addr,dat_content,this);
-                case 0x2D: return std::make_shared<OPCode2D>(addr,dat_content,this);
-                case 0x2E: return std::make_shared<OPCode2E>(addr,dat_content,this);
-                case 0x2F: return std::make_shared<OPCode2F>(addr,dat_content,this);
-                case 0x30: return std::make_shared<OPCode30>(addr,dat_content,this);
-                case 0x31: return std::make_shared<OPCode31>(addr,dat_content,this);
-                case 0x32: return std::make_shared<OPCode32>(addr,dat_content,this);
-                case 0x33: return std::make_shared<OPCode33>(addr,dat_content,this);
-                case 0x34: return std::make_shared<OPCode34>(addr,dat_content,this);
-                case 0x35: return std::make_shared<OPCode35>(addr,dat_content,this);
-                case 0x36: return std::make_shared<OPCode36>(addr,dat_content,this);
-                case 0x37: return std::make_shared<OPCode37>(addr,dat_content,this);
-                case 0x38: return std::make_shared<OPCode38>(addr,dat_content,this);
-                case 0x39: return std::make_shared<OPCode39>(addr,dat_content,this);
-                case 0x3A: return std::make_shared<OPCode3A>(addr,dat_content,this);
-                case 0x3B: return std::make_shared<OPCode3B>(addr,dat_content,this);
-                case 0x3C: return std::make_shared<OPCode3C>(addr,dat_content,this);
-                case 0x3D: return std::make_shared<OPCode3D>(addr,dat_content,this);
-                case 0x3E: return std::make_shared<OPCode3E>(addr,dat_content,this);
-                case 0x3F: return std::make_shared<OPCode3F>(addr,dat_content,this);
-                case 0x40: return std::make_shared<OPCode40>(addr,dat_content,this);
-                case 0x41: return std::make_shared<OPCode41>(addr,dat_content,this);
-                case 0x42: return std::make_shared<OPCode42>(addr,dat_content,this);
-                case 0x43: return std::make_shared<OPCode43>(addr,dat_content,this);
-                case 0x44: return std::make_shared<OPCode44>(addr,dat_content,this);
-                case 0x45: return std::make_shared<OPCode45>(addr,dat_content,this);
-                case 0x46: return std::make_shared<OPCode46>(addr,dat_content,this);
-                case 0x47: return std::make_shared<OPCode47>(addr,dat_content,this);
-                case 0x48: return std::make_shared<OPCode48>(addr,dat_content,this);
-                case 0x49: return std::make_shared<OPCode49>(addr,dat_content,this);
-                case 0x4A: return std::make_shared<OPCode4A>(addr,dat_content,this);
-                case 0x4B: return std::make_shared<OPCode4B>(addr,dat_content,this);
-                case 0x4C: return std::make_shared<OPCode4C>(addr,dat_content,this);
-                case 0x4D: return std::make_shared<OPCode4D>(addr,dat_content,this);
-//                case 0x4E: return std::make_shared<OPCode4E>(addr,dat_content,this);
-                case 0x4F: return std::make_shared<OPCode4F>(addr,dat_content,this);
-                case 0x50: return std::make_shared<OPCode50>(addr,dat_content,this);
-                case 0x51: return std::make_shared<OPCode51>(addr,dat_content,this);
-                case 0x52: return std::make_shared<OPCode52>(addr,dat_content,this);
-                case 0x53: return std::make_shared<OPCode53>(addr,dat_content,this);
-//                case 0x54: return std::make_shared<OPCode54>(addr,dat_content,this);
-                case 0x55: return std::make_shared<OPCode55>(addr,dat_content,this);
-                case 0x56: return std::make_shared<OPCode56>(addr,dat_content,this);
-                case 0x57: return std::make_shared<OPCode57>(addr,dat_content,this);
-                case 0x58: return std::make_shared<OPCode58>(addr,dat_content,this);
-//                case 0x59: return std::make_shared<OPCode59>(addr,dat_content,this);
-                case 0x5A: return std::make_shared<OPCode5A>(addr,dat_content,this);
-                case 0x5B: return std::make_shared<OPCode5B>(addr,dat_content,this);
-//                case 0x5C: return std::make_shared<OPCode5C>(addr,dat_content,this);
-                case 0x5D: return std::make_shared<OPCode5D>(addr,dat_content,this);
-                case 0x5E: return std::make_shared<OPCode5E>(addr,dat_content,this);
-                case 0x5F: return std::make_shared<OPCode5F>(addr,dat_content,this);
-                case 0x60: return std::make_shared<OPCode60>(addr,dat_content,this);
-                case 0x61: return std::make_shared<OPCode61>(addr,dat_content,this);
-                //case 0x62: return std::make_shared<OPCode62>(addr,dat_content,this);
-                case 0x63: return std::make_shared<OPCode63>(addr,dat_content,this);
-                case 0x64: return std::make_shared<OPCode64>(addr,dat_content,this);
-                case 0x65: return std::make_shared<OPCode65>(addr,dat_content,this);
-                case 0x66: return std::make_shared<OPCode66>(addr,dat_content,this);
-                case 0x67: return std::make_shared<OPCode67>(addr,dat_content,this);
-                case 0x68: return std::make_shared<OPCode68>(addr,dat_content,this);
-                case 0x69: return std::make_shared<OPCode69>(addr,dat_content,this);
-                case 0x6A: return std::make_shared<OPCode6A>(addr,dat_content,this);
-                case 0x6B: return std::make_shared<OPCode6B>(addr,dat_content,this);
-                case 0x6C: return std::make_shared<OPCode6C>(addr,dat_content,this);
-                case 0x6D: return std::make_shared<OPCode6D>(addr,dat_content,this);
-                case 0x6E: return std::make_shared<OPCode6E>(addr,dat_content,this);
-                case 0x6F: return std::make_shared<OPCode6F>(addr,dat_content,this);
-                case 0x70: return std::make_shared<OPCode70>(addr,dat_content,this);
-//                case 0x71: return std::make_shared<OPCode71>(addr,dat_content,this);
-                case 0x72: return std::make_shared<OPCode72>(addr,dat_content,this);
-                case 0x73: return std::make_shared<OPCode73>(addr,dat_content,this);
-                case 0x74: return std::make_shared<OPCode74>(addr,dat_content,this);
-                case 0x75: return std::make_shared<OPCode75>(addr,dat_content,this);
-//                case 0x76: return std::make_shared<OPCode76>(addr,dat_content,this);
-//                case 0x78: return std::make_shared<OPCode78>(addr,dat_content,this);
-                case 0x79: return std::make_shared<OPCode79>(addr,dat_content,this);
-//                case 0x7A: return std::make_shared<OPCode7A>(addr,dat_content,this);
-                case 0x7B: return std::make_shared<OPCode7B>(addr,dat_content,this);
-//                case 0x7C: return std::make_shared<OPCode7C>(addr,dat_content,this);
-                case 0x7D: return std::make_shared<OPCode7D>(addr,dat_content,this);
-                case 0x7E: return std::make_shared<OPCode7E>(addr,dat_content,this);
-                case 0x7F: return std::make_shared<OPCode7F>(addr,dat_content,this);
-                case 0x80: return std::make_shared<OPCode80>(addr,dat_content,this);
-                case 0x81: return std::make_shared<OPCode81>(addr,dat_content,this);
-                case 0x82: return std::make_shared<OPCode82>(addr,dat_content,this);
-                case 0x83: return std::make_shared<OPCode83>(addr,dat_content,this);
-                case 0x84: return std::make_shared<OPCode84>(addr,dat_content,this);
-                case 0x85: return std::make_shared<OPCode85>(addr,dat_content,this);
-                case 0x86: return std::make_shared<OPCode86>(addr,dat_content,this);
-                case 0x87: return std::make_shared<OPCode87>(addr,dat_content,this);
-                case 0x88: return std::make_shared<OPCode88>(addr,dat_content,this);
-                case 0x89: return std::make_shared<OPCode89>(addr,dat_content,this);
-                case 0x8A: return std::make_shared<OPCode8A>(addr,dat_content,this);
-//                case 0x8B: return std::make_shared<OPCode8B>(addr,dat_content,this);
-                case 0x8C: return std::make_shared<OPCode8C>(addr,dat_content,this);
-                case 0x8D: return std::make_shared<OPCode8D>(addr,dat_content,this);
-                case 0x8E: return std::make_shared<OPCode8E>(addr,dat_content,this);
-                case 0x8F: return std::make_shared<OPCode8F>(addr,dat_content,this);
-                case 0x90: return std::make_shared<OPCode90>(addr,dat_content,this);
-//                case 0x91: return std::make_shared<OPCode91>(addr,dat_content,this);
-                case 0x92: return std::make_shared<OPCode92>(addr,dat_content,this);
-                case 0x93: return std::make_shared<OPCode93>(addr,dat_content,this);
-                case 0x94: return std::make_shared<OPCode94>(addr,dat_content,this);
-                case 0x95: return std::make_shared<OPCode95>(addr,dat_content,this);
-                case 0x96: return std::make_shared<OPCode96>(addr,dat_content,this);
-                case 0x97: return std::make_shared<OPCode97>(addr,dat_content,this);
-//                case 0x98: return std::make_shared<OPCode98>(addr,dat_content,this);
-//                //case 0x99: return std::make_shared<OPCode99>(addr,dat_content,this);
-//                case 0x9A: return std::make_shared<OPCode9A>(addr,dat_content,this);
-                case 0x9B: return std::make_shared<OPCode9B>(addr,dat_content,this);
-//                case 0x9C: return std::make_shared<OPCode9C>(addr,dat_content,this);
-                  case 0x9D: return std::make_shared<OPCode9D>(addr,dat_content,this);
-                case 0x9E: return std::make_shared<OPCode9E>(addr,dat_content,this);
-                case 0x9F: return std::make_shared<OPCode9F>(addr,dat_content,this);
-                case 0xA0: return std::make_shared<OPCodeA0>(addr,dat_content,this);
-                case 0xA1: return std::make_shared<OPCodeA1>(addr,dat_content,this);
-                case 0xA2: return std::make_shared<OPCodeA2>(addr,dat_content,this);
-                case 0xA3: return std::make_shared<OPCodeA3>(addr,dat_content,this);
-                case 0xA4: return std::make_shared<OPCodeA4>(addr,dat_content,this);
-//                case 0xA5: return std::make_shared<OPCodeA5>(addr,dat_content,this);
-                case 0xA6: return std::make_shared<OPCodeA6>(addr,dat_content,this);
-                case 0xA7: return std::make_shared<OPCodeA7>(addr,dat_content,this);
-                case 0xA8: return std::make_shared<OPCodeA8>(addr,dat_content,this);
-                case 0xA9: return std::make_shared<OPCodeA9>(addr,dat_content,this);
-                case 0xAA: return std::make_shared<OPCodeAA>(addr,dat_content,this);
-                case 0xAB: return std::make_shared<OPCodeAB>(addr,dat_content,this);
-                case 0xAC: return std::make_shared<OPCodeAC>(addr,dat_content,this);
-                case 0xAD: return std::make_shared<OPCodeAD>(addr,dat_content,this);
-//                case 0xAE: return std::make_shared<OPCodeAE>(addr,dat_content,this);
-                case 0xAF: return std::make_shared<OPCodeAF>(addr,dat_content,this);
-                case 0xB0: return std::make_shared<OPCodeB0>(addr,dat_content,this);
-                case 0xB1: return std::make_shared<OPCodeB1>(addr,dat_content,this);
-                case 0xB2: return std::make_shared<OPCodeB2>(addr,dat_content,this);
-                case 0xB3: return std::make_shared<OPCodeB3>(addr,dat_content,this);
-//                case 0xB4: return std::make_shared<OPCodeB4>(addr,dat_content,this);
-                case 0xB5: return std::make_shared<OPCodeB5>(addr,dat_content,this);
-                case 0xB6: return std::make_shared<OPCodeB6>(addr,dat_content,this);
-                case 0xB7: return std::make_shared<OPCodeB7>(addr,dat_content,this);
-                case 0xB8: return std::make_shared<OPCodeB8>(addr,dat_content,this);
-                case 0xB9: return std::make_shared<OPCodeB9>(addr,dat_content,this);
-                case 0xBA: return std::make_shared<OPCodeBA>(addr,dat_content,this);
-                case 0xBB: return std::make_shared<OPCodeBB>(addr,dat_content,this);
-                case 0xBC: return std::make_shared<OPCodeBC>(addr,dat_content,this);
-                case 0xBE: return std::make_shared<OPCodeBE>(addr,dat_content,this);
-                case 0xBF: return std::make_shared<OPCodeBF>(addr,dat_content,this);
-                case 0xC0: return std::make_shared<OPCodeC0>(addr,dat_content,this);
-                case 0xC1: return std::make_shared<OPCodeC1>(addr,dat_content,this);
-                case 0xC2: return std::make_shared<OPCodeC2>(addr,dat_content,this);
-                case 0xC3: return std::make_shared<OPCodeC3>(addr,dat_content,this);
-                case 0xC4: return std::make_shared<OPCodeC4>(addr,dat_content,this);
-                case 0xC5: return std::make_shared<OPCodeC5>(addr,dat_content,this);
-                case 0xC7: return std::make_shared<OPCodeC7>(addr,dat_content,this);
-                case 0xC8: return std::make_shared<OPCodeC8>(addr,dat_content,this);
-                case 0xC9: return std::make_shared<OPCodeC9>(addr,dat_content,this);
-                case 0xCA: return std::make_shared<OPCodeCA>(addr,dat_content,this);
+            switch (OP) {
+                case 0x00:
+                    return std::make_shared<OPCode0>(addr, dat_content, this);
+                case 0x01:
+                    return std::make_shared<OPCode1>(addr, dat_content, this);
+                case 0x02:
+                    return std::make_shared<OPCode02>(addr, dat_content, this);
+                case 0x03:
+                    return std::make_shared<OPCode03>(addr, dat_content, this);
+                case 0x04:
+                    return std::make_shared<OPCode04>(addr, dat_content, this);
+                case 0x05:
+                    return std::make_shared<OPCode05>(addr, dat_content, this);
+                case 0x06:
+                    return std::make_shared<OPCode06>(addr, dat_content, this);
+                case 0x07:
+                    return std::make_shared<OPCode07>(addr, dat_content, this);
+                case 0x08:
+                    return std::make_shared<OPCode08>(addr, dat_content, this);
+                case 0x0A:
+                    return std::make_shared<OPCode0A>(addr, dat_content, this);
+                case 0x0C:
+                    return std::make_shared<OPCode0C>(addr, dat_content, this);
+                case 0x0D:
+                    return std::make_shared<OPCode0D>(addr, dat_content, this);
+                case 0x0E:
+                    return std::make_shared<OPCode0E>(addr, dat_content, this);
+                case 0x0F:
+                    return std::make_shared<OPCode0F>(addr, dat_content, this);
+                case 0x10:
+                    return std::make_shared<OPCode10>(addr, dat_content, this);
+                case 0x11:
+                    return std::make_shared<OPCode11>(addr, dat_content, this);
+                case 0x12:
+                    return std::make_shared<OPCode12>(addr, dat_content, this);
+                case 0x13:
+                    return std::make_shared<OPCode13>(addr, dat_content, this);
+                case 0x14:
+                    return std::make_shared<OPCode14>(addr, dat_content, this);
+                case 0x15:
+                    return std::make_shared<OPCode15>(addr, dat_content, this);
+                case 0x16:
+                    return std::make_shared<OPCode16>(addr, dat_content, this);
+                case 0x17:
+                    return std::make_shared<OPCode17>(addr, dat_content, this);
+                case 0x18:
+                    return std::make_shared<OPCode18>(addr, dat_content, this);
+                case 0x19:
+                    return std::make_shared<OPCode19>(addr, dat_content, this);
+                case 0x1A:
+                    return std::make_shared<OPCode1A>(addr, dat_content, this);
+                case 0x1B:
+                    return std::make_shared<OPCode1B>(addr, dat_content, this);
+                case 0x1C:
+                    return std::make_shared<OPCode1C>(addr, dat_content, this);
+                case 0x1D:
+                    return std::make_shared<OPCode1D>(addr, dat_content, this);
+                case 0x1E:
+                    return std::make_shared<OPCode1E>(addr, dat_content, this);
+                case 0x1F:
+                    return std::make_shared<OPCode1F>(addr, dat_content, this);
+                case 0x20:
+                    return std::make_shared<OPCode20>(addr, dat_content, this);
+                    //                case 0x21: return std::make_shared<OPCode21>(addr,dat_content,this);
+                case 0x22:
+                    return std::make_shared<OPCode22>(addr, dat_content, this);
+                case 0x23:
+                    return std::make_shared<OPCode23>(addr, dat_content, this);
+                case 0x24:
+                    return std::make_shared<OPCode24>(addr, dat_content, this);
+                case 0x25:
+                    return std::make_shared<OPCode25>(addr, dat_content, this);
+                case 0x26:
+                    return std::make_shared<OPCode26>(addr, dat_content, this);
+                case 0x27:
+                    return std::make_shared<OPCode27>(addr, dat_content, this);
+                case 0x28:
+                    return std::make_shared<OPCode28>(addr, dat_content, this);
+                case 0x29:
+                    return std::make_shared<OPCode29>(addr, dat_content, this);
+                case 0x2A:
+                    return std::make_shared<OPCode2A>(addr, dat_content, this);
+                case 0x2B:
+                    return std::make_shared<OPCode2B>(addr, dat_content, this);
+                case 0x2C:
+                    return std::make_shared<OPCode2C>(addr, dat_content, this);
+                case 0x2D:
+                    return std::make_shared<OPCode2D>(addr, dat_content, this);
+                case 0x2E:
+                    return std::make_shared<OPCode2E>(addr, dat_content, this);
+                case 0x2F:
+                    return std::make_shared<OPCode2F>(addr, dat_content, this);
+                case 0x30:
+                    return std::make_shared<OPCode30>(addr, dat_content, this);
+                case 0x31:
+                    return std::make_shared<OPCode31>(addr, dat_content, this);
+                case 0x32:
+                    return std::make_shared<OPCode32>(addr, dat_content, this);
+                case 0x33:
+                    return std::make_shared<OPCode33>(addr, dat_content, this);
+                case 0x34:
+                    return std::make_shared<OPCode34>(addr, dat_content, this);
+                case 0x35:
+                    return std::make_shared<OPCode35>(addr, dat_content, this);
+                case 0x36:
+                    return std::make_shared<OPCode36>(addr, dat_content, this);
+                case 0x37:
+                    return std::make_shared<OPCode37>(addr, dat_content, this);
+                case 0x38:
+                    return std::make_shared<OPCode38>(addr, dat_content, this);
+                case 0x39:
+                    return std::make_shared<OPCode39>(addr, dat_content, this);
+                case 0x3A:
+                    return std::make_shared<OPCode3A>(addr, dat_content, this);
+                case 0x3B:
+                    return std::make_shared<OPCode3B>(addr, dat_content, this);
+                case 0x3C:
+                    return std::make_shared<OPCode3C>(addr, dat_content, this);
+                case 0x3D:
+                    return std::make_shared<OPCode3D>(addr, dat_content, this);
+                case 0x3E:
+                    return std::make_shared<OPCode3E>(addr, dat_content, this);
+                case 0x3F:
+                    return std::make_shared<OPCode3F>(addr, dat_content, this);
+                case 0x40:
+                    return std::make_shared<OPCode40>(addr, dat_content, this);
+                case 0x41:
+                    return std::make_shared<OPCode41>(addr, dat_content, this);
+                case 0x42:
+                    return std::make_shared<OPCode42>(addr, dat_content, this);
+                case 0x43:
+                    return std::make_shared<OPCode43>(addr, dat_content, this);
+                case 0x44:
+                    return std::make_shared<OPCode44>(addr, dat_content, this);
+                case 0x45:
+                    return std::make_shared<OPCode45>(addr, dat_content, this);
+                case 0x46:
+                    return std::make_shared<OPCode46>(addr, dat_content, this);
+                case 0x47:
+                    return std::make_shared<OPCode47>(addr, dat_content, this);
+                case 0x48:
+                    return std::make_shared<OPCode48>(addr, dat_content, this);
+                case 0x49:
+                    return std::make_shared<OPCode49>(addr, dat_content, this);
+                case 0x4A:
+                    return std::make_shared<OPCode4A>(addr, dat_content, this);
+                case 0x4B:
+                    return std::make_shared<OPCode4B>(addr, dat_content, this);
+                case 0x4C:
+                    return std::make_shared<OPCode4C>(addr, dat_content, this);
+                case 0x4D:
+                    return std::make_shared<OPCode4D>(addr, dat_content, this);
+                    //                case 0x4E: return std::make_shared<OPCode4E>(addr,dat_content,this);
+                case 0x4F:
+                    return std::make_shared<OPCode4F>(addr, dat_content, this);
+                case 0x50:
+                    return std::make_shared<OPCode50>(addr, dat_content, this);
+                case 0x51:
+                    return std::make_shared<OPCode51>(addr, dat_content, this);
+                case 0x52:
+                    return std::make_shared<OPCode52>(addr, dat_content, this);
+                case 0x53:
+                    return std::make_shared<OPCode53>(addr, dat_content, this);
+                    //                case 0x54: return std::make_shared<OPCode54>(addr,dat_content,this);
+                case 0x55:
+                    return std::make_shared<OPCode55>(addr, dat_content, this);
+                case 0x56:
+                    return std::make_shared<OPCode56>(addr, dat_content, this);
+                case 0x57:
+                    return std::make_shared<OPCode57>(addr, dat_content, this);
+                case 0x58:
+                    return std::make_shared<OPCode58>(addr, dat_content, this);
+                    //                case 0x59: return std::make_shared<OPCode59>(addr,dat_content,this);
+                case 0x5A:
+                    return std::make_shared<OPCode5A>(addr, dat_content, this);
+                case 0x5B:
+                    return std::make_shared<OPCode5B>(addr, dat_content, this);
+                    //                case 0x5C: return std::make_shared<OPCode5C>(addr,dat_content,this);
+                case 0x5D:
+                    return std::make_shared<OPCode5D>(addr, dat_content, this);
+                case 0x5E:
+                    return std::make_shared<OPCode5E>(addr, dat_content, this);
+                case 0x5F:
+                    return std::make_shared<OPCode5F>(addr, dat_content, this);
+                case 0x60:
+                    return std::make_shared<OPCode60>(addr, dat_content, this);
+                case 0x61:
+                    return std::make_shared<OPCode61>(addr, dat_content, this);
+                // case 0x62: return std::make_shared<OPCode62>(addr,dat_content,this);
+                case 0x63:
+                    return std::make_shared<OPCode63>(addr, dat_content, this);
+                case 0x64:
+                    return std::make_shared<OPCode64>(addr, dat_content, this);
+                case 0x65:
+                    return std::make_shared<OPCode65>(addr, dat_content, this);
+                case 0x66:
+                    return std::make_shared<OPCode66>(addr, dat_content, this);
+                case 0x67:
+                    return std::make_shared<OPCode67>(addr, dat_content, this);
+                case 0x68:
+                    return std::make_shared<OPCode68>(addr, dat_content, this);
+                case 0x69:
+                    return std::make_shared<OPCode69>(addr, dat_content, this);
+                case 0x6A:
+                    return std::make_shared<OPCode6A>(addr, dat_content, this);
+                case 0x6B:
+                    return std::make_shared<OPCode6B>(addr, dat_content, this);
+                case 0x6C:
+                    return std::make_shared<OPCode6C>(addr, dat_content, this);
+                case 0x6D:
+                    return std::make_shared<OPCode6D>(addr, dat_content, this);
+                case 0x6E:
+                    return std::make_shared<OPCode6E>(addr, dat_content, this);
+                case 0x6F:
+                    return std::make_shared<OPCode6F>(addr, dat_content, this);
+                case 0x70:
+                    return std::make_shared<OPCode70>(addr, dat_content, this);
+                    //                case 0x71: return std::make_shared<OPCode71>(addr,dat_content,this);
+                case 0x72:
+                    return std::make_shared<OPCode72>(addr, dat_content, this);
+                case 0x73:
+                    return std::make_shared<OPCode73>(addr, dat_content, this);
+                case 0x74:
+                    return std::make_shared<OPCode74>(addr, dat_content, this);
+                case 0x75:
+                    return std::make_shared<OPCode75>(addr, dat_content, this);
+                    //                case 0x76: return std::make_shared<OPCode76>(addr,dat_content,this);
+                    //                case 0x78: return std::make_shared<OPCode78>(addr,dat_content,this);
+                case 0x79:
+                    return std::make_shared<OPCode79>(addr, dat_content, this);
+                    //                case 0x7A: return std::make_shared<OPCode7A>(addr,dat_content,this);
+                case 0x7B:
+                    return std::make_shared<OPCode7B>(addr, dat_content, this);
+                    //                case 0x7C: return std::make_shared<OPCode7C>(addr,dat_content,this);
+                case 0x7D:
+                    return std::make_shared<OPCode7D>(addr, dat_content, this);
+                case 0x7E:
+                    return std::make_shared<OPCode7E>(addr, dat_content, this);
+                case 0x7F:
+                    return std::make_shared<OPCode7F>(addr, dat_content, this);
+                case 0x80:
+                    return std::make_shared<OPCode80>(addr, dat_content, this);
+                case 0x81:
+                    return std::make_shared<OPCode81>(addr, dat_content, this);
+                case 0x82:
+                    return std::make_shared<OPCode82>(addr, dat_content, this);
+                case 0x83:
+                    return std::make_shared<OPCode83>(addr, dat_content, this);
+                case 0x84:
+                    return std::make_shared<OPCode84>(addr, dat_content, this);
+                case 0x85:
+                    return std::make_shared<OPCode85>(addr, dat_content, this);
+                case 0x86:
+                    return std::make_shared<OPCode86>(addr, dat_content, this);
+                case 0x87:
+                    return std::make_shared<OPCode87>(addr, dat_content, this);
+                case 0x88:
+                    return std::make_shared<OPCode88>(addr, dat_content, this);
+                case 0x89:
+                    return std::make_shared<OPCode89>(addr, dat_content, this);
+                case 0x8A:
+                    return std::make_shared<OPCode8A>(addr, dat_content, this);
+                    //                case 0x8B: return std::make_shared<OPCode8B>(addr,dat_content,this);
+                case 0x8C:
+                    return std::make_shared<OPCode8C>(addr, dat_content, this);
+                case 0x8D:
+                    return std::make_shared<OPCode8D>(addr, dat_content, this);
+                case 0x8E:
+                    return std::make_shared<OPCode8E>(addr, dat_content, this);
+                case 0x8F:
+                    return std::make_shared<OPCode8F>(addr, dat_content, this);
+                case 0x90:
+                    return std::make_shared<OPCode90>(addr, dat_content, this);
+                    //                case 0x91: return std::make_shared<OPCode91>(addr,dat_content,this);
+                case 0x92:
+                    return std::make_shared<OPCode92>(addr, dat_content, this);
+                case 0x93:
+                    return std::make_shared<OPCode93>(addr, dat_content, this);
+                case 0x94:
+                    return std::make_shared<OPCode94>(addr, dat_content, this);
+                case 0x95:
+                    return std::make_shared<OPCode95>(addr, dat_content, this);
+                case 0x96:
+                    return std::make_shared<OPCode96>(addr, dat_content, this);
+                case 0x97:
+                    return std::make_shared<OPCode97>(addr, dat_content, this);
+                    //                case 0x98: return std::make_shared<OPCode98>(addr,dat_content,this);
+                    //                //case 0x99: return std::make_shared<OPCode99>(addr,dat_content,this);
+                    //                case 0x9A: return std::make_shared<OPCode9A>(addr,dat_content,this);
+                case 0x9B:
+                    return std::make_shared<OPCode9B>(addr, dat_content, this);
+                    //                case 0x9C: return std::make_shared<OPCode9C>(addr,dat_content,this);
+                case 0x9D:
+                    return std::make_shared<OPCode9D>(addr, dat_content, this);
+                case 0x9E:
+                    return std::make_shared<OPCode9E>(addr, dat_content, this);
+                case 0x9F:
+                    return std::make_shared<OPCode9F>(addr, dat_content, this);
+                case 0xA0:
+                    return std::make_shared<OPCodeA0>(addr, dat_content, this);
+                case 0xA1:
+                    return std::make_shared<OPCodeA1>(addr, dat_content, this);
+                case 0xA2:
+                    return std::make_shared<OPCodeA2>(addr, dat_content, this);
+                case 0xA3:
+                    return std::make_shared<OPCodeA3>(addr, dat_content, this);
+                case 0xA4:
+                    return std::make_shared<OPCodeA4>(addr, dat_content, this);
+                    //                case 0xA5: return std::make_shared<OPCodeA5>(addr,dat_content,this);
+                case 0xA6:
+                    return std::make_shared<OPCodeA6>(addr, dat_content, this);
+                case 0xA7:
+                    return std::make_shared<OPCodeA7>(addr, dat_content, this);
+                case 0xA8:
+                    return std::make_shared<OPCodeA8>(addr, dat_content, this);
+                case 0xA9:
+                    return std::make_shared<OPCodeA9>(addr, dat_content, this);
+                case 0xAA:
+                    return std::make_shared<OPCodeAA>(addr, dat_content, this);
+                case 0xAB:
+                    return std::make_shared<OPCodeAB>(addr, dat_content, this);
+                case 0xAC:
+                    return std::make_shared<OPCodeAC>(addr, dat_content, this);
+                case 0xAD:
+                    return std::make_shared<OPCodeAD>(addr, dat_content, this);
+                    //                case 0xAE: return std::make_shared<OPCodeAE>(addr,dat_content,this);
+                case 0xAF:
+                    return std::make_shared<OPCodeAF>(addr, dat_content, this);
+                case 0xB0:
+                    return std::make_shared<OPCodeB0>(addr, dat_content, this);
+                case 0xB1:
+                    return std::make_shared<OPCodeB1>(addr, dat_content, this);
+                case 0xB2:
+                    return std::make_shared<OPCodeB2>(addr, dat_content, this);
+                case 0xB3:
+                    return std::make_shared<OPCodeB3>(addr, dat_content, this);
+                    //                case 0xB4: return std::make_shared<OPCodeB4>(addr,dat_content,this);
+                case 0xB5:
+                    return std::make_shared<OPCodeB5>(addr, dat_content, this);
+                case 0xB6:
+                    return std::make_shared<OPCodeB6>(addr, dat_content, this);
+                case 0xB7:
+                    return std::make_shared<OPCodeB7>(addr, dat_content, this);
+                case 0xB8:
+                    return std::make_shared<OPCodeB8>(addr, dat_content, this);
+                case 0xB9:
+                    return std::make_shared<OPCodeB9>(addr, dat_content, this);
+                case 0xBA:
+                    return std::make_shared<OPCodeBA>(addr, dat_content, this);
+                case 0xBB:
+                    return std::make_shared<OPCodeBB>(addr, dat_content, this);
+                case 0xBC:
+                    return std::make_shared<OPCodeBC>(addr, dat_content, this);
+                case 0xBE:
+                    return std::make_shared<OPCodeBE>(addr, dat_content, this);
+                case 0xBF:
+                    return std::make_shared<OPCodeBF>(addr, dat_content, this);
+                case 0xC0:
+                    return std::make_shared<OPCodeC0>(addr, dat_content, this);
+                case 0xC1:
+                    return std::make_shared<OPCodeC1>(addr, dat_content, this);
+                case 0xC2:
+                    return std::make_shared<OPCodeC2>(addr, dat_content, this);
+                case 0xC3:
+                    return std::make_shared<OPCodeC3>(addr, dat_content, this);
+                case 0xC4:
+                    return std::make_shared<OPCodeC4>(addr, dat_content, this);
+                case 0xC5:
+                    return std::make_shared<OPCodeC5>(addr, dat_content, this);
+                case 0xC7:
+                    return std::make_shared<OPCodeC7>(addr, dat_content, this);
+                case 0xC8:
+                    return std::make_shared<OPCodeC8>(addr, dat_content, this);
+                case 0xC9:
+                    return std::make_shared<OPCodeC9>(addr, dat_content, this);
+                case 0xCA:
+                    return std::make_shared<OPCodeCA>(addr, dat_content, this);
                 default:
-                std::stringstream stream;
-                stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
+                    std::stringstream stream;
+                    stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << addr;
 
-                error = true;
-                std::string result( stream.str() );
-                qFatal("%s", result.c_str());
+                    error = true;
+                    std::string result(stream.str());
+                    qFatal("%s", result.c_str());
 
-                return std::shared_ptr<Instruction>();
+                    return std::shared_ptr<Instruction>();
             }
         }
 
-        else if (function_type==2){//the function is a "effect" function
+        else if (function_type == 2) { // the function is a "effect" function
 
-            return std::make_shared<EffectsInstr>(addr,dat_content,this);
+            return std::make_shared<EffectsInstr>(addr, dat_content, this);
         }
 
-        else if (function_type==10){
+        else if (function_type == 10) {
 
-            return std::make_shared<AnimeClipTable>(addr,dat_content,this);
-        }
-        else if (function_type==11){
+            return std::make_shared<AnimeClipTable>(addr, dat_content, this);
+        } else if (function_type == 11) {
 
-            return std::make_shared<FieldMonsterData>(addr,dat_content,this);
-        }
-
-        else if (function_type==13){
-
-            return std::make_shared<FC_autoX>(addr,dat_content,this);
-       }
-        else if (function_type==14){
-
-            return std::make_shared<BookData99>(addr,dat_content,this);
-        }
-        else if (function_type==15){
-
-            return std::make_shared<BookDataX>(addr,dat_content,this);
+            return std::make_shared<FieldMonsterData>(addr, dat_content, this);
         }
 
+        else if (function_type == 13) {
+
+            return std::make_shared<FC_autoX>(addr, dat_content, this);
+        } else if (function_type == 14) {
+
+            return std::make_shared<BookData99>(addr, dat_content, this);
+        } else if (function_type == 15) {
+
+            return std::make_shared<BookDataX>(addr, dat_content, this);
+        }
 
         return std::shared_ptr<Instruction>();
     }
-    bool CreateHeaderFromDAT(QByteArray &dat_content){
+    bool CreateHeaderFromDAT(QByteArray& dat_content) {
         display_text("Reading header...");
         uint nb_functions = ReadIntegerFromByteArray(0x14, dat_content);
         uint position_filename = ReadIntegerFromByteArray(0x4, dat_content);
@@ -8784,250 +9562,444 @@ class TXBuilder : public Builder
         QString filename = ReadStringFromByteArray(position, dat_content);
         SceneName = filename;
         int start_offset_area = ReadIntegerFromByteArray(0x8, dat_content);
-        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++){
-            position = start_offset_area + 4*idx_fun;
-            next_position = start_offset_area + 4*(idx_fun+1);
+        for (uint idx_fun = 0; idx_fun < nb_functions; idx_fun++) {
+            position = start_offset_area + 4 * idx_fun;
+            next_position = start_offset_area + 4 * (idx_fun + 1);
             int addr = ReadIntegerFromByteArray(position, dat_content);
-            position = start_offset_area + 4*nb_functions + 2 * idx_fun;
+            position = start_offset_area + 4 * nb_functions + 2 * idx_fun;
             short name_pos = ReadShortFromByteArray(position, dat_content);
             int name_pos_int = name_pos;
             QString function_name = ReadStringFromByteArray(name_pos_int, dat_content);
             int end_addr;
-            if (idx_fun == nb_functions-1) //we are at the last function, so it ends at the end of the file
+            if (idx_fun == nb_functions - 1) // we are at the last function, so it ends at the end of the file
                 end_addr = dat_content.size();
-            else
-            {
+            else {
                 end_addr = ReadIntegerFromByteArray(next_position, dat_content);
             }
-            FunctionsToParse.push_back(function(idx_fun,function_name,name_pos,addr,end_addr));
-
+            FunctionsToParse.push_back(function(idx_fun, function_name, name_pos, addr, end_addr));
         }
         display_text("Header parsed.");
         return true;
     }
-    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int &addr, int row, QXlsx::Document &xls_content){
+    std::shared_ptr<Instruction> CreateInstructionFromXLSX(int& addr, int row, QXlsx::Document& xls_content) {
 
-        uint OP = xls_content.read(row+1, 2).toInt();
+        uint OP = xls_content.read(row + 1, 2).toInt();
         int i = TXUIFiles.indexOf(SceneName);
-        if ((i != -1)&&(OP == 0x13)) return std::make_shared<UI_OP13>(addr,row, xls_content,this);
+        if ((i != -1) && (OP == 0x13)) return std::make_shared<UI_OP13>(addr, row, xls_content, this);
 
-        switch(OP){
-            case 0x00: return std::make_shared<OPCode0>(addr, row, xls_content,this);
-            case 0x01: return std::make_shared<OPCode1>(addr, row, xls_content,this);
-            case 0x02: return std::make_shared<OPCode02>(addr, row, xls_content,this);
-            case 0x03: return std::make_shared<OPCode03>(addr, row, xls_content,this);
-            case 0x04: return std::make_shared<OPCode04>(addr, row, xls_content,this);
-            case 0x05: return std::make_shared<OPCode05>(addr, row, xls_content,this);
-            case 0x06: return std::make_shared<OPCode06>(addr, row, xls_content,this);
-            case 0x07: return std::make_shared<OPCode07>(addr, row, xls_content,this);
-            case 0x08: return std::make_shared<OPCode08>(addr, row, xls_content,this);
-            case 0x0A: return std::make_shared<OPCode0A>(addr, row, xls_content,this);
-            case 0x0C: return std::make_shared<OPCode0C>(addr, row, xls_content,this);
-            case 0x0D: return std::make_shared<OPCode0D>(addr, row, xls_content,this);
-            case 0x0E: return std::make_shared<OPCode0E>(addr, row, xls_content,this);
-            case 0x0F: return std::make_shared<OPCode0F>(addr, row, xls_content,this);
-            case 0x10: return std::make_shared<OPCode10>(addr, row, xls_content,this);
-            case 0x11: return std::make_shared<OPCode11>(addr, row, xls_content,this);
-            case 0x12: return std::make_shared<OPCode12>(addr, row, xls_content,this);
-            case 0x13: return std::make_shared<OPCode13>(addr, row, xls_content,this);
-            case 0x14: return std::make_shared<OPCode14>(addr, row, xls_content,this);
-            case 0x15: return std::make_shared<OPCode15>(addr, row, xls_content,this);
-            case 0x16: return std::make_shared<OPCode16>(addr, row, xls_content,this);
-            case 0x17: return std::make_shared<OPCode17>(addr, row, xls_content,this);
-            case 0x18: return std::make_shared<OPCode18>(addr, row, xls_content,this);
-            case 0x19: return std::make_shared<OPCode19>(addr, row, xls_content,this);
-            case 0x1A: return std::make_shared<OPCode1A>(addr, row, xls_content,this);
-            case 0x1B: return std::make_shared<OPCode1B>(addr, row, xls_content,this);
-            case 0x1C: return std::make_shared<OPCode1C>(addr, row, xls_content,this);
-            case 0x1D: return std::make_shared<OPCode1D>(addr, row, xls_content,this);
-            case 0x1E: return std::make_shared<OPCode1E>(addr, row, xls_content,this);
-            case 0x1F: return std::make_shared<OPCode1F>(addr, row, xls_content,this);
-            case 0x20: return std::make_shared<OPCode20>(addr, row, xls_content,this);
-    //                case 0x21: return std::make_shared<OPCode21>(addr, row, xls_content,this);
-            case 0x22: return std::make_shared<OPCode22>(addr, row, xls_content,this);
-            case 0x23: return std::make_shared<OPCode23>(addr, row, xls_content,this);
-            case 0x24: return std::make_shared<OPCode24>(addr, row, xls_content,this);
-            case 0x25: return std::make_shared<OPCode25>(addr, row, xls_content,this);
-            case 0x26: return std::make_shared<OPCode26>(addr, row, xls_content,this);
-            case 0x27: return std::make_shared<OPCode27>(addr, row, xls_content,this);
-            case 0x28: return std::make_shared<OPCode28>(addr, row, xls_content,this);
-            case 0x29: return std::make_shared<OPCode29>(addr, row, xls_content,this);
-            case 0x2A: return std::make_shared<OPCode2A>(addr, row, xls_content,this);
-            case 0x2B: return std::make_shared<OPCode2B>(addr, row, xls_content,this);
-            case 0x2C: return std::make_shared<OPCode2C>(addr, row, xls_content,this);
-            case 0x2D: return std::make_shared<OPCode2D>(addr, row, xls_content,this);
-            case 0x2E: return std::make_shared<OPCode2E>(addr, row, xls_content,this);
-            case 0x2F: return std::make_shared<OPCode2F>(addr, row, xls_content,this);
-            case 0x30: return std::make_shared<OPCode30>(addr, row, xls_content,this);
-            case 0x31: return std::make_shared<OPCode31>(addr, row, xls_content,this);
-            case 0x32: return std::make_shared<OPCode32>(addr, row, xls_content,this);
-            case 0x33: return std::make_shared<OPCode33>(addr, row, xls_content,this);
-            case 0x34: return std::make_shared<OPCode34>(addr, row, xls_content,this);
-            case 0x35: return std::make_shared<OPCode35>(addr, row, xls_content,this);
-            case 0x36: return std::make_shared<OPCode36>(addr, row, xls_content,this);
-            case 0x37: return std::make_shared<OPCode37>(addr, row, xls_content,this);
-            case 0x38: return std::make_shared<OPCode38>(addr, row, xls_content,this);
-            case 0x39: return std::make_shared<OPCode39>(addr, row, xls_content,this);
-            case 0x3A: return std::make_shared<OPCode3A>(addr, row, xls_content,this);
-            case 0x3B: return std::make_shared<OPCode3B>(addr, row, xls_content,this);
-            case 0x3C: return std::make_shared<OPCode3C>(addr, row, xls_content,this);
-            case 0x3D: return std::make_shared<OPCode3D>(addr, row, xls_content,this);
-            case 0x3E: return std::make_shared<OPCode3E>(addr, row, xls_content,this);
-            case 0x3F: return std::make_shared<OPCode3F>(addr, row, xls_content,this);
-            case 0x40: return std::make_shared<OPCode40>(addr, row, xls_content,this);
-            case 0x41: return std::make_shared<OPCode41>(addr, row, xls_content,this);
-            case 0x42: return std::make_shared<OPCode42>(addr, row, xls_content,this);
-            case 0x43: return std::make_shared<OPCode43>(addr, row, xls_content,this);
-            case 0x44: return std::make_shared<OPCode44>(addr, row, xls_content,this);
-            case 0x45: return std::make_shared<OPCode45>(addr, row, xls_content,this);
-            case 0x46: return std::make_shared<OPCode46>(addr, row, xls_content,this);
-            case 0x47: return std::make_shared<OPCode47>(addr, row, xls_content,this);
-            case 0x48: return std::make_shared<OPCode48>(addr, row, xls_content,this);
-            case 0x49: return std::make_shared<OPCode49>(addr, row, xls_content,this);
-            case 0x4A: return std::make_shared<OPCode4A>(addr, row, xls_content,this);
-            case 0x4B: return std::make_shared<OPCode4B>(addr, row, xls_content,this);
-            case 0x4C: return std::make_shared<OPCode4C>(addr, row, xls_content,this);
-            case 0x4D: return std::make_shared<OPCode4D>(addr, row, xls_content,this);
-    //                case 0x4E: return std::make_shared<OPCode4E>(addr, row, xls_content,this);
-            case 0x4F: return std::make_shared<OPCode4F>(addr, row, xls_content,this);
-            case 0x50: return std::make_shared<OPCode50>(addr, row, xls_content,this);
-            case 0x51: return std::make_shared<OPCode51>(addr, row, xls_content,this);
-            case 0x52: return std::make_shared<OPCode52>(addr, row, xls_content,this);
-            case 0x53: return std::make_shared<OPCode53>(addr, row, xls_content,this);
-    //                case 0x54: return std::make_shared<OPCode54>(addr, row, xls_content,this);
-            case 0x55: return std::make_shared<OPCode55>(addr, row, xls_content,this);
-            case 0x56: return std::make_shared<OPCode56>(addr, row, xls_content,this);
-            case 0x57: return std::make_shared<OPCode57>(addr, row, xls_content,this);
-            case 0x58: return std::make_shared<OPCode58>(addr, row, xls_content,this);
-    //                case 0x59: return std::make_shared<OPCode59>(addr, row, xls_content,this);
-            case 0x5A: return std::make_shared<OPCode5A>(addr, row, xls_content,this);
-            case 0x5B: return std::make_shared<OPCode5B>(addr, row, xls_content,this);
-    //                case 0x5C: return std::make_shared<OPCode5C>(addr, row, xls_content,this);
-            case 0x5D: return std::make_shared<OPCode5D>(addr, row, xls_content,this);
-            case 0x5E: return std::make_shared<OPCode5E>(addr, row, xls_content,this);
-            case 0x5F: return std::make_shared<OPCode5F>(addr, row, xls_content,this);
-            case 0x60: return std::make_shared<OPCode60>(addr, row, xls_content,this);
-            case 0x61: return std::make_shared<OPCode61>(addr, row, xls_content,this);
-    //                case 0x62: return std::make_shared<OPCode62>(addr, row, xls_content,this);
-            case 0x63: return std::make_shared<OPCode63>(addr, row, xls_content,this);
-            case 0x64: return std::make_shared<OPCode64>(addr, row, xls_content,this);
-            case 0x65: return std::make_shared<OPCode65>(addr, row, xls_content,this);
-            case 0x66: return std::make_shared<OPCode66>(addr, row, xls_content,this);
-            case 0x67: return std::make_shared<OPCode67>(addr, row, xls_content,this);
-            case 0x68: return std::make_shared<OPCode68>(addr, row, xls_content,this);
-            case 0x69: return std::make_shared<OPCode69>(addr, row, xls_content,this);
-            case 0x6A: return std::make_shared<OPCode6A>(addr, row, xls_content,this);
-                    case 0x6B: return std::make_shared<OPCode6B>(addr, row, xls_content,this);
-            case 0x6C: return std::make_shared<OPCode6C>(addr, row, xls_content,this);
-                    case 0x6D: return std::make_shared<OPCode6D>(addr, row, xls_content,this);
-            case 0x6E: return std::make_shared<OPCode6E>(addr, row, xls_content,this);
-            case 0x6F: return std::make_shared<OPCode6F>(addr, row, xls_content,this);
-            case 0x70: return std::make_shared<OPCode70>(addr, row, xls_content,this);
-    //                case 0x71: return std::make_shared<OPCode71>(addr, row, xls_content,this);
-            case 0x72: return std::make_shared<OPCode72>(addr, row, xls_content,this);
-            case 0x73: return std::make_shared<OPCode73>(addr, row, xls_content,this);
-            case 0x74: return std::make_shared<OPCode74>(addr, row, xls_content,this);
-            case 0x75: return std::make_shared<OPCode75>(addr, row, xls_content,this);
-    //                case 0x76: return std::make_shared<OPCode76>(addr, row, xls_content,this);
-    //                case 0x78: return std::make_shared<OPCode78>(addr, row, xls_content,this);
-            case 0x79: return std::make_shared<OPCode79>(addr, row, xls_content,this);
-    //                case 0x7A: return std::make_shared<OPCode7A>(addr, row, xls_content,this);
-                    case 0x7B: return std::make_shared<OPCode7B>(addr, row, xls_content,this);
-    //                case 0x7C: return std::make_shared<OPCode7C>(addr, row, xls_content,this);
-              case 0x7D: return std::make_shared<OPCode7D>(addr, row, xls_content,this);
-              case 0x7E: return std::make_shared<OPCode7E>(addr, row, xls_content,this);
-              case 0x7F: return std::make_shared<OPCode7F>(addr, row, xls_content,this);
-            case 0x80: return std::make_shared<OPCode80>(addr, row, xls_content,this);
-            case 0x81: return std::make_shared<OPCode81>(addr, row, xls_content,this);
-            case 0x82: return std::make_shared<OPCode82>(addr, row, xls_content,this);
-            case 0x83: return std::make_shared<OPCode83>(addr, row, xls_content,this);
-            case 0x84: return std::make_shared<OPCode84>(addr, row, xls_content,this);
-            case 0x85: return std::make_shared<OPCode85>(addr, row, xls_content,this);
-            case 0x86: return std::make_shared<OPCode86>(addr, row, xls_content,this);
-            case 0x87: return std::make_shared<OPCode87>(addr, row, xls_content,this);
-            case 0x88: return std::make_shared<OPCode88>(addr, row, xls_content,this);
-            case 0x89: return std::make_shared<OPCode89>(addr, row, xls_content,this);
-            case 0x8A: return std::make_shared<OPCode8A>(addr, row, xls_content,this);
-    //                case 0x8B: return std::make_shared<OPCode8B>(addr, row, xls_content,this);
-            case 0x8C: return std::make_shared<OPCode8C>(addr, row, xls_content,this);
-                    case 0x8D: return std::make_shared<OPCode8D>(addr, row, xls_content,this);
-            case 0x8E: return std::make_shared<OPCode8E>(addr, row, xls_content,this);
-            case 0x8F: return std::make_shared<OPCode8F>(addr, row, xls_content,this);
-            case 0x90: return std::make_shared<OPCode90>(addr, row, xls_content,this);
-    //                case 0x91: return std::make_shared<OPCode91>(addr, row, xls_content,this);
-            case 0x92: return std::make_shared<OPCode92>(addr, row, xls_content,this);
-            case 0x93: return std::make_shared<OPCode93>(addr, row, xls_content,this);
-                    case 0x94: return std::make_shared<OPCode94>(addr, row, xls_content,this);
-            case 0x95: return std::make_shared<OPCode95>(addr, row, xls_content,this);
-            case 0x96: return std::make_shared<OPCode96>(addr, row, xls_content,this);
-            case 0x97: return std::make_shared<OPCode97>(addr, row, xls_content,this);
-    //                case 0x98: return std::make_shared<OPCode98>(addr, row, xls_content,this);
-    //                //case 0x99: return std::make_shared<OPCode99>(addr, row, xls_content,this);
-    //                case 0x9A: return std::make_shared<OPCode9A>(addr, row, xls_content,this);
-            case 0x9B: return std::make_shared<OPCode9B>(addr, row, xls_content,this);
-    //                case 0x9C: return std::make_shared<OPCode9C>(addr, row, xls_content,this);
-            case 0x9D: return std::make_shared<OPCode9D>(addr, row, xls_content,this);
-            case 0x9E: return std::make_shared<OPCode9E>(addr, row, xls_content,this);
-            case 0x9F: return std::make_shared<OPCode9F>(addr, row, xls_content,this);
-            case 0xA0: return std::make_shared<OPCodeA0>(addr, row, xls_content,this);
-            case 0xA1: return std::make_shared<OPCodeA1>(addr, row, xls_content,this);
-            case 0xA2: return std::make_shared<OPCodeA2>(addr, row, xls_content,this);
-            case 0xA3: return std::make_shared<OPCodeA3>(addr, row, xls_content,this);
-            case 0xA4: return std::make_shared<OPCodeA4>(addr, row, xls_content,this);
-    //                case 0xA5: return std::make_shared<OPCodeA5>(addr, row, xls_content,this);
-            case 0xA6: return std::make_shared<OPCodeA6>(addr, row, xls_content,this);
-            case 0xA7: return std::make_shared<OPCodeA7>(addr, row, xls_content,this);
-            case 0xA8: return std::make_shared<OPCodeA8>(addr, row, xls_content,this);
-            case 0xA9: return std::make_shared<OPCodeA9>(addr, row, xls_content,this);
-            case 0xAA: return std::make_shared<OPCodeAA>(addr, row, xls_content,this);
-            case 0xAB: return std::make_shared<OPCodeAB>(addr, row, xls_content,this);
-            case 0xAC: return std::make_shared<OPCodeAC>(addr, row, xls_content,this);
-            case 0xAD: return std::make_shared<OPCodeAD>(addr, row, xls_content,this);
-    //                case 0xAE: return std::make_shared<OPCodeAE>(addr, row, xls_content,this);
-            case 0xAF: return std::make_shared<OPCodeAF>(addr, row, xls_content,this);
-            case 0xB0: return std::make_shared<OPCodeB0>(addr, row, xls_content,this);
-            case 0xB1: return std::make_shared<OPCodeB1>(addr, row, xls_content,this);
-            case 0xB2: return std::make_shared<OPCodeB2>(addr, row, xls_content,this);
-            case 0xB3: return std::make_shared<OPCodeB3>(addr, row, xls_content,this);
-    //                case 0xB4: return std::make_shared<OPCodeB4>(addr, row, xls_content,this);
-            case 0xB5: return std::make_shared<OPCodeB5>(addr, row, xls_content,this);
-            case 0xB6: return std::make_shared<OPCodeB6>(addr, row, xls_content,this);
-            case 0xB7: return std::make_shared<OPCodeB7>(addr, row, xls_content,this);
-            case 0xB8: return std::make_shared<OPCodeB8>(addr, row, xls_content,this);
-            case 0xB9: return std::make_shared<OPCodeB9>(addr, row, xls_content,this);
-            case 0xBA: return std::make_shared<OPCodeBA>(addr, row, xls_content,this);
-            case 0xBB: return std::make_shared<OPCodeBB>(addr, row, xls_content,this);
-            case 0xBC: return std::make_shared<OPCodeBC>(addr, row, xls_content,this);
-            case 0xBE: return std::make_shared<OPCodeBE>(addr, row, xls_content,this);
-            case 0xBF: return std::make_shared<OPCodeBF>(addr, row, xls_content,this);
-            case 0xC0: return std::make_shared<OPCodeC0>(addr, row, xls_content,this);
-            case 0xC1: return std::make_shared<OPCodeC1>(addr, row, xls_content,this);
-            case 0xC2: return std::make_shared<OPCodeC2>(addr, row, xls_content,this);
-            case 0xC3: return std::make_shared<OPCodeC3>(addr, row, xls_content,this);
-            case 0xC4: return std::make_shared<OPCodeC4>(addr, row, xls_content,this);
-            case 0xC5: return std::make_shared<OPCodeC5>(addr, row, xls_content,this);
-            case 0xC7: return std::make_shared<OPCodeC7>(addr, row, xls_content,this);
-            case 0xC8: return std::make_shared<OPCodeC8>(addr, row, xls_content,this);
-            case 0xC9: return std::make_shared<OPCodeC9>(addr, row, xls_content,this);
-            case 0xCA: return std::make_shared<OPCodeCA>(addr, row, xls_content,this);
-            case 256: return std::make_shared<CreateMonsters>(addr, row, xls_content,this);
-            case 257: return std::make_shared<EffectsInstr>(addr, row, xls_content,this);
-            case 258: return std::make_shared<ActionTable>(addr, row, xls_content,this);
-            case 259: return std::make_shared<AlgoTable>(addr, row, xls_content,this);
-            case 260: return std::make_shared<WeaponAttTable>(addr, row, xls_content,this);
-            case 261: return std::make_shared<BreakTable>(addr, row, xls_content,this);
-            case 262: return std::make_shared<SummonTable>(addr, row, xls_content,this);
-            case 263: return std::make_shared<ReactionTable>(addr, row, xls_content,this);
-            case 264: return std::make_shared<PartTable>(addr, row, xls_content,this);
-            case 265: return std::make_shared<AnimeClipTable>(addr, row, xls_content,this);
-            case 266: return std::make_shared<FieldMonsterData>(addr, row, xls_content,this);
-            case 267: return std::make_shared<FieldFollowData>(addr, row, xls_content,this);
-            case 268: return std::make_shared<FC_autoX>(addr, row, xls_content,this);
-            case 269: return std::make_shared<BookData99>(addr, row, xls_content,this);
-            case 270: return std::make_shared<BookDataX>(addr, row, xls_content,this);
-            case 271: return std::make_shared<AddCollision>(addr, row, xls_content,this);
-            case 272: return std::make_shared<ConditionTable>(addr, row, xls_content,this);
-            case 273: return std::make_shared<AnimeClipData>(addr, row, xls_content,this);
+        switch (OP) {
+            case 0x00:
+                return std::make_shared<OPCode0>(addr, row, xls_content, this);
+            case 0x01:
+                return std::make_shared<OPCode1>(addr, row, xls_content, this);
+            case 0x02:
+                return std::make_shared<OPCode02>(addr, row, xls_content, this);
+            case 0x03:
+                return std::make_shared<OPCode03>(addr, row, xls_content, this);
+            case 0x04:
+                return std::make_shared<OPCode04>(addr, row, xls_content, this);
+            case 0x05:
+                return std::make_shared<OPCode05>(addr, row, xls_content, this);
+            case 0x06:
+                return std::make_shared<OPCode06>(addr, row, xls_content, this);
+            case 0x07:
+                return std::make_shared<OPCode07>(addr, row, xls_content, this);
+            case 0x08:
+                return std::make_shared<OPCode08>(addr, row, xls_content, this);
+            case 0x0A:
+                return std::make_shared<OPCode0A>(addr, row, xls_content, this);
+            case 0x0C:
+                return std::make_shared<OPCode0C>(addr, row, xls_content, this);
+            case 0x0D:
+                return std::make_shared<OPCode0D>(addr, row, xls_content, this);
+            case 0x0E:
+                return std::make_shared<OPCode0E>(addr, row, xls_content, this);
+            case 0x0F:
+                return std::make_shared<OPCode0F>(addr, row, xls_content, this);
+            case 0x10:
+                return std::make_shared<OPCode10>(addr, row, xls_content, this);
+            case 0x11:
+                return std::make_shared<OPCode11>(addr, row, xls_content, this);
+            case 0x12:
+                return std::make_shared<OPCode12>(addr, row, xls_content, this);
+            case 0x13:
+                return std::make_shared<OPCode13>(addr, row, xls_content, this);
+            case 0x14:
+                return std::make_shared<OPCode14>(addr, row, xls_content, this);
+            case 0x15:
+                return std::make_shared<OPCode15>(addr, row, xls_content, this);
+            case 0x16:
+                return std::make_shared<OPCode16>(addr, row, xls_content, this);
+            case 0x17:
+                return std::make_shared<OPCode17>(addr, row, xls_content, this);
+            case 0x18:
+                return std::make_shared<OPCode18>(addr, row, xls_content, this);
+            case 0x19:
+                return std::make_shared<OPCode19>(addr, row, xls_content, this);
+            case 0x1A:
+                return std::make_shared<OPCode1A>(addr, row, xls_content, this);
+            case 0x1B:
+                return std::make_shared<OPCode1B>(addr, row, xls_content, this);
+            case 0x1C:
+                return std::make_shared<OPCode1C>(addr, row, xls_content, this);
+            case 0x1D:
+                return std::make_shared<OPCode1D>(addr, row, xls_content, this);
+            case 0x1E:
+                return std::make_shared<OPCode1E>(addr, row, xls_content, this);
+            case 0x1F:
+                return std::make_shared<OPCode1F>(addr, row, xls_content, this);
+            case 0x20:
+                return std::make_shared<OPCode20>(addr, row, xls_content, this);
+                //                case 0x21: return std::make_shared<OPCode21>(addr, row, xls_content,this);
+            case 0x22:
+                return std::make_shared<OPCode22>(addr, row, xls_content, this);
+            case 0x23:
+                return std::make_shared<OPCode23>(addr, row, xls_content, this);
+            case 0x24:
+                return std::make_shared<OPCode24>(addr, row, xls_content, this);
+            case 0x25:
+                return std::make_shared<OPCode25>(addr, row, xls_content, this);
+            case 0x26:
+                return std::make_shared<OPCode26>(addr, row, xls_content, this);
+            case 0x27:
+                return std::make_shared<OPCode27>(addr, row, xls_content, this);
+            case 0x28:
+                return std::make_shared<OPCode28>(addr, row, xls_content, this);
+            case 0x29:
+                return std::make_shared<OPCode29>(addr, row, xls_content, this);
+            case 0x2A:
+                return std::make_shared<OPCode2A>(addr, row, xls_content, this);
+            case 0x2B:
+                return std::make_shared<OPCode2B>(addr, row, xls_content, this);
+            case 0x2C:
+                return std::make_shared<OPCode2C>(addr, row, xls_content, this);
+            case 0x2D:
+                return std::make_shared<OPCode2D>(addr, row, xls_content, this);
+            case 0x2E:
+                return std::make_shared<OPCode2E>(addr, row, xls_content, this);
+            case 0x2F:
+                return std::make_shared<OPCode2F>(addr, row, xls_content, this);
+            case 0x30:
+                return std::make_shared<OPCode30>(addr, row, xls_content, this);
+            case 0x31:
+                return std::make_shared<OPCode31>(addr, row, xls_content, this);
+            case 0x32:
+                return std::make_shared<OPCode32>(addr, row, xls_content, this);
+            case 0x33:
+                return std::make_shared<OPCode33>(addr, row, xls_content, this);
+            case 0x34:
+                return std::make_shared<OPCode34>(addr, row, xls_content, this);
+            case 0x35:
+                return std::make_shared<OPCode35>(addr, row, xls_content, this);
+            case 0x36:
+                return std::make_shared<OPCode36>(addr, row, xls_content, this);
+            case 0x37:
+                return std::make_shared<OPCode37>(addr, row, xls_content, this);
+            case 0x38:
+                return std::make_shared<OPCode38>(addr, row, xls_content, this);
+            case 0x39:
+                return std::make_shared<OPCode39>(addr, row, xls_content, this);
+            case 0x3A:
+                return std::make_shared<OPCode3A>(addr, row, xls_content, this);
+            case 0x3B:
+                return std::make_shared<OPCode3B>(addr, row, xls_content, this);
+            case 0x3C:
+                return std::make_shared<OPCode3C>(addr, row, xls_content, this);
+            case 0x3D:
+                return std::make_shared<OPCode3D>(addr, row, xls_content, this);
+            case 0x3E:
+                return std::make_shared<OPCode3E>(addr, row, xls_content, this);
+            case 0x3F:
+                return std::make_shared<OPCode3F>(addr, row, xls_content, this);
+            case 0x40:
+                return std::make_shared<OPCode40>(addr, row, xls_content, this);
+            case 0x41:
+                return std::make_shared<OPCode41>(addr, row, xls_content, this);
+            case 0x42:
+                return std::make_shared<OPCode42>(addr, row, xls_content, this);
+            case 0x43:
+                return std::make_shared<OPCode43>(addr, row, xls_content, this);
+            case 0x44:
+                return std::make_shared<OPCode44>(addr, row, xls_content, this);
+            case 0x45:
+                return std::make_shared<OPCode45>(addr, row, xls_content, this);
+            case 0x46:
+                return std::make_shared<OPCode46>(addr, row, xls_content, this);
+            case 0x47:
+                return std::make_shared<OPCode47>(addr, row, xls_content, this);
+            case 0x48:
+                return std::make_shared<OPCode48>(addr, row, xls_content, this);
+            case 0x49:
+                return std::make_shared<OPCode49>(addr, row, xls_content, this);
+            case 0x4A:
+                return std::make_shared<OPCode4A>(addr, row, xls_content, this);
+            case 0x4B:
+                return std::make_shared<OPCode4B>(addr, row, xls_content, this);
+            case 0x4C:
+                return std::make_shared<OPCode4C>(addr, row, xls_content, this);
+            case 0x4D:
+                return std::make_shared<OPCode4D>(addr, row, xls_content, this);
+                //                case 0x4E: return std::make_shared<OPCode4E>(addr, row, xls_content,this);
+            case 0x4F:
+                return std::make_shared<OPCode4F>(addr, row, xls_content, this);
+            case 0x50:
+                return std::make_shared<OPCode50>(addr, row, xls_content, this);
+            case 0x51:
+                return std::make_shared<OPCode51>(addr, row, xls_content, this);
+            case 0x52:
+                return std::make_shared<OPCode52>(addr, row, xls_content, this);
+            case 0x53:
+                return std::make_shared<OPCode53>(addr, row, xls_content, this);
+                //                case 0x54: return std::make_shared<OPCode54>(addr, row, xls_content,this);
+            case 0x55:
+                return std::make_shared<OPCode55>(addr, row, xls_content, this);
+            case 0x56:
+                return std::make_shared<OPCode56>(addr, row, xls_content, this);
+            case 0x57:
+                return std::make_shared<OPCode57>(addr, row, xls_content, this);
+            case 0x58:
+                return std::make_shared<OPCode58>(addr, row, xls_content, this);
+                //                case 0x59: return std::make_shared<OPCode59>(addr, row, xls_content,this);
+            case 0x5A:
+                return std::make_shared<OPCode5A>(addr, row, xls_content, this);
+            case 0x5B:
+                return std::make_shared<OPCode5B>(addr, row, xls_content, this);
+                //                case 0x5C: return std::make_shared<OPCode5C>(addr, row, xls_content,this);
+            case 0x5D:
+                return std::make_shared<OPCode5D>(addr, row, xls_content, this);
+            case 0x5E:
+                return std::make_shared<OPCode5E>(addr, row, xls_content, this);
+            case 0x5F:
+                return std::make_shared<OPCode5F>(addr, row, xls_content, this);
+            case 0x60:
+                return std::make_shared<OPCode60>(addr, row, xls_content, this);
+            case 0x61:
+                return std::make_shared<OPCode61>(addr, row, xls_content, this);
+                //                case 0x62: return std::make_shared<OPCode62>(addr, row, xls_content,this);
+            case 0x63:
+                return std::make_shared<OPCode63>(addr, row, xls_content, this);
+            case 0x64:
+                return std::make_shared<OPCode64>(addr, row, xls_content, this);
+            case 0x65:
+                return std::make_shared<OPCode65>(addr, row, xls_content, this);
+            case 0x66:
+                return std::make_shared<OPCode66>(addr, row, xls_content, this);
+            case 0x67:
+                return std::make_shared<OPCode67>(addr, row, xls_content, this);
+            case 0x68:
+                return std::make_shared<OPCode68>(addr, row, xls_content, this);
+            case 0x69:
+                return std::make_shared<OPCode69>(addr, row, xls_content, this);
+            case 0x6A:
+                return std::make_shared<OPCode6A>(addr, row, xls_content, this);
+            case 0x6B:
+                return std::make_shared<OPCode6B>(addr, row, xls_content, this);
+            case 0x6C:
+                return std::make_shared<OPCode6C>(addr, row, xls_content, this);
+            case 0x6D:
+                return std::make_shared<OPCode6D>(addr, row, xls_content, this);
+            case 0x6E:
+                return std::make_shared<OPCode6E>(addr, row, xls_content, this);
+            case 0x6F:
+                return std::make_shared<OPCode6F>(addr, row, xls_content, this);
+            case 0x70:
+                return std::make_shared<OPCode70>(addr, row, xls_content, this);
+                //                case 0x71: return std::make_shared<OPCode71>(addr, row, xls_content,this);
+            case 0x72:
+                return std::make_shared<OPCode72>(addr, row, xls_content, this);
+            case 0x73:
+                return std::make_shared<OPCode73>(addr, row, xls_content, this);
+            case 0x74:
+                return std::make_shared<OPCode74>(addr, row, xls_content, this);
+            case 0x75:
+                return std::make_shared<OPCode75>(addr, row, xls_content, this);
+                //                case 0x76: return std::make_shared<OPCode76>(addr, row, xls_content,this);
+                //                case 0x78: return std::make_shared<OPCode78>(addr, row, xls_content,this);
+            case 0x79:
+                return std::make_shared<OPCode79>(addr, row, xls_content, this);
+                //                case 0x7A: return std::make_shared<OPCode7A>(addr, row, xls_content,this);
+            case 0x7B:
+                return std::make_shared<OPCode7B>(addr, row, xls_content, this);
+                //                case 0x7C: return std::make_shared<OPCode7C>(addr, row, xls_content,this);
+            case 0x7D:
+                return std::make_shared<OPCode7D>(addr, row, xls_content, this);
+            case 0x7E:
+                return std::make_shared<OPCode7E>(addr, row, xls_content, this);
+            case 0x7F:
+                return std::make_shared<OPCode7F>(addr, row, xls_content, this);
+            case 0x80:
+                return std::make_shared<OPCode80>(addr, row, xls_content, this);
+            case 0x81:
+                return std::make_shared<OPCode81>(addr, row, xls_content, this);
+            case 0x82:
+                return std::make_shared<OPCode82>(addr, row, xls_content, this);
+            case 0x83:
+                return std::make_shared<OPCode83>(addr, row, xls_content, this);
+            case 0x84:
+                return std::make_shared<OPCode84>(addr, row, xls_content, this);
+            case 0x85:
+                return std::make_shared<OPCode85>(addr, row, xls_content, this);
+            case 0x86:
+                return std::make_shared<OPCode86>(addr, row, xls_content, this);
+            case 0x87:
+                return std::make_shared<OPCode87>(addr, row, xls_content, this);
+            case 0x88:
+                return std::make_shared<OPCode88>(addr, row, xls_content, this);
+            case 0x89:
+                return std::make_shared<OPCode89>(addr, row, xls_content, this);
+            case 0x8A:
+                return std::make_shared<OPCode8A>(addr, row, xls_content, this);
+                //                case 0x8B: return std::make_shared<OPCode8B>(addr, row, xls_content,this);
+            case 0x8C:
+                return std::make_shared<OPCode8C>(addr, row, xls_content, this);
+            case 0x8D:
+                return std::make_shared<OPCode8D>(addr, row, xls_content, this);
+            case 0x8E:
+                return std::make_shared<OPCode8E>(addr, row, xls_content, this);
+            case 0x8F:
+                return std::make_shared<OPCode8F>(addr, row, xls_content, this);
+            case 0x90:
+                return std::make_shared<OPCode90>(addr, row, xls_content, this);
+                //                case 0x91: return std::make_shared<OPCode91>(addr, row, xls_content,this);
+            case 0x92:
+                return std::make_shared<OPCode92>(addr, row, xls_content, this);
+            case 0x93:
+                return std::make_shared<OPCode93>(addr, row, xls_content, this);
+            case 0x94:
+                return std::make_shared<OPCode94>(addr, row, xls_content, this);
+            case 0x95:
+                return std::make_shared<OPCode95>(addr, row, xls_content, this);
+            case 0x96:
+                return std::make_shared<OPCode96>(addr, row, xls_content, this);
+            case 0x97:
+                return std::make_shared<OPCode97>(addr, row, xls_content, this);
+                //                case 0x98: return std::make_shared<OPCode98>(addr, row, xls_content,this);
+                //                //case 0x99: return std::make_shared<OPCode99>(addr, row, xls_content,this);
+                //                case 0x9A: return std::make_shared<OPCode9A>(addr, row, xls_content,this);
+            case 0x9B:
+                return std::make_shared<OPCode9B>(addr, row, xls_content, this);
+                //                case 0x9C: return std::make_shared<OPCode9C>(addr, row, xls_content,this);
+            case 0x9D:
+                return std::make_shared<OPCode9D>(addr, row, xls_content, this);
+            case 0x9E:
+                return std::make_shared<OPCode9E>(addr, row, xls_content, this);
+            case 0x9F:
+                return std::make_shared<OPCode9F>(addr, row, xls_content, this);
+            case 0xA0:
+                return std::make_shared<OPCodeA0>(addr, row, xls_content, this);
+            case 0xA1:
+                return std::make_shared<OPCodeA1>(addr, row, xls_content, this);
+            case 0xA2:
+                return std::make_shared<OPCodeA2>(addr, row, xls_content, this);
+            case 0xA3:
+                return std::make_shared<OPCodeA3>(addr, row, xls_content, this);
+            case 0xA4:
+                return std::make_shared<OPCodeA4>(addr, row, xls_content, this);
+                //                case 0xA5: return std::make_shared<OPCodeA5>(addr, row, xls_content,this);
+            case 0xA6:
+                return std::make_shared<OPCodeA6>(addr, row, xls_content, this);
+            case 0xA7:
+                return std::make_shared<OPCodeA7>(addr, row, xls_content, this);
+            case 0xA8:
+                return std::make_shared<OPCodeA8>(addr, row, xls_content, this);
+            case 0xA9:
+                return std::make_shared<OPCodeA9>(addr, row, xls_content, this);
+            case 0xAA:
+                return std::make_shared<OPCodeAA>(addr, row, xls_content, this);
+            case 0xAB:
+                return std::make_shared<OPCodeAB>(addr, row, xls_content, this);
+            case 0xAC:
+                return std::make_shared<OPCodeAC>(addr, row, xls_content, this);
+            case 0xAD:
+                return std::make_shared<OPCodeAD>(addr, row, xls_content, this);
+                //                case 0xAE: return std::make_shared<OPCodeAE>(addr, row, xls_content,this);
+            case 0xAF:
+                return std::make_shared<OPCodeAF>(addr, row, xls_content, this);
+            case 0xB0:
+                return std::make_shared<OPCodeB0>(addr, row, xls_content, this);
+            case 0xB1:
+                return std::make_shared<OPCodeB1>(addr, row, xls_content, this);
+            case 0xB2:
+                return std::make_shared<OPCodeB2>(addr, row, xls_content, this);
+            case 0xB3:
+                return std::make_shared<OPCodeB3>(addr, row, xls_content, this);
+                //                case 0xB4: return std::make_shared<OPCodeB4>(addr, row, xls_content,this);
+            case 0xB5:
+                return std::make_shared<OPCodeB5>(addr, row, xls_content, this);
+            case 0xB6:
+                return std::make_shared<OPCodeB6>(addr, row, xls_content, this);
+            case 0xB7:
+                return std::make_shared<OPCodeB7>(addr, row, xls_content, this);
+            case 0xB8:
+                return std::make_shared<OPCodeB8>(addr, row, xls_content, this);
+            case 0xB9:
+                return std::make_shared<OPCodeB9>(addr, row, xls_content, this);
+            case 0xBA:
+                return std::make_shared<OPCodeBA>(addr, row, xls_content, this);
+            case 0xBB:
+                return std::make_shared<OPCodeBB>(addr, row, xls_content, this);
+            case 0xBC:
+                return std::make_shared<OPCodeBC>(addr, row, xls_content, this);
+            case 0xBE:
+                return std::make_shared<OPCodeBE>(addr, row, xls_content, this);
+            case 0xBF:
+                return std::make_shared<OPCodeBF>(addr, row, xls_content, this);
+            case 0xC0:
+                return std::make_shared<OPCodeC0>(addr, row, xls_content, this);
+            case 0xC1:
+                return std::make_shared<OPCodeC1>(addr, row, xls_content, this);
+            case 0xC2:
+                return std::make_shared<OPCodeC2>(addr, row, xls_content, this);
+            case 0xC3:
+                return std::make_shared<OPCodeC3>(addr, row, xls_content, this);
+            case 0xC4:
+                return std::make_shared<OPCodeC4>(addr, row, xls_content, this);
+            case 0xC5:
+                return std::make_shared<OPCodeC5>(addr, row, xls_content, this);
+            case 0xC7:
+                return std::make_shared<OPCodeC7>(addr, row, xls_content, this);
+            case 0xC8:
+                return std::make_shared<OPCodeC8>(addr, row, xls_content, this);
+            case 0xC9:
+                return std::make_shared<OPCodeC9>(addr, row, xls_content, this);
+            case 0xCA:
+                return std::make_shared<OPCodeCA>(addr, row, xls_content, this);
+            case 256:
+                return std::make_shared<CreateMonsters>(addr, row, xls_content, this);
+            case 257:
+                return std::make_shared<EffectsInstr>(addr, row, xls_content, this);
+            case 258:
+                return std::make_shared<ActionTable>(addr, row, xls_content, this);
+            case 259:
+                return std::make_shared<AlgoTable>(addr, row, xls_content, this);
+            case 260:
+                return std::make_shared<WeaponAttTable>(addr, row, xls_content, this);
+            case 261:
+                return std::make_shared<BreakTable>(addr, row, xls_content, this);
+            case 262:
+                return std::make_shared<SummonTable>(addr, row, xls_content, this);
+            case 263:
+                return std::make_shared<ReactionTable>(addr, row, xls_content, this);
+            case 264:
+                return std::make_shared<PartTable>(addr, row, xls_content, this);
+            case 265:
+                return std::make_shared<AnimeClipTable>(addr, row, xls_content, this);
+            case 266:
+                return std::make_shared<FieldMonsterData>(addr, row, xls_content, this);
+            case 267:
+                return std::make_shared<FieldFollowData>(addr, row, xls_content, this);
+            case 268:
+                return std::make_shared<FC_autoX>(addr, row, xls_content, this);
+            case 269:
+                return std::make_shared<BookData99>(addr, row, xls_content, this);
+            case 270:
+                return std::make_shared<BookDataX>(addr, row, xls_content, this);
+            case 271:
+                return std::make_shared<AddCollision>(addr, row, xls_content, this);
+            case 272:
+                return std::make_shared<ConditionTable>(addr, row, xls_content, this);
+            case 273:
+                return std::make_shared<AnimeClipData>(addr, row, xls_content, this);
             default:
                 std::stringstream stream;
                 stream << "L'OP code " << std::hex << OP << " n'est pas défini !! " << this->SceneName.toStdString();
@@ -9041,8 +10013,7 @@ class TXBuilder : public Builder
         }
     }
 
-
-    QByteArray CreateHeaderBytes(){
+    QByteArray CreateHeaderBytes() {
 
         QByteArray header;
 
@@ -9051,43 +10022,43 @@ class TXBuilder : public Builder
         int size_of_scene_name = scene_name_bytes.length();
         header.append(GetBytesFromInt(0x20));
         header.append(GetBytesFromInt(0x20));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name));
-        header.append(GetBytesFromInt(FunctionsParsed.size()*4));
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name));
+        header.append(GetBytesFromInt(FunctionsParsed.size() * 4));
+        header.append(GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4));
         header.append(GetBytesFromInt(FunctionsParsed.size()));
         int length_of_names_section = 0;
-        for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
-        header.append(GetBytesFromInt(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + length_of_names_section));
+        for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++)
+            length_of_names_section = length_of_names_section + FunctionsParsed[idx_fun].name.toUtf8().length() + 1;
+        header.append(
+          GetBytesFromInt(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + length_of_names_section));
         header.append(GetBytesFromInt(0xABCDEF00));
         header.append(scene_name_bytes);
-        if (FunctionsParsed.size()>0){
+        if (FunctionsParsed.size() > 0) {
             QByteArray position_names;
             QByteArray actual_names;
             int offset_names = 0;
-            for (uint idx_fun = 0; idx_fun<FunctionsParsed.size(); idx_fun++) {
+            for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++) {
                 header.append(GetBytesFromInt(FunctionsParsed[idx_fun].actual_addr));
                 QByteArray name = FunctionsParsed[idx_fun].name.toUtf8();
                 name.append('\x0');
-                position_names.append(GetBytesFromShort(0x20+size_of_scene_name + FunctionsParsed.size()*4 + FunctionsParsed.size()*2 + offset_names));
+                position_names.append(
+                  GetBytesFromShort(0x20 + size_of_scene_name + FunctionsParsed.size() * 4 + FunctionsParsed.size() * 2 + offset_names));
                 actual_names.append(name);
                 offset_names = offset_names + name.size();
-
             }
             header.append(position_names);
             header.append(actual_names);
             int multiple = 4;
             if (FunctionsParsed[0].name.startsWith("_")) multiple = 0x10;
-            int nb_byte_to_add = (((int) ceil((float)header.size()/multiple)))*multiple - header.size();
+            int nb_byte_to_add = (((int)ceil((float)header.size() / multiple))) * multiple - header.size();
             QByteArray remaining;
-            for (int i = 0; i < nb_byte_to_add;i++) {
+            for (int i = 0; i < nb_byte_to_add; i++) {
                 remaining.push_back('\x0');
             }
             header.append(remaining);
         }
         return header;
     }
-
 };
-
 
 #endif // TXINSTRUCTIONSSET_H

--- a/headers/decompiler.h
+++ b/headers/decompiler.h
@@ -8,27 +8,24 @@
 #include <QString>
 
 /*
-The Decompiler class is here to write the XLSX and DAT output files, as well as setting some global parameters such as the game name, or run regression tests
-The point is that through the two reading functions, you will build a Translation File object that could then be written in both output format
+The Decompiler class is here to write the XLSX and DAT output files, as well as setting some global parameters such as
+the game name, or run regression tests The point is that through the two reading functions, you will build a Translation
+File object that could then be written in both output format
 
 SetupGame: selects the correct Builder depending on which game name is provided to the program
-ReadXLSX: calls the builder's reading function for XLSX files, then update the pointers (executes the whole reading process in fact)
-ReadDAT: calls the builder's reading function for DAT files, then update the pointers
-ReadFile: selects the correct reading function depending on the provided file path
-UpdateCurrentTF: transfers all functions from the builder to the translation file object
-WriteXLSX: writes the translation file to an xlsx spreadsheet
-WriteDAT: writes the translation file to a dat file readable by the game
-CheckAllFiles: runs a regression test
-GetTF: returns the translation file being edited
-WriteFile: writes the correct file depending on the provided file path
+ReadXLSX: calls the builder's reading function for XLSX files, then update the pointers (executes the whole reading
+process in fact) ReadDAT: calls the builder's reading function for DAT files, then update the pointers ReadFile: selects
+the correct reading function depending on the provided file path UpdateCurrentTF: transfers all functions from the
+builder to the translation file object WriteXLSX: writes the translation file to an xlsx spreadsheet WriteDAT: writes
+the translation file to a dat file readable by the game CheckAllFiles: runs a regression test GetTF: returns the
+translation file being edited WriteFile: writes the correct file depending on the provided file path
 */
-class Decompiler
-{
-public:
+class Decompiler {
+  public:
     Decompiler();
     bool SetupGame(QString Game);
-    bool ReadXLSX(QFile &File);
-    bool ReadDAT(QFile &File);
+    bool ReadXLSX(QFile& File);
+    bool ReadDAT(QFile& File);
     bool ReadFile(QString filepath);
     bool UpdateCurrentTF();
     bool WriteXLSX(QString output_folder);
@@ -37,10 +34,10 @@ public:
     TranslationFile GetTF();
     bool WriteFile(QString filepath, QString output_folder);
 
-private:
+  private:
     TranslationFile CurrentTF;
     QString Game;
-    Builder *IB;
+    Builder* IB;
 };
 
 #endif // READER_H

--- a/headers/functions.h
+++ b/headers/functions.h
@@ -1,33 +1,31 @@
 #ifndef FUNCTIONS_H
 #define FUNCTIONS_H
-#include <QString>
 #include "headers/instruction.h"
+#include <QString>
 /*
 The class function
 */
-class function{
-public:
-    function(){}
-    function(int ID, QString n,int declr_pos,int addr, int end);
+class function {
+  public:
+    function() {}
+    function(int ID, QString n, int declr_pos, int addr, int end);
     void AddInstruction(std::shared_ptr<Instruction> instr);
     void UsingOPCodes(bool is);
     std::vector<std::shared_ptr<Instruction>> InstructionsInFunction;
     QString name;
-    int declr_position; //covers the list of offsets at the beginning
-    int actual_addr; //covers the pointers before that
+    int declr_position; // covers the list of offsets at the beginning
+    int actual_addr;    // covers the pointers before that
     uint end_addr;
     int XLSX_row_index;
-    bool called = false; //by default
+    bool called = false; // by default
     int ID;
-    friend bool operator< (const function &f1, const function &f2);
-    friend bool operator== (const function &f1, const function &f2);
+    friend bool operator<(const function& f1, const function& f2);
+    friend bool operator==(const function& f1, const function& f2);
     int nb_pad;
     void SetAddr(int addr);
     int get_length_in_bytes();
-
-
 };
-std::vector<function>::iterator find_function_by_name(std::vector<function> &v, QString name);
-std::vector<function>::iterator find_function_by_ID(std::vector<function> &v, int ID);
-std::vector<function>::iterator find_function_by_XLSX_row_index(std::vector<function> &v, int row_index);
+std::vector<function>::iterator find_function_by_name(std::vector<function>& v, QString name);
+std::vector<function>::iterator find_function_by_ID(std::vector<function>& v, int ID);
+std::vector<function>::iterator find_function_by_XLSX_row_index(std::vector<function>& v, int row_index);
 #endif // FUNCTIONS_H

--- a/headers/instruction.h
+++ b/headers/instruction.h
@@ -1,44 +1,43 @@
 #ifndef INSTRUCTION_H
 #define INSTRUCTION_H
-#include <QString>
-#include <QDebug>
-#include <cmath>
-#include "headers/operande.h"
 #include "headers/Builder.h"
+#include "headers/operande.h"
+#include <QDebug>
+#include <QString>
+#include <cmath>
 
-#include "xlsxdocument.h"
-#include "xlsxchartsheet.h"
 #include "xlsxcellrange.h"
 #include "xlsxchart.h"
+#include "xlsxchartsheet.h"
+#include "xlsxdocument.h"
 #include "xlsxrichstring.h"
 #include "xlsxworkbook.h"
 
-class Instruction{
-    public:
-        Instruction(int addr, uint OP, Builder *Maker);
-        Instruction(int addr, QString name, uint OP,Builder *Maker);
-        Instruction(int &addr, int idx_row, QXlsx::Document  &excelScenarioSheet, QString name, uint OP,Builder *Maker);
-        virtual ~Instruction();
-        virtual int WriteXLSX(QXlsx::Document &excelScenarioSheet, std::vector<function> funs, int row, int &col);
-        virtual void WriteDat();
-        void AddOperande(operande op);
-        int get_length_in_bytes();
-        int get_Nb_operandes();
-        operande get_operande(int i);
-        uint get_OP();
-        int get_addr_instr();
-        void set_addr_instr(int i);
-        QByteArray getBytes();
-        Builder *Maker;
-        std::vector<operande> operandes;
-        bool error = false;
-    protected:
-        int addr_instr;
-        uint OPCode;
-        QString name;
-        int length_in_bytes;
+class Instruction {
+  public:
+    Instruction(int addr, uint OP, Builder* Maker);
+    Instruction(int addr, QString name, uint OP, Builder* Maker);
+    Instruction(int& addr, int idx_row, QXlsx::Document& excelScenarioSheet, QString name, uint OP, Builder* Maker);
+    virtual ~Instruction();
+    virtual int WriteXLSX(QXlsx::Document& excelScenarioSheet, std::vector<function> funs, int row, int& col);
+    virtual void WriteDat();
+    void AddOperande(operande op);
+    int get_length_in_bytes();
+    int get_Nb_operandes();
+    operande get_operande(int i);
+    uint get_OP();
+    int get_addr_instr();
+    void set_addr_instr(int i);
+    QByteArray getBytes();
+    Builder* Maker;
+    std::vector<operande> operandes;
+    bool error = false;
 
+  protected:
+    int addr_instr;
+    uint OPCode;
+    QString name;
+    int length_in_bytes;
 };
-
 
 #endif // INSTRUCTION_H

--- a/headers/operande.h
+++ b/headers/operande.h
@@ -1,9 +1,9 @@
 #ifndef OPERANDE_H
 #define OPERANDE_H
-#include <QString>
 #include "headers/utilities.h"
-struct Destination{
-    Destination(int FID, int IID, int OID){
+#include <QString>
+struct Destination {
+    Destination(int FID, int IID, int OID) {
         FunctionID = FID;
         InstructionID = IID;
         OperandeID = OID;
@@ -12,62 +12,44 @@ struct Destination{
     int InstructionID;
     int OperandeID;
 };
-class operande{
+class operande {
 
-public:
-    operande(){}
-    operande(Destination pointer, int position, QString type, QByteArray value){
+  public:
+    operande() {}
+    operande(Destination pointer, int position, QString type, QByteArray value) {
         Dest = pointer;
         Position = position;
         Type = type;
         Value = value;
     }
-    operande(int position, QString type, QByteArray value){
+    operande(int position, QString type, QByteArray value) {
         Position = position;
         Type = type;
         Value = value;
     }
-    bool IsPointer(){
-        if ((Dest.FunctionID == -1) || (Dest.InstructionID == -1)) return false;
-        else return true;
+    bool IsPointer() {
+        if ((Dest.FunctionID == -1) || (Dest.InstructionID == -1))
+            return false;
+        else
+            return true;
     }
-    QByteArray getValue(){
-        return Value;
-    }
-    void setValue(QByteArray v){
-        Value = v;
-    }
-    int getIntegerValue(){
-
-        return ReadIntegerFromByteArray(0, Value);
-    }
-    void setBytesToFill(int b){
-        bytes_to_fill = b;
-    }
-    int getBytesToFill(){
-
-        return bytes_to_fill;
-    }
-    int getLength(){
+    QByteArray getValue() { return Value; }
+    void setValue(QByteArray v) { Value = v; }
+    int getIntegerValue() { return ReadIntegerFromByteArray(0, Value); }
+    void setBytesToFill(int b) { bytes_to_fill = b; }
+    int getBytesToFill() { return bytes_to_fill; }
+    int getLength() {
         int size = Value.size();
-        if (Type=="string") size++;
+        if (Type == "string") size++;
         return size;
     }
-    uint getAddr(){
-        return Position;
-    }
-    QString getType(){
-        return Type;
-    }
-    void setDestination(int ID_fun, int ID_instr, int ID_operande){
-        Dest = Destination(ID_fun,ID_instr, ID_operande);
-    }
-    Destination getDestination(){
-        return Dest;
-    }
+    uint getAddr() { return Position; }
+    QString getType() { return Type; }
+    void setDestination(int ID_fun, int ID_instr, int ID_operande) { Dest = Destination(ID_fun, ID_instr, ID_operande); }
+    Destination getDestination() { return Dest; }
 
-private:
-    Destination Dest = Destination(-1,-1,-1);
+  private:
+    Destination Dest = Destination(-1, -1, -1);
     int Position;
     QString Type;
     QByteArray Value;

--- a/headers/translationfile.h
+++ b/headers/translationfile.h
@@ -3,9 +3,8 @@
 
 #include "headers/functions.h"
 
-class TranslationFile
-{
-public:
+class TranslationFile {
+  public:
     TranslationFile();
 
     void setName(QString name);
@@ -14,11 +13,8 @@ public:
     void addFunction(function fun);
     std::vector<function> FunctionsInFile;
 
-
-protected:
-
+  protected:
     QString SceneName;
-
 };
 
 #endif // TRANSLATIONFILE_H

--- a/headers/utilities.h
+++ b/headers/utilities.h
@@ -1,20 +1,19 @@
 #ifndef UTILITIES_H
 #define UTILITIES_H
-#include <QTextCodec>
 #include <QDebug>
+#include <QTextCodec>
 #include <QTextStream>
 #include <iomanip>
 #include <sstream>
 void display_text(QString text);
 
-
-QString ReadStringFromByteArray(int start_pos, QByteArray &content);
-int ReadIntegerFromByteArray(int start_pos, QByteArray &content);
-short ReadShortFromByteArray(int start_pos, QByteArray &content);
-QByteArray ReadSubByteArray(QByteArray &content, int &addr, int size);
-QByteArray ReadStringSubByteArray(QByteArray &content, int &addr);
+QString ReadStringFromByteArray(int start_pos, QByteArray& content);
+int ReadIntegerFromByteArray(int start_pos, QByteArray& content);
+short ReadShortFromByteArray(int start_pos, QByteArray& content);
+QByteArray ReadSubByteArray(QByteArray& content, int& addr, int size);
+QByteArray ReadStringSubByteArray(QByteArray& content, int& addr);
 QString ConvertBytesToString(QByteArray Bytes);
-float QByteArrayToFloat(QByteArray &content);
+float QByteArrayToFloat(QByteArray& content);
 QByteArray GetBytesFromInt(int i);
 QByteArray GetBytesFromFloat(float f);
 QByteArray GetBytesFromShort(short i);

--- a/sources/Builder.cpp
+++ b/sources/Builder.cpp
@@ -1,20 +1,17 @@
 #include "headers/Builder.h"
 #include "headers/functions.h"
-Builder::Builder()
-{
-
-}
-void Builder::ReadFunctionsXLSX(QXlsx::Document &doc){
+Builder::Builder() {}
+void Builder::ReadFunctionsXLSX(QXlsx::Document& doc) {
     SceneName = doc.read(2, 1).toString();
     int first_row = 4;
     int last_row = doc.dimension().lastRow();
     int ID_fun = 0;
 
     QString content_first_cell = doc.read(first_row, 1).toString();
-    if (content_first_cell == "FUNCTION"){
+    if (content_first_cell == "FUNCTION") {
 
         function current_fun;
-        current_fun.name  = doc.read(first_row, 2).toString();
+        current_fun.name = doc.read(first_row, 2).toString();
         current_fun.ID = ID_fun;
         int addr_instr = 0;
         current_fun.declr_position = 0;
@@ -22,32 +19,29 @@ void Builder::ReadFunctionsXLSX(QXlsx::Document &doc){
         current_fun.InstructionsInFunction.clear();
         current_fun.actual_addr = 0;
 
-        for (int idx_row = first_row+1; idx_row < last_row; idx_row++){
+        for (int idx_row = first_row + 1; idx_row < last_row; idx_row++) {
 
             QString content_first_cell = doc.read(idx_row, 1).toString();
-            if (content_first_cell == "FUNCTION"){ //We start a new function
+            if (content_first_cell == "FUNCTION") { // We start a new function
 
                 QString next_fun_name = doc.read(idx_row, 2).toString();
 
                 addr_instr = 0;
                 FunctionsParsed.push_back(current_fun);
-                current_fun.name  = next_fun_name;
+                current_fun.name = next_fun_name;
                 current_fun.ID = ID_fun;
                 current_fun.declr_position = 0;
                 current_fun.XLSX_row_index = idx_row;
                 current_fun.InstructionsInFunction.clear();
                 ID_fun++;
 
-            }
-            else{
+            } else {
 
                 std::shared_ptr<Instruction> instr = CreateInstructionFromXLSX(addr_instr, idx_row, doc);
                 current_fun.AddInstruction(instr);
 
                 idx_row++;
-
             }
-
         }
         int addr_fun = 0;
         FunctionsParsed.push_back(current_fun);
@@ -56,32 +50,33 @@ void Builder::ReadFunctionsXLSX(QXlsx::Document &doc){
 
         int start_header = header.size();
         addr_fun = start_header;
-        for (uint idx_fun = 0; idx_fun<FunctionsParsed.size()-1; idx_fun++){
+        for (uint idx_fun = 0; idx_fun < FunctionsParsed.size() - 1; idx_fun++) {
             FunctionsParsed[idx_fun].actual_addr = addr_fun;
 
             int length = FunctionsParsed[idx_fun].get_length_in_bytes();
 
             FunctionsParsed[idx_fun].end_addr = length + FunctionsParsed[idx_fun].actual_addr;
-            addr_fun =  length + FunctionsParsed[idx_fun].actual_addr;
+            addr_fun = length + FunctionsParsed[idx_fun].actual_addr;
             int multiple = 4;
-            if (isMultiple0x10(FunctionsParsed[idx_fun+1].name)) multiple = 0x10;
+            if (isMultiple0x10(FunctionsParsed[idx_fun + 1].name)) multiple = 0x10;
 
-            int padding = (((int) ceil((float)addr_fun/multiple)))*multiple - addr_fun;
+            int padding = (((int)ceil((float)addr_fun / multiple))) * multiple - addr_fun;
 
             addr_fun = addr_fun + padding;
 
-
-            for (uint idx_instr = 0; idx_instr<FunctionsParsed[idx_fun].InstructionsInFunction.size(); idx_instr++){
-               FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->set_addr_instr(FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->get_addr_instr()+ FunctionsParsed[idx_fun].actual_addr);
+            for (uint idx_instr = 0; idx_instr < FunctionsParsed[idx_fun].InstructionsInFunction.size(); idx_instr++) {
+                FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->set_addr_instr(
+                  FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->get_addr_instr() + FunctionsParsed[idx_fun].actual_addr);
             }
         }
-        FunctionsParsed[FunctionsParsed.size()-1].actual_addr = addr_fun;
-        int length = FunctionsParsed[FunctionsParsed.size()-1].get_length_in_bytes();
-        FunctionsParsed[FunctionsParsed.size()-1].end_addr = length + FunctionsParsed[FunctionsParsed.size()-1].actual_addr;
-        for (uint idx_instr = 0; idx_instr<FunctionsParsed[FunctionsParsed.size()-1].InstructionsInFunction.size(); idx_instr++){
-           FunctionsParsed[FunctionsParsed.size()-1].InstructionsInFunction[idx_instr]->set_addr_instr(FunctionsParsed[FunctionsParsed.size()-1].InstructionsInFunction[idx_instr]->get_addr_instr()+ FunctionsParsed[FunctionsParsed.size()-1].actual_addr);
+        FunctionsParsed[FunctionsParsed.size() - 1].actual_addr = addr_fun;
+        int length = FunctionsParsed[FunctionsParsed.size() - 1].get_length_in_bytes();
+        FunctionsParsed[FunctionsParsed.size() - 1].end_addr = length + FunctionsParsed[FunctionsParsed.size() - 1].actual_addr;
+        for (uint idx_instr = 0; idx_instr < FunctionsParsed[FunctionsParsed.size() - 1].InstructionsInFunction.size(); idx_instr++) {
+            FunctionsParsed[FunctionsParsed.size() - 1].InstructionsInFunction[idx_instr]->set_addr_instr(
+              FunctionsParsed[FunctionsParsed.size() - 1].InstructionsInFunction[idx_instr]->get_addr_instr() +
+              FunctionsParsed[FunctionsParsed.size() - 1].actual_addr);
         }
-
 
         UpdatePointersXLSX();
     }
@@ -89,141 +84,120 @@ void Builder::ReadFunctionsXLSX(QXlsx::Document &doc){
     display_text("XLSX file read.");
 }
 
-void Builder::ReadFunctionsDAT(QByteArray &dat_content){
-    //From what I've seen, some functions in the file don't use OP Codes and it's not very explicit
-    if (FunctionsToParse.size()>0){
-        for (std::vector<function>::iterator it = FunctionsToParse.begin(); it != FunctionsToParse.end(); it++){
-            if (!std::count(FunctionsParsed.begin(), FunctionsParsed.end(), *it)){
-                qDebug() << "Reading function " << it->name;// << "at addr " << hex << it->actual_addr << " and ending at " << hex << it->end_addr;
+void Builder::ReadFunctionsDAT(QByteArray& dat_content) {
+    // From what I've seen, some functions in the file don't use OP Codes and it's not very explicit
+    if (FunctionsToParse.size() > 0) {
+        for (std::vector<function>::iterator it = FunctionsToParse.begin(); it != FunctionsToParse.end(); it++) {
+            if (!std::count(FunctionsParsed.begin(), FunctionsParsed.end(), *it)) {
+                qDebug() << "Reading function "
+                         << it->name; // << "at addr " << hex << it->actual_addr << " and ending at " << hex << it->end_addr;
 
                 std::vector<function>::iterator itt = find_function_by_ID(FunctionsParsed, it->ID);
-                if (itt == FunctionsParsed.end()){ //if we never read it, we'll do that
+                if (itt == FunctionsParsed.end()) { // if we never read it, we'll do that
                     idx_current_fun = it->ID;
-                    ReadIndividualFunction(*it,dat_content);
+                    ReadIndividualFunction(*it, dat_content);
                     FunctionsParsed.push_back(*it);
                 }
                 previous_fun_name = it->name;
             }
-
-
         }
 
         std::sort(FunctionsParsed.begin(), FunctionsParsed.end());
 
         UpdatePointersDAT();
-        int current_addr = FunctionsParsed[0].actual_addr; //first function shouldn't have changed
-        for (uint idx_fun = 1; idx_fun < FunctionsParsed.size(); idx_fun++){
+        int current_addr = FunctionsParsed[0].actual_addr; // first function shouldn't have changed
+        for (uint idx_fun = 1; idx_fun < FunctionsParsed.size(); idx_fun++) {
 
-
-            current_addr = current_addr + FunctionsParsed[idx_fun-1].get_length_in_bytes();
+            current_addr = current_addr + FunctionsParsed[idx_fun - 1].get_length_in_bytes();
             int multiple = 4;
             if (isMultiple0x10(FunctionsParsed[idx_fun].name)) multiple = 0x10;
 
-            int padding = (((int) ceil((float)current_addr/multiple)))*multiple - current_addr;
+            int padding = (((int)ceil((float)current_addr / multiple))) * multiple - current_addr;
             current_addr = current_addr + padding;
             FunctionsParsed[idx_fun].SetAddr(current_addr);
         }
-
-
     }
-
-
 }
-int Builder::ReadIndividualFunction(function &fun,QByteArray &dat_content){
+int Builder::ReadIndividualFunction(function& fun, QByteArray& dat_content) {
     int current_position = fun.actual_addr;
     goal = fun.end_addr;
     std::shared_ptr<Instruction> instr;
     int latest_op_code = 1;
 
-
     int function_type = 0;
-    if (fun.name == "ActionTable"){
+    if (fun.name == "ActionTable") {
         function_type = 3;
-    }
-    else if (fun.name == "AlgoTable"){
+    } else if (fun.name == "AlgoTable") {
         function_type = 4;
-    }
-    else if (fun.name == "WeaponAttTable"){
+    } else if (fun.name == "WeaponAttTable") {
         function_type = 5;
-    }
-    else if (fun.name == "BreakTable"){
+    } else if (fun.name == "BreakTable") {
         function_type = 6;
-    }
-    else if (fun.name == "SummonTable"){
+    } else if (fun.name == "SummonTable") {
         function_type = 7;
-    }
-    else if (fun.name == "ReactionTable"){
+    } else if (fun.name == "ReactionTable") {
         function_type = 8;
-    }
-    else if (fun.name == "PartTable"){
+    } else if (fun.name == "PartTable") {
         function_type = 9;
-    }
-    else if (fun.name == "AnimeClipTable"){
+    } else if (fun.name == "AnimeClipTable") {
         function_type = 10;
-    }
-    else if (fun.name == "FieldMonsterData"){
+    } else if (fun.name == "FieldMonsterData") {
         function_type = 11;
-    }
-    else if (fun.name == "FieldFollowData"){
+    } else if (fun.name == "FieldFollowData") {
         function_type = 12;
-    }
-    else if (fun.name.startsWith("FC_auto")){
+    } else if (fun.name.startsWith("FC_auto")) {
         function_type = 13;
-    }
-    else if (fun.name.startsWith("BookData")){ //Book: the first short read is crucial I think. 0 = text incoming; not zero =
+    } else if (fun.name.startsWith("BookData")) { // Book: the first short read is crucial I think. 0 = text incoming; not zero =
         QRegExp rx("BookData(\\d+[A-Z]?)_(\\d+)");
         std::vector<int> result;
 
         rx.indexIn(fun.name, 0);
         int Nb_Data = rx.cap(2).toInt();
 
-        if (Nb_Data == 99) function_type = 14; //DATA, the 99 is clearly hardcoded; The behaviour is: 99=> two shorts (probably number of pages) and that's it
+        if (Nb_Data == 99)
+            function_type = 14; // DATA, the 99 is clearly hardcoded; The behaviour is: 99=> two shorts (probably number
+                                // of pages) and that's it
 
-        else function_type = 15;
+        else
+            function_type = 15;
 
-    }
-    else if (fun.name.startsWith("_")) {
-        if ((fun.name != "_"+previous_fun_name)||fun.end_addr == static_cast<uint>(dat_content.size())) //last one is for btl1006, cs3; not cool but I'm starting to feel like the "_" functions are just not supposed to exist, so this hack only helps me checking the integrity of the files
+    } else if (fun.name.startsWith("_")) {
+        if ((fun.name != "_" + previous_fun_name) ||
+            fun.end_addr == static_cast<uint>(dat_content.size())) // last one is for btl1006, cs3; not cool but I'm starting to feel
+                                                                   // like the "_" functions are just not supposed to exist, so this
+                                                                   // hack only helps me checking the integrity of the files
         {
-         function_type = 2;
+            function_type = 2;
         }
 
-    }
-    else if (fun.name == "AddCollision"){
+    } else if (fun.name == "AddCollision") {
         function_type = 16;
-    }
-    else if (fun.name == "ConditionTable"){
+    } else if (fun.name == "ConditionTable") {
         function_type = 17;
-    }
-    else if (fun.name.startsWith("StyleName")){
+    } else if (fun.name.startsWith("StyleName")) {
         function_type = 18;
     }
 
+    if (function_type == 0) { // we use OP codes
 
-    if (function_type == 0){ //we use OP codes
-
-
-        while(current_position<goal){
-
-
+        while (current_position < goal) {
 
             instr = CreateInstructionFromDAT(current_position, dat_content, function_type);
 
-            if ((error)||((instr->get_OP() != 0)&&(latest_op_code == 0))){ //this clearly means the function is incorrect or is a monster function.
+            if ((error) || ((instr->get_OP() != 0) &&
+                            (latest_op_code == 0))) { // this clearly means the function is incorrect or is a monster function.
 
                 error = false;
                 fun.InstructionsInFunction.clear();
                 current_position = fun.actual_addr;
-                if (fun.name.startsWith("_")){
+                if (fun.name.startsWith("_")) {
                     instr = CreateInstructionFromDAT(current_position, dat_content, 2);
                     fun.AddInstruction(instr);
                     instr = CreateInstructionFromDAT(current_position, dat_content, 0);
                     fun.AddInstruction(instr);
                     return current_position;
 
-
-                }
-                else{
+                } else {
                     instr = CreateInstructionFromDAT(current_position, dat_content, 1);
 
                     if (flag_monsters) {
@@ -231,160 +205,146 @@ int Builder::ReadIndividualFunction(function &fun,QByteArray &dat_content){
                         instr = CreateInstructionFromDAT(current_position, dat_content, 0);
                         fun.AddInstruction(instr);
                         return current_position;
-                    }
-                    else{
+                    } else {
 
-                        //the function is incorrect, therefore, we parse it again as an OP Code function but remove the part that is incorrect
-                        //qDebug() << "Fail. There is a problem with this function at offset " << hex << current_position;
+                        // the function is incorrect, therefore, we parse it again as an OP Code function but remove the
+                        // part that is incorrect qDebug() << "Fail. There is a problem with this function at offset " <<
+                        // hex << current_position;
                         current_position = fun.actual_addr;
-                        while(current_position<goal){
+                        while (current_position < goal) {
                             instr = CreateInstructionFromDAT(current_position, dat_content, 0);
-                            if (error){
-                                //qFatal("error");
-                                display_text("Incorrect instruction read at " + QString::number(current_position) +". Skipped." );
+                            if (error) {
+                                // qFatal("error");
+                                display_text("Incorrect instruction read at " + QString::number(current_position) + ". Skipped.");
                                 error = false;
 
-                            }
-                            else fun.AddInstruction(instr);
+                            } else
+                                fun.AddInstruction(instr);
                         }
                         return current_position;
                     }
                 }
 
-            }
-            else fun.AddInstruction(instr);
+            } else
+                fun.AddInstruction(instr);
             latest_op_code = instr->get_OP();
-
         }
-    }
-    else
-    {
-        while(current_position<goal){
+    } else {
+        while (current_position < goal) {
 
             instr = CreateInstructionFromDAT(current_position, dat_content, function_type);
             fun.AddInstruction(instr);
             function_type = 0;
-
         }
-
     }
 
     return current_position;
 }
 
-bool Builder::UpdatePointersDAT(){
+bool Builder::UpdatePointersDAT() {
 
-    for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++){
+    for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++) {
 
         std::vector<std::shared_ptr<Instruction>> instructions = FunctionsParsed[idx_fun].InstructionsInFunction;
-        for (uint idx_instr = 0; idx_instr < FunctionsParsed[idx_fun].InstructionsInFunction.size(); idx_instr++){
+        for (uint idx_instr = 0; idx_instr < FunctionsParsed[idx_fun].InstructionsInFunction.size(); idx_instr++) {
 
-            for (uint idx_operand = 0; idx_operand < FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes.size(); idx_operand++){
-                if (FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].getType()=="pointer"){
+            for (uint idx_operand = 0; idx_operand < FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes.size();
+                 idx_operand++) {
+                if (FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].getType() == "pointer") {
 
                     int addr_ptr = FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].getIntegerValue();
                     int idx_fun_ = find_function(addr_ptr);
-                    if (idx_fun_ != -1){
+                    if (idx_fun_ != -1) {
                         function fun = FunctionsParsed[idx_fun_];
-                        int id_instr = find_instruction(addr_ptr,fun);
+                        int id_instr = find_instruction(addr_ptr, fun);
                         int id_op = 0;
-                        if (id_instr != -1)
-                        {
-                            id_op = find_operande(addr_ptr,*fun.InstructionsInFunction[id_instr]);
-                            FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].setDestination(fun.ID, id_instr, id_op);
-                        }
-                        else{
+                        if (id_instr != -1) {
+                            id_op = find_operande(addr_ptr, *fun.InstructionsInFunction[id_instr]);
+                            FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].setDestination(
+                              fun.ID, id_instr, id_op);
+                        } else {
                             FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].setDestination(fun.ID, 0, 0);
                         }
-                    }
-                    else{
+                    } else {
                         FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].setDestination(0, 0, 0);
-
                     }
-
                 }
             }
         }
     }
     qDebug() << "Done";
     return true;
-
 }
-bool Builder::Reset(){
+bool Builder::Reset() {
 
     FunctionsParsed.clear();
     FunctionsToParse.clear();
     return true;
 }
-bool Builder::UpdatePointersXLSX(){
+bool Builder::UpdatePointersXLSX() {
 
-
-    for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++){
+    for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++) {
 
         std::vector<std::shared_ptr<Instruction>> instructions = FunctionsParsed[idx_fun].InstructionsInFunction;
-        for (uint idx_instr = 0; idx_instr < FunctionsParsed[idx_fun].InstructionsInFunction.size(); idx_instr++){
+        for (uint idx_instr = 0; idx_instr < FunctionsParsed[idx_fun].InstructionsInFunction.size(); idx_instr++) {
 
-            for (uint idx_operand = 0; idx_operand < FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes.size(); idx_operand++){
-                if (FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].getType()=="pointer"){
+            for (uint idx_operand = 0; idx_operand < FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes.size();
+                 idx_operand++) {
+                if (FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].getType() == "pointer") {
                     int idx_row_ptr = FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].getIntegerValue();
                     function current_fun = FunctionsParsed[0];
 
-                    if (FunctionsParsed.size()>1){
+                    if (FunctionsParsed.size() > 1) {
 
                         function next_fun = FunctionsParsed[1];
-                        for (uint idx_fun = 1; idx_fun < FunctionsParsed.size(); idx_fun++){
-                            if (idx_row_ptr<next_fun.XLSX_row_index){
+                        for (uint idx_fun = 1; idx_fun < FunctionsParsed.size(); idx_fun++) {
+                            if (idx_row_ptr < next_fun.XLSX_row_index) {
                                 break;
                             }
 
                             current_fun = FunctionsParsed[idx_fun];
-                            if ((idx_fun+1)<FunctionsParsed.size()) next_fun = FunctionsParsed[idx_fun+1];
+                            if ((idx_fun + 1) < FunctionsParsed.size()) next_fun = FunctionsParsed[idx_fun + 1];
                         }
-
-                       }
-                    int nb_instruction_inside_function = (idx_row_ptr-(current_fun.XLSX_row_index+1))/2;
+                    }
+                    int nb_instruction_inside_function = (idx_row_ptr - (current_fun.XLSX_row_index + 1)) / 2;
                     int addr_pointed = current_fun.InstructionsInFunction[nb_instruction_inside_function]->get_addr_instr();
-                    FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].setValue(GetBytesFromInt(addr_pointed));
+                    FunctionsParsed[idx_fun].InstructionsInFunction[idx_instr]->operandes[idx_operand].setValue(
+                      GetBytesFromInt(addr_pointed));
                 }
             }
         }
     }
 
-
-
     return true;
-
 }
-int Builder::find_function(uint addr){
+int Builder::find_function(uint addr) {
     int result = -1;
 
-    for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++){
+    for (uint idx_fun = 0; idx_fun < FunctionsParsed.size(); idx_fun++) {
         uint fun_addr = FunctionsParsed[idx_fun].actual_addr;
 
-        if (addr<fun_addr) {
+        if (addr < fun_addr) {
 
-            result = idx_fun-1;
+            result = idx_fun - 1;
             break;
         }
-
     }
-    if ((result == -1) && (addr <FunctionsParsed[FunctionsParsed.size()-1].end_addr)) result = FunctionsParsed.size()-1;
+    if ((result == -1) && (addr < FunctionsParsed[FunctionsParsed.size() - 1].end_addr)) result = FunctionsParsed.size() - 1;
 
     return result;
 }
-int Builder::find_instruction(uint addr, function fun){
+int Builder::find_instruction(uint addr, function fun) {
     uint result = -1;
     uint idx_instr = 0;
     bool success = false;
-    for (;idx_instr < fun.InstructionsInFunction.size(); idx_instr++){
+    for (; idx_instr < fun.InstructionsInFunction.size(); idx_instr++) {
         uint instr_addr = fun.InstructionsInFunction[idx_instr]->get_addr_instr();
-        if (addr==instr_addr) {
+        if (addr == instr_addr) {
             success = true;
             result = idx_instr;
 
             break;
         }
-
     }
 
     if (!success) {
@@ -394,18 +354,17 @@ int Builder::find_instruction(uint addr, function fun){
 
     return result;
 }
-int Builder::find_operande(uint addr, Instruction instr){//NOT USEFUL! Since we should point towards OP codes exclusively
+int Builder::find_operande(uint addr,
+                           Instruction instr) { // NOT USEFUL! Since we should point towards OP codes exclusively
 
     int idx_operande = 0;
-    for (;idx_operande < instr.get_Nb_operandes(); idx_operande++){
+    for (; idx_operande < instr.get_Nb_operandes(); idx_operande++) {
 
         operande ope = instr.get_operande(idx_operande);
         uint ope_addr = ope.getAddr();
-        if (addr==ope_addr) {
+        if (addr == ope_addr) {
             break;
         }
     }
     return idx_operande;
 }
-
-

--- a/sources/decompiler.cpp
+++ b/sources/decompiler.cpp
@@ -1,42 +1,39 @@
 #include "headers/decompiler.h"
+#include "headers/CS1InstructionsSet.h"
+#include "headers/CS2InstructionsSet.h"
 #include "headers/CS3InstructionsSet.h"
 #include "headers/CS4InstructionsSet.h"
-#include "headers/CS1InstructionsSet.h"
 #include "headers/TXInstructionsSet.h"
-#include "headers/CS2InstructionsSet.h"
-#include "qxlsx/headers/xlsxdocument.h"
-#include "qxlsx/headers/xlsxchartsheet.h"
 #include "qxlsx/headers/xlsxcellrange.h"
 #include "qxlsx/headers/xlsxchart.h"
+#include "qxlsx/headers/xlsxchartsheet.h"
+#include "qxlsx/headers/xlsxdocument.h"
+#include "qxlsx/headers/xlsxformat.h"
 #include "qxlsx/headers/xlsxrichstring.h"
 #include "qxlsx/headers/xlsxworkbook.h"
-#include "qxlsx/headers/xlsxformat.h"
 #include <QColor>
-#include <QDebug>
 #include <QCoreApplication>
+#include <QDebug>
 #include <QDir>
 
 using namespace QXlsx;
 
+Decompiler::Decompiler() {}
 
-Decompiler::Decompiler()
-{
-
-}
-
-bool Decompiler::SetupGame(QString Game_){
+bool Decompiler::SetupGame(QString Game_) {
     Game = Game_;
-    if (Game == "CS3") IB = new CS3Builder();
+    if (Game == "CS3")
+        IB = new CS3Builder();
     else if (Game == "CS1") {
         IB = new CS1Builder();
-    }
-    else if (Game == "CS2") {
+    } else if (Game == "CS2") {
 
         IB = new CS2Builder();
-    }
-    else if (Game == "CS4") IB = new CS4Builder();
-    //else if (Game == "Hajimari") IB = new HajimariBuilder();
-    else if (Game == "TX") IB = new TXBuilder();
+    } else if (Game == "CS4")
+        IB = new CS4Builder();
+    // else if (Game == "Hajimari") IB = new HajimariBuilder();
+    else if (Game == "TX")
+        IB = new TXBuilder();
     else {
         display_text("FAILURE: Unrecognized game specified.");
         return false;
@@ -44,9 +41,8 @@ bool Decompiler::SetupGame(QString Game_){
 
     return true;
 }
-bool Decompiler::ReadXLSX(QFile &File){
+bool Decompiler::ReadXLSX(QFile& File) {
     QFileInfo info(File);
-
 
     if (!File.open(QIODevice::ReadOnly)) return false;
 
@@ -63,16 +59,16 @@ bool Decompiler::ReadXLSX(QFile &File){
     return true;
 }
 
-bool Decompiler::UpdateCurrentTF(){
+bool Decompiler::UpdateCurrentTF() {
     CurrentTF.setName(IB->SceneName);
 
-
     CurrentTF.FunctionsInFile.clear();
-    for (uint idx_fun = 0; idx_fun < IB->FunctionsParsed.size(); idx_fun++) CurrentTF.addFunction(IB->FunctionsParsed[idx_fun]);
+    for (uint idx_fun = 0; idx_fun < IB->FunctionsParsed.size(); idx_fun++)
+        CurrentTF.addFunction(IB->FunctionsParsed[idx_fun]);
 
     return true;
 }
-bool Decompiler::ReadDAT(QFile &File){
+bool Decompiler::ReadDAT(QFile& File) {
 
     if (!File.open(QIODevice::ReadOnly)) {
         return false;
@@ -86,8 +82,7 @@ bool Decompiler::ReadDAT(QFile &File){
     UpdateCurrentTF();
     return true;
 }
-bool Decompiler::WriteDAT(QString folder){
-
+bool Decompiler::WriteDAT(QString folder) {
 
     QByteArray functions, current_fun, file_content;
 
@@ -95,30 +90,27 @@ bool Decompiler::WriteDAT(QString folder){
     QByteArray header = IB->CreateHeaderBytes();
 
     addr = addr + header.size();
-    for (int idx_fun = 0; idx_fun < CurrentTF.getNbFunctions()-1; idx_fun++) {
+    for (int idx_fun = 0; idx_fun < CurrentTF.getNbFunctions() - 1; idx_fun++) {
 
         function fun = CurrentTF.FunctionsInFile[idx_fun];
 
         current_fun.clear();
 
-
         for (uint idx_instr = 0; idx_instr < fun.InstructionsInFunction.size(); idx_instr++) {
             current_fun.push_back(fun.InstructionsInFunction[idx_instr]->getBytes());
-
         }
         addr = addr + current_fun.size();
 
-        int next_addr = CurrentTF.FunctionsInFile[idx_fun+1].actual_addr;
+        int next_addr = CurrentTF.FunctionsInFile[idx_fun + 1].actual_addr;
         int padding = next_addr - addr;
-        for (int i_z = 0; i_z < padding; i_z++) current_fun.push_back('\0');
+        for (int i_z = 0; i_z < padding; i_z++)
+            current_fun.push_back('\0');
         addr = next_addr;
         functions.push_back(current_fun);
-
-
     }
 
-    if (CurrentTF.getNbFunctions()-1>=0){
-        function fun = CurrentTF.FunctionsInFile[CurrentTF.FunctionsInFile.size()-1];
+    if (CurrentTF.getNbFunctions() - 1 >= 0) {
+        function fun = CurrentTF.FunctionsInFile[CurrentTF.FunctionsInFile.size() - 1];
         current_fun.clear();
         for (uint idx_instr = 0; idx_instr < fun.InstructionsInFunction.size(); idx_instr++) {
             current_fun.push_back(fun.InstructionsInFunction[idx_instr]->getBytes());
@@ -132,16 +124,16 @@ bool Decompiler::WriteDAT(QString folder){
     QDir dir(folder);
     if (!dir.exists()) dir.mkpath(".");
 
-    QString output_path = folder + "\\"+CurrentTF.getName() + ".dat";
+    QString output_path = folder + "\\" + CurrentTF.getName() + ".dat";
     QFile file(output_path);
 
     file.open(QIODevice::WriteOnly);
     file.write(file_content);
     file.close();
-    display_text("File "+output_path+" created.");
+    display_text("File " + output_path + " created.");
     return true;
 }
-bool Decompiler::WriteXLSX(QString output_folder){
+bool Decompiler::WriteXLSX(QString output_folder) {
 
     QFont font = QFont("Arial");
     QString filename = CurrentTF.getName() + ".xlsx";
@@ -149,9 +141,9 @@ bool Decompiler::WriteXLSX(QString output_folder){
     Format format;
     format.setFont(font);
     format.setFontBold(true);
-    QColor DarkYellow = QColor(qRgb(255,222,155));
+    QColor DarkYellow = QColor(qRgb(255, 222, 155));
     format.setPatternBackgroundColor(DarkYellow);
-    QColor FontColor = QColor(qRgb(255,0,0));
+    QColor FontColor = QColor(qRgb(255, 0, 0));
 
     format.setFontColor(FontColor);
     format.setFontSize(14);
@@ -167,7 +159,7 @@ bool Decompiler::WriteXLSX(QString output_folder){
 
     Format rowFormat;
     rowFormat.setFillPattern(Format::PatternSolid);
-    rowFormat.setPatternBackgroundColor(qRgb(255,255,200));
+    rowFormat.setPatternBackgroundColor(qRgb(255, 255, 200));
     rowFormat.setFont(font);
     rowFormat.setFontSize(10);
     excelScenarioSheet.setRowFormat(1, 3, format);
@@ -177,7 +169,7 @@ bool Decompiler::WriteXLSX(QString output_folder){
     Format formatTitleChars;
     formatTitleChars.setFont(font);
     formatTitleChars.setFontSize(10);
-    formatTitleChars.setPatternBackgroundColor(qRgb(255,255,200));
+    formatTitleChars.setPatternBackgroundColor(qRgb(255, 255, 200));
     formatTitleChars.setHorizontalAlignment(Format::AlignHCenter);
     formatTitleChars.setVerticalAlignment(Format::AlignVCenter);
 
@@ -185,66 +177,67 @@ bool Decompiler::WriteXLSX(QString output_folder){
     FormatTitleColumnChars.setHorizontalAlignment(Format::AlignHCenter);
     FormatTitleColumnChars.setVerticalAlignment(Format::AlignVCenter);
     FormatTitleColumnChars.setFontSize(10);
-    FormatTitleColumnChars.setPatternBackgroundColor(qRgb(255,255,200));
+    FormatTitleColumnChars.setPatternBackgroundColor(qRgb(255, 255, 200));
     FormatTitleColumnChars.setTopBorderStyle(Format::BorderThin);
     FormatTitleColumnChars.setBottomBorderStyle(Format::BorderThin);
     FormatTitleColumnChars.setLeftBorderStyle(Format::BorderThin);
     FormatTitleColumnChars.setRightBorderStyle(Format::BorderThin);
     FormatTitleColumnChars.setFont(font);
     FormatTitleColumnChars.setFontSize(10);
-    FormatTitleColumnChars.setPatternBackgroundColor(qRgb(255,255,255));
+    FormatTitleColumnChars.setPatternBackgroundColor(qRgb(255, 255, 255));
 
     FormatTitleColumnChars.setBottomBorderStyle(Format::BorderThin);
     FormatTitleColumnChars.setLeftBorderStyle(Format::BorderThin);
     FormatTitleColumnChars.setRightBorderStyle(Format::BorderThin);
     FormatTitleColumnChars.setTopBorderStyle(Format::BorderThin);
     Format rowFormatFunctions;
-    rowFormatFunctions.setPatternBackgroundColor(qRgb(255,200,200));
+    rowFormatFunctions.setPatternBackgroundColor(qRgb(255, 200, 200));
     rowFormatFunctions.setFont(font);
     rowFormatFunctions.setFontSize(13);
     rowFormatFunctions.setBottomBorderStyle(QXlsx::Format::BorderThin);
 
     rowFormatFunctions.setTopBorderStyle(QXlsx::Format::BorderThin);
     int excel_row = 4;
-    for (uint idx_fun=0; idx_fun<CurrentTF.FunctionsInFile.size(); idx_fun++){
+    for (uint idx_fun = 0; idx_fun < CurrentTF.FunctionsInFile.size(); idx_fun++) {
         function fun = CurrentTF.FunctionsInFile[idx_fun];
         excelScenarioSheet.setRowFormat(excel_row, excel_row, rowFormatFunctions);
-        excelScenarioSheet.write(excel_row,1,"FUNCTION");
-        excelScenarioSheet.write(excel_row,2,fun.name);
+        excelScenarioSheet.write(excel_row, 1, "FUNCTION");
+        excelScenarioSheet.write(excel_row, 2, fun.name);
 
         excel_row++;
-        for (uint idx_instr=0; idx_instr<fun.InstructionsInFunction.size(); idx_instr++){
+        for (uint idx_instr = 0; idx_instr < fun.InstructionsInFunction.size(); idx_instr++) {
             excelScenarioSheet.write(excel_row, 1, "Location");
-            excelScenarioSheet.write(excel_row+1, 1, fun.InstructionsInFunction[idx_instr]->get_addr_instr());
+            excelScenarioSheet.write(excel_row + 1, 1, fun.InstructionsInFunction[idx_instr]->get_addr_instr());
             int col = 0;
-            fun.InstructionsInFunction[idx_instr]->WriteXLSX(excelScenarioSheet,CurrentTF.FunctionsInFile, excel_row, col);
-            excel_row+=2;
+            fun.InstructionsInFunction[idx_instr]->WriteXLSX(excelScenarioSheet, CurrentTF.FunctionsInFile, excel_row, col);
+            excel_row += 2;
         }
     }
 
     QString xlsx_output_file = QDir::toNativeSeparators(output_folder + "/" + filename);
 
-    display_text("File " +xlsx_output_file + " created.");
+    display_text("File " + xlsx_output_file + " created.");
     QDir dir(output_folder);
     if (!dir.exists()) dir.mkpath(".");
     excelScenarioSheet.saveAs(xlsx_output_file);
     return true;
 }
 
+bool Decompiler::CheckAllFiles(QStringList filesToRead,
+                               QString folder_for_reference,
+                               QString folder_for_generated_files,
+                               QString output_folder) {
+    QFile file("C:\\Users\\Antoine\\Desktop\\log.txt");
 
+    QTextStream stream(&file);
+    file.remove();
+    file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text);
 
-bool Decompiler::CheckAllFiles(QStringList filesToRead, QString folder_for_reference, QString folder_for_generated_files,QString output_folder){
-        QFile file("C:\\Users\\Antoine\\Desktop\\log.txt");
+    foreach (QString file_, filesToRead) {
 
-        QTextStream stream(&file);
-        file.remove();
-        file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text);
-
-    foreach(QString file_, filesToRead) {
-
-        QString full_path = folder_for_reference +"/" + file_;
+        QString full_path = folder_for_reference + "/" + file_;
         QString filename = full_path.mid(full_path.lastIndexOf("/"));
-        QString croped_fileName = filename.section(".",0,0);
+        QString croped_fileName = filename.section(".", 0, 0);
         qDebug() << "Checking " << full_path;
         QString full_path_ref = folder_for_reference + filename;
         stream << full_path << "\n";
@@ -258,9 +251,9 @@ bool Decompiler::CheckAllFiles(QStringList filesToRead, QString folder_for_refer
         qDebug() << "writing dat file";
         this->WriteDAT(output_folder);
         qDebug() << "full done";
-        qDebug() << "reading dat file" << folder_for_generated_files + "/recompiled_files"+ filename;
+        qDebug() << "reading dat file" << folder_for_generated_files + "/recompiled_files" + filename;
         qDebug() << "reading dat file" << full_path_ref;
-        QFile file1(folder_for_generated_files + "/release/recompiled_files"+ filename);
+        QFile file1(folder_for_generated_files + "/release/recompiled_files" + filename);
         QFile file2(full_path_ref);
         if (!file1.open(QIODevice::ReadOnly)) {
 
@@ -276,56 +269,56 @@ bool Decompiler::CheckAllFiles(QStringList filesToRead, QString folder_for_refer
         QByteArray content2 = file2.readAll();
         std::string msg = "Problème de taille avec " + croped_fileName.toStdString();
         int ref_size = content2.size();
-        for (int i=0; i< ref_size; i++){
-            if (content1[i]!=content2[i]) {
+        for (int i = 0; i < ref_size; i++) {
+            if (content1[i] != content2[i]) {
                 stream << "Mismatch at " << Qt::hex << i << " " << (int)content1[i] << " should be " << (int)content2[i] << "\n";
                 qDebug() << "Mismatch at " << Qt::hex << i << " " << (int)content1[i] << " should be " << (int)content2[i] << "\n";
             }
         }
-        if (content1.size()<ref_size) {
+        if (content1.size() < ref_size) {
             qFatal("size too short");
-            stream << "size too short" << "\n";
-        }
-        else{
+            stream << "size too short"
+                   << "\n";
+        } else {
 
-            if (content1.size()>ref_size) {
+            if (content1.size() > ref_size) {
                 qFatal("size too big");
-                stream << "too big" << "\n";
+                stream << "too big"
+                       << "\n";
             }
-
         }
         stream << " Size 1: " << Qt::hex << content1.size() << " vs Size 2: " << Qt::hex << content2.size();
-
-
     }
     return true;
 }
-bool Decompiler::ReadFile(QString filepath){
+bool Decompiler::ReadFile(QString filepath) {
     IB->Reset();
     CurrentTF = TranslationFile();
     QFile file(filepath);
     QFileInfo infoFile(file);
 
-    if (infoFile.suffix()=="xlsx") ReadXLSX(file);
-    else if (infoFile.suffix()=="dat") ReadDAT(file);
+    if (infoFile.suffix() == "xlsx")
+        ReadXLSX(file);
+    else if (infoFile.suffix() == "dat")
+        ReadDAT(file);
     else {
         display_text("FAILURE: Unrecognized extension.");
         return false;
     }
     return true;
 }
-bool Decompiler::WriteFile(QString filepath, QString output_folder){
+bool Decompiler::WriteFile(QString filepath, QString output_folder) {
 
     QFile file(filepath);
     QFileInfo infoFile(file);
-    if (infoFile.suffix()=="dat") WriteXLSX(output_folder);
-    else if (infoFile.suffix()=="xlsx") WriteDAT(output_folder);
+    if (infoFile.suffix() == "dat")
+        WriteXLSX(output_folder);
+    else if (infoFile.suffix() == "xlsx")
+        WriteDAT(output_folder);
     else {
         display_text("FAILURE: Unrecognized extension.");
         return false;
     }
     return true;
 }
-TranslationFile Decompiler::GetTF(){
-    return CurrentTF;
-}
+TranslationFile Decompiler::GetTF() { return CurrentTF; }

--- a/sources/functions.cpp
+++ b/sources/functions.cpp
@@ -1,7 +1,7 @@
 
 #include "headers/functions.h"
 
-function::function(int ID, QString n,int declr_pos,int addr, int end){
+function::function(int ID, QString n, int declr_pos, int addr, int end) {
     this->ID = ID;
     name = n;
     declr_position = declr_pos;
@@ -9,37 +9,29 @@ function::function(int ID, QString n,int declr_pos,int addr, int end){
     this->end_addr = end;
     int multiple = 4;
     if (isMultiple0x10(this->name)) multiple = 0x10;
-    int nb_byte_to_add = (((int) ceil((float)addr/multiple)))*multiple - addr;
+    int nb_byte_to_add = (((int)ceil((float)addr / multiple))) * multiple - addr;
     nb_pad = nb_byte_to_add;
 }
-void function::AddInstruction(std::shared_ptr<Instruction> instr){
+void function::AddInstruction(std::shared_ptr<Instruction> instr) {
     if (instr->get_OP() > 0) InstructionsInFunction.push_back(instr);
 }
 
-
-bool operator< (const function &f1, const function &f2)
-{
-    return f1.actual_addr < f2.actual_addr;
-}
-void function::SetAddr(int addr){
-    this->actual_addr = addr;
-}
-int function::get_length_in_bytes(){
+bool operator<(const function& f1, const function& f2) { return f1.actual_addr < f2.actual_addr; }
+void function::SetAddr(int addr) { this->actual_addr = addr; }
+int function::get_length_in_bytes() {
 
     int length_in_bytes = 0;
-    for (std::vector<std::shared_ptr<Instruction>>::iterator it = InstructionsInFunction.begin(); it!=InstructionsInFunction.end();it++) length_in_bytes = length_in_bytes+(*it)->get_length_in_bytes();
+    for (std::vector<std::shared_ptr<Instruction>>::iterator it = InstructionsInFunction.begin(); it != InstructionsInFunction.end(); it++)
+        length_in_bytes = length_in_bytes + (*it)->get_length_in_bytes();
     return length_in_bytes;
 }
-bool operator== (const function &f1, const function &f2)
-{
-    return f1.ID == f2.ID;
+bool operator==(const function& f1, const function& f2) { return f1.ID == f2.ID; }
+std::vector<function>::iterator find_function_by_name(std::vector<function>& v, QString name) {
+    return find_if(v.begin(), v.end(), [&name](const function& obj) { return obj.name == name; });
 }
-std::vector<function>::iterator find_function_by_name(std::vector<function> &v, QString name){
-    return find_if(v.begin(), v.end(), [&name](const function& obj) {return obj.name == name;});
+std::vector<function>::iterator find_function_by_ID(std::vector<function>& v, int ID) {
+    return find_if(v.begin(), v.end(), [&ID](const function& obj) { return obj.ID == ID; });
 }
-std::vector<function>::iterator find_function_by_ID(std::vector<function> &v, int ID){
-    return find_if(v.begin(), v.end(), [&ID](const function& obj) {return obj.ID == ID;});
-}
-std::vector<function>::iterator find_function_by_XLSX_row_index(std::vector<function> &v, int row_index){
-    return find_if(v.begin(), v.end(), [&row_index](const function& obj) {return obj.XLSX_row_index == row_index;});
+std::vector<function>::iterator find_function_by_XLSX_row_index(std::vector<function>& v, int row_index) {
+    return find_if(v.begin(), v.end(), [&row_index](const function& obj) { return obj.XLSX_row_index == row_index; });
 }

--- a/sources/instruction.cpp
+++ b/sources/instruction.cpp
@@ -1,138 +1,118 @@
 #include "headers/instruction.h"
 #include "headers/functions.h"
-#include "headers/utilities.h"
 #include "headers/global_vars.h"
+#include "headers/utilities.h"
 
-Instruction::Instruction(int addr, uint OP, Builder *Maker)
-{
-            OPCode = OP;
-            this->Maker = Maker;
-            this->addr_instr = addr;
+Instruction::Instruction(int addr, uint OP, Builder* Maker) {
+    OPCode = OP;
+    this->Maker = Maker;
+    this->addr_instr = addr;
 }
-Instruction::Instruction(int addr, QString name, uint OP, Builder *Maker){
-     this->addr_instr = addr;
-     OPCode = OP;
-     this->name = name;
-     this->Maker = Maker;
+Instruction::Instruction(int addr, QString name, uint OP, Builder* Maker) {
+    this->addr_instr = addr;
+    OPCode = OP;
+    this->name = name;
+    this->Maker = Maker;
 }
-Instruction::~Instruction(){
+Instruction::~Instruction() {}
+Instruction::Instruction(int& addr, int idx_row, QXlsx::Document& excelScenarioSheet, QString name, uint OP, Builder* Maker) {
+    this->name = name;
+    this->OPCode = OP;
+    this->Maker = Maker;
+    addr_instr = addr;
+    if (OPCode <= 0xFF) addr++;
 
-}
-Instruction::Instruction(int &addr, int idx_row, QXlsx::Document  &excelScenarioSheet, QString name, uint OP,Builder *Maker){
-        this->name = name;
-        this->OPCode = OP;
-        this->Maker = Maker;
-        addr_instr = addr;
-        if (OPCode<=0xFF) addr++;
+    int idx_operande = 3;
+    QString type = excelScenarioSheet.read(idx_row, idx_operande).toString();
+    while (!type.isEmpty()) {
 
-        int idx_operande = 3;
-        QString type = excelScenarioSheet.read(idx_row, idx_operande).toString();
-        while(!type.isEmpty()){
+        QByteArray Value;
+        operande op;
+        if (type == "int") {
+            int Operande = excelScenarioSheet.read(idx_row + 1, idx_operande).toInt();
 
-            QByteArray Value;
-            operande op;
-            if (type == "int"){
-                int Operande = excelScenarioSheet.read(idx_row+1, idx_operande).toInt();
+            Value = GetBytesFromInt(Operande);
+            op = operande(addr, "int", Value);
 
-                Value = GetBytesFromInt(Operande);
-                op = operande(addr,"int", Value);
+        } else if (type == "float") {
 
-            }
-            else if (type == "float"){
+            float Operande = excelScenarioSheet.read(idx_row + 1, idx_operande).toFloat();
 
-                float Operande = excelScenarioSheet.read(idx_row+1, idx_operande).toFloat();
+            Value = GetBytesFromFloat(Operande);
+            op = operande(addr, "float", Value);
+        } else if (type == "short") {
+            ushort Operande = excelScenarioSheet.read(idx_row + 1, idx_operande).toInt();
+            Value = GetBytesFromShort(Operande);
+            op = operande(addr, "short", Value);
 
-                Value = GetBytesFromFloat(Operande);
-                op = operande(addr,"float", Value);
-            }
-            else if (type == "short"){
-                ushort Operande = excelScenarioSheet.read(idx_row+1, idx_operande).toInt();
-                Value = GetBytesFromShort(Operande);
-                op = operande(addr,"short", Value);
+        } else if ((type == "byte") || (type == "OP Code")) {
+            int OP = excelScenarioSheet.read(idx_row + 1, idx_operande).toInt();
 
-            }
-            else if ((type == "byte")||(type == "OP Code")){
-                int OP = excelScenarioSheet.read(idx_row+1, idx_operande).toInt();
-
-
-                if (OP<=0xFF){ // actually the opposite never happens.
-                unsigned char Operande = ((OP)& 0x000000FF);
+            if (OP <= 0xFF) { // actually the opposite never happens.
+                unsigned char Operande = ((OP)&0x000000FF);
                 Value.push_back(Operande);
-                op = operande(addr,"byte", Value);}
+                op = operande(addr, "byte", Value);
             }
-            else if (type == "fill"){
+        } else if (type == "fill") {
 
-                QString Operande_prev = excelScenarioSheet.read(idx_row+1, idx_operande-1).toString();
-                QString Operande = excelScenarioSheet.read(idx_row+1, idx_operande).toString();
-                QString str_max_length = Operande.mid(1,Operande.indexOf('-')-1);
+            QString Operande_prev = excelScenarioSheet.read(idx_row + 1, idx_operande - 1).toString();
+            QString Operande = excelScenarioSheet.read(idx_row + 1, idx_operande).toString();
+            QString str_max_length = Operande.mid(1, Operande.indexOf('-') - 1);
 
-                //apparently it is not possible to get the result of the formula...
+            // apparently it is not possible to get the result of the formula...
 
-                for (int id = 0; id < str_max_length.toInt()-Operande_prev.toUtf8().size()-1; id++) Value.push_back('\0');
+            for (int id = 0; id < str_max_length.toInt() - Operande_prev.toUtf8().size() - 1; id++)
+                Value.push_back('\0');
 
-                op = operande(addr,"fill", Value);
+            op = operande(addr, "fill", Value);
 
-            }
-
-            else if ((type == "string")||(type == "dialog")){
-                QString Operande = (excelScenarioSheet.read(idx_row+1, idx_operande).toString());
-                Value = Operande.toUtf8();
-                QTextCodec *codec = QTextCodec::codecForName(OutputDatFileEncoding.toUtf8());
-                QByteArray Value = codec->fromUnicode(Operande);
-                Value.replace('\n', 1);
-
-                op = operande(addr,type, Value);
-            }
-            else if (type == "bytearray"){
-
-                            while(type == "bytearray"){
-                                unsigned char Operande = ((excelScenarioSheet.read(idx_row+1, idx_operande).toInt())& 0x000000FF);
-                                Value.push_back(Operande);
-                                idx_operande++;
-                                type = excelScenarioSheet.read(idx_row, idx_operande).toString();
-                            }
-                            op = operande(addr,"bytearray", Value);
-                            idx_operande--;
-                        }
-            else if (type == "pointer"){
-                QString Operande = (excelScenarioSheet.read(idx_row+1, idx_operande).toString());
-
-                QString RowPointedStr = Operande.right(Operande.length()-2);
-
-                int actual_row = RowPointedStr.toInt();
-
-                Value = GetBytesFromInt(actual_row);
-
-                op = operande(addr,"pointer", Value);
-
-            }
-            this->AddOperande(op);
-            idx_operande++;
-            addr = addr + op.getLength();
-            type = excelScenarioSheet.read(idx_row, idx_operande).toString();
         }
 
-}
-int Instruction::get_Nb_operandes(){
-    return operandes.size();
-}
-operande Instruction::get_operande(int i){
-    return operandes[i];
-}
+        else if ((type == "string") || (type == "dialog")) {
+            QString Operande = (excelScenarioSheet.read(idx_row + 1, idx_operande).toString());
+            Value = Operande.toUtf8();
+            QTextCodec* codec = QTextCodec::codecForName(OutputDatFileEncoding.toUtf8());
+            QByteArray Value = codec->fromUnicode(Operande);
+            Value.replace('\n', 1);
 
-int Instruction::get_addr_instr(){
-    return this->addr_instr;
-}
-void Instruction::WriteDat()
-{
+            op = operande(addr, type, Value);
+        } else if (type == "bytearray") {
 
+            while (type == "bytearray") {
+                unsigned char Operande = ((excelScenarioSheet.read(idx_row + 1, idx_operande).toInt()) & 0x000000FF);
+                Value.push_back(Operande);
+                idx_operande++;
+                type = excelScenarioSheet.read(idx_row, idx_operande).toString();
+            }
+            op = operande(addr, "bytearray", Value);
+            idx_operande--;
+        } else if (type == "pointer") {
+            QString Operande = (excelScenarioSheet.read(idx_row + 1, idx_operande).toString());
+
+            QString RowPointedStr = Operande.right(Operande.length() - 2);
+
+            int actual_row = RowPointedStr.toInt();
+
+            Value = GetBytesFromInt(actual_row);
+
+            op = operande(addr, "pointer", Value);
+        }
+        this->AddOperande(op);
+        idx_operande++;
+        addr = addr + op.getLength();
+        type = excelScenarioSheet.read(idx_row, idx_operande).toString();
+    }
 }
-int Instruction::WriteXLSX(QXlsx::Document &excelScenarioSheet, std::vector<function> funs, int row, int &col)
-{
+int Instruction::get_Nb_operandes() { return operandes.size(); }
+operande Instruction::get_operande(int i) { return operandes[i]; }
+
+int Instruction::get_addr_instr() { return this->addr_instr; }
+void Instruction::WriteDat() {}
+int Instruction::WriteXLSX(QXlsx::Document& excelScenarioSheet, std::vector<function> funs, int row, int& col) {
     QXlsx::Format FormatInstr;
     QXlsx::Format FormatType;
     QXlsx::Format FormatOP;
-    QColor ColorBg = QColor(qRgb(255,230,210));
+    QColor ColorBg = QColor(qRgb(255, 230, 210));
     FormatType.setHorizontalAlignment(QXlsx::Format::AlignHCenter);
     FormatType.setVerticalAlignment(QXlsx::Format::AlignVCenter);
     FormatType.setTextWrap(true);
@@ -144,7 +124,6 @@ int Instruction::WriteXLSX(QXlsx::Document &excelScenarioSheet, std::vector<func
     FormatType.setRightBorderStyle(QXlsx::Format::BorderThin);
     FormatType.setTopBorderStyle(QXlsx::Format::BorderThin);
     FormatType.setPatternBackgroundColor(ColorBg);
-
 
     FormatInstr.setBottomBorderStyle(QXlsx::Format::BorderThin);
     FormatInstr.setLeftBorderStyle(QXlsx::Format::BorderThin);
@@ -159,94 +138,89 @@ int Instruction::WriteXLSX(QXlsx::Document &excelScenarioSheet, std::vector<func
     FormatType.setFontBold(true);
     QColor color;
 
-
-    color = QColor::fromHsl((int)OPCode,255,185,255);
+    color = QColor::fromHsl((int)OPCode, 255, 185, 255);
     FormatOP.setPatternBackgroundColor(color);
 
-    excelScenarioSheet.write(row, col + 2, "OP Code",FormatType);
-    excelScenarioSheet.write(row+1, col + 2, OPCode,FormatOP);
+    excelScenarioSheet.write(row, col + 2, "OP Code", FormatType);
+    excelScenarioSheet.write(row + 1, col + 2, OPCode, FormatOP);
     int col_cnt = 0;
-    for (uint idx_op = 0; idx_op < operandes.size(); idx_op++){
+    for (uint idx_op = 0; idx_op < operandes.size(); idx_op++) {
 
         QString type = operandes[idx_op].getType();
         QByteArray Value = operandes[idx_op].getValue();
 
-
-        if (type == "int"){
-            excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
-            excelScenarioSheet.write(row+1, col + 3+col_cnt, ReadIntegerFromByteArray(0,Value),FormatInstr);
+        if (type == "int") {
+            excelScenarioSheet.write(row, col + 3 + col_cnt, type, FormatType);
+            excelScenarioSheet.write(row + 1, col + 3 + col_cnt, ReadIntegerFromByteArray(0, Value), FormatInstr);
             col_cnt++;
-        }
-        else if (type == "float"){
-            excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
-            excelScenarioSheet.write(row+1, col + 3+col_cnt, QByteArrayToFloat(Value), FormatInstr);
+        } else if (type == "float") {
+            excelScenarioSheet.write(row, col + 3 + col_cnt, type, FormatType);
+            excelScenarioSheet.write(row + 1, col + 3 + col_cnt, QByteArrayToFloat(Value), FormatInstr);
             col_cnt++;
-        }
-        else if (type == "short"){
-            excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
-            excelScenarioSheet.write(row+1, col + 3+col_cnt, (ushort)ReadShortFromByteArray(0,Value),FormatInstr);
+        } else if (type == "short") {
+            excelScenarioSheet.write(row, col + 3 + col_cnt, type, FormatType);
+            excelScenarioSheet.write(row + 1, col + 3 + col_cnt, (ushort)ReadShortFromByteArray(0, Value), FormatInstr);
             col_cnt++;
-        }
-        else if (type == "byte"){
+        } else if (type == "byte") {
 
-            excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
-            excelScenarioSheet.write(row+1, col + 3+col_cnt, (unsigned char)Value[0],FormatInstr);
+            excelScenarioSheet.write(row, col + 3 + col_cnt, type, FormatType);
+            excelScenarioSheet.write(row + 1, col + 3 + col_cnt, (unsigned char)Value[0], FormatInstr);
             col_cnt++;
-        }
-        else if (type == "fill"){
-            excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
-            excelScenarioSheet.write(row+1, col + 3+col_cnt, "="+QString::number(operandes[idx_op].getBytesToFill())+"-LENB(INDIRECT(ADDRESS("+QString::number(row+1)+","+QString::number(3+col_cnt-1)+")))",FormatInstr);
+        } else if (type == "fill") {
+            excelScenarioSheet.write(row, col + 3 + col_cnt, type, FormatType);
+            excelScenarioSheet.write(row + 1,
+                                     col + 3 + col_cnt,
+                                     "=" + QString::number(operandes[idx_op].getBytesToFill()) + "-LENB(INDIRECT(ADDRESS(" +
+                                       QString::number(row + 1) + "," + QString::number(3 + col_cnt - 1) + ")))",
+                                     FormatInstr);
             col_cnt++;
-        }
-        else if (type == "bytearray"){
+        } else if (type == "bytearray") {
 
-                   for (int idx_byte = 0; idx_byte<Value.size(); idx_byte++){
-                       excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
-                       excelScenarioSheet.write(row+1, col + 3+col_cnt, (unsigned char)Value[idx_byte],FormatInstr);
-                       col_cnt++;
-                   }
+            for (int idx_byte = 0; idx_byte < Value.size(); idx_byte++) {
+                excelScenarioSheet.write(row, col + 3 + col_cnt, type, FormatType);
+                excelScenarioSheet.write(row + 1, col + 3 + col_cnt, (unsigned char)Value[idx_byte], FormatInstr);
+                col_cnt++;
+            }
 
-               }
-        else if (type == "instruction"){
-                   int addr = 0;
+        } else if (type == "instruction") {
+            int addr = 0;
 
-                   std::shared_ptr<Instruction> instr = Maker->CreateInstructionFromDAT(addr,Value,0);//function type is 0 here because sub05 is only called by OP Code instructions.
-                   int column_instr = col + 3+col_cnt - 2;
-                   int cnt;
-                   cnt = instr->WriteXLSX(excelScenarioSheet,funs,row,column_instr);
+            std::shared_ptr<Instruction> instr = Maker->CreateInstructionFromDAT(
+              addr, Value, 0); // function type is 0 here because sub05 is only called by OP Code instructions.
+            int column_instr = col + 3 + col_cnt - 2;
+            int cnt;
+            cnt = instr->WriteXLSX(excelScenarioSheet, funs, row, column_instr);
 
-                   col = col + cnt+1;
+            col = col + cnt + 1;
 
-               }
-        else if ((type == "string")||(type == "dialog")){
+        } else if ((type == "string") || (type == "dialog")) {
 
-            excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
+            excelScenarioSheet.write(row, col + 3 + col_cnt, type, FormatType);
             QByteArray value_ = Value;
 
             value_.replace(1, "\n");
 
-            QTextCodec *codec = QTextCodec::codecForName(InputDatFileEncoding.toUtf8());
+            QTextCodec* codec = QTextCodec::codecForName(InputDatFileEncoding.toUtf8());
 
             QString string = codec->toUnicode(value_);
 
-            excelScenarioSheet.write(row+1, col + 3+col_cnt, string,FormatInstr);
+            excelScenarioSheet.write(row + 1, col + 3 + col_cnt, string, FormatInstr);
             col_cnt++;
-        }
-        else if (type == "pointer"){
-            excelScenarioSheet.write(row, col + 3+col_cnt, type,FormatType);
+        } else if (type == "pointer") {
+            excelScenarioSheet.write(row, col + 3 + col_cnt, type, FormatType);
             int ID = funs[0].ID;
             int nb_row = 3;
             int idx_fun = 0;
-            while (ID != operandes[idx_op].getDestination().FunctionID){
+            while (ID != operandes[idx_op].getDestination().FunctionID) {
 
-                nb_row = nb_row + 1; //row with function name
+                nb_row = nb_row + 1; // row with function name
                 nb_row = nb_row + 2 * funs[idx_fun].InstructionsInFunction.size();
                 idx_fun++;
                 ID = funs[idx_fun].ID;
             }
-            nb_row = nb_row + 1; //row with function name
-            nb_row = nb_row + 2 * (operandes[idx_op].getDestination().InstructionID+1);
-            QString ptrExcel = "=A"+QString::number((nb_row));
+            nb_row = nb_row + 1; // row with function name
+            nb_row = nb_row + 2 * (operandes[idx_op].getDestination().InstructionID + 1);
+            QString ptrExcel = "=A" + QString::number((nb_row));
 
             QXlsx::Format format;
             format.setBottomBorderStyle(QXlsx::Format::BorderThin);
@@ -254,53 +228,47 @@ int Instruction::WriteXLSX(QXlsx::Document &excelScenarioSheet, std::vector<func
             format.setRightBorderStyle(QXlsx::Format::BorderThin);
             format.setTopBorderStyle(QXlsx::Format::BorderThin);
             format.setFontBold(true);
-            QColor FontColor = QColor(qRgb(255,0,0));
+            QColor FontColor = QColor(qRgb(255, 0, 0));
             format.setFontColor(FontColor);
-            excelScenarioSheet.write(row+1, col + 3+col_cnt, ptrExcel,format);
+            excelScenarioSheet.write(row + 1, col + 3 + col_cnt, ptrExcel, format);
             col_cnt++;
         }
-
-
     }
 
     return col_cnt;
 }
-void Instruction::set_addr_instr(int i){
-    addr_instr = i;
-}
+void Instruction::set_addr_instr(int i) { addr_instr = i; }
 /*This version of AddOperande is supposed to check if a string contain illegal xml characters,
 but I didn't finish it yet.
 If there is any illegal xml character, every string in the sheet disappears and the file can't be decompiled,
 this is a problem for some broken files that we would want to restore (example is ply000 from CS3)*/
-void Instruction::AddOperande(operande op){
+void Instruction::AddOperande(operande op) {
 
     QByteArray value = op.getValue();
 
-    if (op.getType()=="string"){
+    if (op.getType() == "string") {
         QTextCodec::ConverterState state;
 
-        QTextCodec *codec = QTextCodec::codecForName(InputDatFileEncoding.toUtf8());
+        QTextCodec* codec = QTextCodec::codecForName(InputDatFileEncoding.toUtf8());
         const QString text = codec->toUnicode(value, value.size(), &state);
 
-        if ((state.invalidChars > 0)||text.contains('\x0B')||text.contains('\x06')||text.contains('\x07')||text.contains('\x08')||text.contains('\x05')||text.contains('\x04')||text.contains('\x03')||text.contains('\x02')) {
+        if ((state.invalidChars > 0) || text.contains('\x0B') || text.contains('\x06') || text.contains('\x07') || text.contains('\x08') ||
+            text.contains('\x05') || text.contains('\x04') || text.contains('\x03') || text.contains('\x02')) {
             op.setValue(QByteArray(0));
 
-            //operandes.push_back(op);
-        }
-        else{
-            //qDebug() << "value: " << value;
+            // operandes.push_back(op);
+        } else {
+            // qDebug() << "value: " << value;
             operandes.push_back(op);
         }
-    }
-    else {
+    } else {
         operandes.push_back(op);
     }
-     //if (op.getType()=="pointer") qDebug() << "pointer: " << hex << ReadIntegerFromByteArray(0,value);
+    // if (op.getType()=="pointer") qDebug() << "pointer: " << hex << ReadIntegerFromByteArray(0,value);
 
+    // if (op.getType()=="string") qDebug() << value;
 
-    //if (op.getType()=="string") qDebug() << value;
-
-    //if (op.getType()=="pointer") qDebug() << "pointer: " << hex << ReadIntegerFromByteArray(0,value);
+    // if (op.getType()=="pointer") qDebug() << "pointer: " << hex << ReadIntegerFromByteArray(0,value);
 }
 
 /*void Instruction::AddOperande(operande op){
@@ -313,23 +281,18 @@ void Instruction::AddOperande(operande op){
 
     //if (op.getType()=="pointer") qDebug() << "pointer: " << hex << ReadIntegerFromByteArray(0,value);
 }*/
-int Instruction::get_length_in_bytes(){
+int Instruction::get_length_in_bytes() { return getBytes().size(); }
 
-    return getBytes().size();
-}
-
-uint Instruction::get_OP(){
-    return OPCode;
-}
-QByteArray Instruction::getBytes(){
+uint Instruction::get_OP() { return OPCode; }
+QByteArray Instruction::getBytes() {
     QByteArray bytes;
-    if (OPCode<=0xFF) bytes.push_back((unsigned char) OPCode);
-    for (std::vector<operande>::iterator it = operandes.begin(); it!=operandes.end();it++) {
+    if (OPCode <= 0xFF) bytes.push_back((unsigned char)OPCode);
+    for (std::vector<operande>::iterator it = operandes.begin(); it != operandes.end(); it++) {
 
         QByteArray op_bytes = it->getValue();
-        if (it->getType()=="string") op_bytes.push_back('\x0');
-        for (int i = 0; i < op_bytes.size(); i++) bytes.push_back(op_bytes[i]);
-
+        if (it->getType() == "string") op_bytes.push_back('\x0');
+        for (int i = 0; i < op_bytes.size(); i++)
+            bytes.push_back(op_bytes[i]);
     }
     return bytes;
 }

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -1,49 +1,46 @@
-#include <QCoreApplication>
-#include "headers/global_vars.h"
 #include "headers/decompiler.h"
+#include "headers/global_vars.h"
+#include <QCoreApplication>
 #include <QDir>
 #include <QSettings>
 QString Game;
 QString InputDatFileEncoding;
 QString OutputDatFileEncoding;
 
+QString header[] = { ".                           ,##(&%%@                                            ",
+                     "          .           .  ..(##/%%%%%%%&. .                  ....                ",
+                     "          .           (.../##/%%%##(%%%%%/,.....,*(/  .  (%#((%%/.              ",
+                     "                  .. ....(##(%%%#(/#..............*#,....*&%%%%%&               ",
+                     "                   /....####%%%%/....................*..//*..,/#%. .            ",
+                     "                  (.,.*%##*%%%....... ..........................%%,             ",
+                     "               . #.(.,#%%%%%(......... ...,,*,.....,,........... .#, .          ",
+                     "                (.(,%(((%%%*.......,.*....*,.,.*.#............,. .., .          ",
+                     "              .#.(#####%&%*.............,(.., .(#..,........,..*......          ",
+                     "              (.(%#(/%%%%%.,..,..*...*.#,(*..#,(,(/..... ...#.........          ",
+                     "             ,..(/%%%&%%%....(.....,*.(*(*..,.%/./*,........(.../..,..*         ",
+                     "          .. *.,(/(%%%&%%.(.(.../.,#.*,*%./. *(,*(,.,......//,..(..,..(         ",
+                     "           .(..,(.((&%%%*./##...(./*/,  #/./((*#((,(,...,./*.*.(/..,..(         ",
+                     "          . ....(.#(((((.(,(/,..((#%@@@@&* **#%*#(%*...*.*,*%,#(......*.        ",
+                     "          .(...,,/(((((%,,,/*...(,/.,#(&,/,@&(,/(/,.//((/ /**,#...*... .        ",
+                     "         . ....,.#((//((/(,*,...#,   .((,       */,..@@@@@@**#...,..(*          ",
+                     "        . #....,.((,/,(,..*,,...(,                 . * .( #./..(,..%*           ",
+                     "         /,...*,,(,*.((..(&.*...(,                     ,  /(,##../ ,(.          ",
+                     "        ..,...(*(,/..((..*##/.../,,              *       ,(((#./ .  (           ",
+                     "        ,,....((/,.,(((...(%#..,&/,,                     %(((##  .              ",
+                     "       /.*...((#../(#((,,..(%..,%,,#,                 ./%(((((#  .              ",
+                     "      *.(...,((..(((#((%,..,(...* ,,,*% .     .... #####%(((((#                 ",
+                     "   . ..(*...(*..((((%(#%.(..,#...,%#/,,,*//.*&&%#%%###((#*((((#  .              ",
+                     "   . *((.../* **      , (.*....../,  %(((*,,(#&//&&%#((((.(((((  .              ",
+                     "    #((/.,...,    ,      .%*......(.   ,,#(#%&&&&&&&,&#/(,(/(((*                ",
+                     "  .#(((*.*,#,,,      ,   **%/......#((  .*(#%&&&&&*.%/%( /.#(((( .              ",
+                     " ./#,.%.../.           .  #(((......*.  ./(%%%(*(&&&&/&#,#.*#*((( ..            ",
+                     ",((((//. (#             .  #(,(......#. (((. *./*((/@/&&,,..##,.((%.            ",
+                     "%(/(/(*./(/.           , .  /(,(....../,((*,(  #(.,(((#*,,*..%#(...,/.         (",
+                     "( (((//(,**/*/*(      ,,.*,   (*(..*.,./(%..((&*/.%(.../# *..,,*&,....*      #**",
+                     " (/#///((*,*...       ,,(((/***(%/..(....#%,,.(#%#&#.,,,,%*#../,  #*...../ %**##",
+                     "(/(/////%            ,(/%*,  .,,((..,#..*.(,(,*##%%%%(,,.,*/#(..(, ,.*...#**##*." };
 
-QString header[] = {".                           ,##(&%%@                                            ",
-                    "          .           .  ..(##/%%%%%%%&. .                  ....                ",
-                    "          .           (.../##/%%%##(%%%%%/,.....,*(/  .  (%#((%%/.              ",
-                    "                  .. ....(##(%%%#(/#..............*#,....*&%%%%%&               ",
-                    "                   /....####%%%%/....................*..//*..,/#%. .            ",
-                    "                  (.,.*%##*%%%....... ..........................%%,             ",
-                    "               . #.(.,#%%%%%(......... ...,,*,.....,,........... .#, .          ",
-                    "                (.(,%(((%%%*.......,.*....*,.,.*.#............,. .., .          ",
-                    "              .#.(#####%&%*.............,(.., .(#..,........,..*......          ",
-                    "              (.(%#(/%%%%%.,..,..*...*.#,(*..#,(,(/..... ...#.........          ",
-                    "             ,..(/%%%&%%%....(.....,*.(*(*..,.%/./*,........(.../..,..*         ",
-                    "          .. *.,(/(%%%&%%.(.(.../.,#.*,*%./. *(,*(,.,......//,..(..,..(         ",
-                    "           .(..,(.((&%%%*./##...(./*/,  #/./((*#((,(,...,./*.*.(/..,..(         ",
-                    "          . ....(.#(((((.(,(/,..((#%@@@@&* **#%*#(%*...*.*,*%,#(......*.        ",
-                    "          .(...,,/(((((%,,,/*...(,/.,#(&,/,@&(,/(/,.//((/ /**,#...*... .        ",
-                    "         . ....,.#((//((/(,*,...#,   .((,       */,..@@@@@@**#...,..(*          ",
-                    "        . #....,.((,/,(,..*,,...(,                 . * .( #./..(,..%*           ",
-                    "         /,...*,,(,*.((..(&.*...(,                     ,  /(,##../ ,(.          ",
-                    "        ..,...(*(,/..((..*##/.../,,              *       ,(((#./ .  (           ",
-                    "        ,,....((/,.,(((...(%#..,&/,,                     %(((##  .              ",
-                    "       /.*...((#../(#((,,..(%..,%,,#,                 ./%(((((#  .              ",
-                    "      *.(...,((..(((#((%,..,(...* ,,,*% .     .... #####%(((((#                 ",
-                    "   . ..(*...(*..((((%(#%.(..,#...,%#/,,,*//.*&&%#%%###((#*((((#  .              ",
-                    "   . *((.../* **      , (.*....../,  %(((*,,(#&//&&%#((((.(((((  .              ",
-                    "    #((/.,...,    ,      .%*......(.   ,,#(#%&&&&&&&,&#/(,(/(((*                ",
-                    "  .#(((*.*,#,,,      ,   **%/......#((  .*(#%&&&&&*.%/%( /.#(((( .              ",
-                    " ./#,.%.../.           .  #(((......*.  ./(%%%(*(&&&&/&#,#.*#*((( ..            ",
-                    ",((((//. (#             .  #(,(......#. (((. *./*((/@/&&,,..##,.((%.            ",
-                    "%(/(/(*./(/.           , .  /(,(....../,((*,(  #(.,(((#*,,*..%#(...,/.         (",
-                    "( (((//(,**/*/*(      ,,.*,   (*(..*.,./(%..((&*/.%(.../# *..,,*&,....*      #**",
-                    " (/#///((*,*...       ,,(((/***(%/..(....#%,,.(#%#&#.,,,,%*#../,  #*...../ %**##",
-                    "(/(/////%            ,(/%*,  .,,((..,#..*.(,(,*##%%%%(,,.,*/#(..(, ,.*...#**##*."};
-
-
-int main(int argc, char *argv[])
-    {
+int main(int argc, char* argv[]) {
     QCoreApplication a(argc, argv);
     QSettings settings(QCoreApplication::applicationDirPath() + "/config.ini", QSettings::IniFormat);
     Game = settings.value("Game", "CS4").toString();
@@ -54,10 +51,12 @@ int main(int argc, char *argv[])
     Dc.SetupGame("CS4");
     QDir directory("C:/Users/Antoine/Desktop/CS4Debug");
     QStringList dat = directory.entryList(QStringList() << "*.dat",QDir::Files);
-    Dc.CheckAllFiles(dat, "C:/Users/Antoine/Desktop/CS4Debug", "C:/Users/Antoine/Documents/build-SenScriptsDecompiler-Desktop_Qt_5_9_9_MSVC2015_32bit-Release");
+    Dc.CheckAllFiles(dat, "C:/Users/Antoine/Desktop/CS4Debug",
+    "C:/Users/Antoine/Documents/build-SenScriptsDecompiler-Desktop_Qt_5_9_9_MSVC2015_32bit-Release");
     */
-    if (argc < 2){
-        for (int i = 0; i < 32; i++) display_text(header[i]);
+    if (argc < 2) {
+        for (int i = 0; i < 32; i++)
+            display_text(header[i]);
         display_text("----------------------------------------------------------------------------------------------------------");
         display_text("This tool was first meant for translation projects of the Trails of Cold Steel games, starting with ToCS3.");
         display_text("Then it has become a tool for modding in general.");
@@ -68,44 +67,38 @@ int main(int argc, char *argv[])
         display_text("3- SenScriptsDecompiler.exe <Game> <filepath_to_convert> <output_folder>");
         display_text("Encodings can be defined in the config.ini file.");
         display_text("The output format is decided by the extension of the input file: XLSX gives a DAT and DAT gives a XLSX.");
-        display_text("If you need more assistance, please join the discord server for modding Trails games: https://discord.gg/XpFrXWht6j");
+        display_text("If you need more assistance, please join the discord server for modding Trails games: "
+                     "https://discord.gg/XpFrXWht6j");
         display_text("Credits to NZerker and kirigaia for their support and testing.");
-    }
-    else if (argc >= 2)
-    {
+    } else if (argc >= 2) {
         QString full_path;
         if (argc == 3) {
             Game = QCoreApplication::arguments().at(1);
             full_path = QCoreApplication::arguments().at(2);
-        }
-        else if (argc == 4) {
+        } else if (argc == 4) {
             Game = QCoreApplication::arguments().at(1);
             full_path = QCoreApplication::arguments().at(2);
             output_folder = QCoreApplication::arguments().at(3);
-        }
-        else {
+        } else {
             full_path = QCoreApplication::arguments().at(1);
         }
         QFileInfo info_file = QFileInfo(full_path);
 
         QDir directory = info_file.absoluteDir();
         QString file = info_file.fileName();
-        QFileInfoList dat = directory.entryInfoList(QStringList() << file,QDir::Files);
+        QFileInfoList dat = directory.entryInfoList(QStringList() << file, QDir::Files);
 
-        if (!dat.isEmpty())
-        {
-            foreach(QFileInfo file_, dat){
+        if (!dat.isEmpty()) {
+            foreach (QFileInfo file_, dat) {
                 Decompiler Dc;
                 Dc.SetupGame(Game);
                 Dc.ReadFile(file_.absoluteFilePath());
-                Dc.WriteFile(file_.absoluteFilePath(),output_folder);
+                Dc.WriteFile(file_.absoluteFilePath(), output_folder);
             }
-        }
-        else {
+        } else {
             display_text("No file was found.");
         }
     }
-
 
     return 0;
 }

--- a/sources/translationfile.cpp
+++ b/sources/translationfile.cpp
@@ -1,21 +1,9 @@
 #include "headers/translationfile.h"
 
-TranslationFile::TranslationFile()
-{
+TranslationFile::TranslationFile() {}
 
-}
+void TranslationFile::setName(QString name) { SceneName = name; }
+QString TranslationFile::getName() { return SceneName; }
+int TranslationFile::getNbFunctions() { return FunctionsInFile.size(); }
 
-void TranslationFile::setName(QString name){
-    SceneName = name;
-}
-QString TranslationFile::getName(){
-    return SceneName;
-}
-int TranslationFile::getNbFunctions(){
-    return FunctionsInFile.size();
-}
-
-
-void TranslationFile::addFunction(function fun){
-    FunctionsInFile.push_back(fun);
-}
+void TranslationFile::addFunction(function fun) { FunctionsInFile.push_back(fun); }

--- a/sources/utilities.cpp
+++ b/sources/utilities.cpp
@@ -1,26 +1,26 @@
 #include "headers/utilities.h"
 
-void display_text(QString text){
+void display_text(QString text) {
     QTextStream out(stdout);
     out << text << Qt::endl;
 }
-QString ConvertBytesToString(QByteArray Bytes){
+QString ConvertBytesToString(QByteArray Bytes) {
     QString DataAsString = QString::fromStdString(Bytes.toStdString());
     return DataAsString;
 }
-QString ReadStringFromByteArray(int start_pos, QByteArray &content){
+QString ReadStringFromByteArray(int start_pos, QByteArray& content) {
 
     QString filename = "";
-    while (content.at(start_pos)!=0) {
+    while (content.at(start_pos) != 0) {
         filename.push_back((char)content.at(start_pos));
         start_pos++;
     }
 
     return filename;
 }
-QByteArray ReadStringSubByteArray(QByteArray &content, int &addr){
+QByteArray ReadStringSubByteArray(QByteArray& content, int& addr) {
     QByteArray result;
-    while (content.at(addr)!=0) {
+    while (content.at(addr) != 0) {
         result.push_back(content.at(addr));
         addr++;
     }
@@ -28,23 +28,24 @@ QByteArray ReadStringSubByteArray(QByteArray &content, int &addr){
     addr++;
     return result;
 }
-int ReadIntegerFromByteArray(int start_pos, QByteArray &content){
-    int size = ((static_cast<unsigned int>(content[start_pos+0]) & 0xFF) << 0)
-            + ((static_cast<unsigned int>(content[start_pos+1]) & 0xFF) << 8)
-            + ((static_cast<unsigned int>(content[start_pos+2]) & 0xFF) << 16)
-            + ((static_cast<unsigned int>(content[start_pos+3]) & 0xFF) << 24);
+int ReadIntegerFromByteArray(int start_pos, QByteArray& content) {
+    int size = ((static_cast<unsigned int>(content[start_pos + 0]) & 0xFF) << 0) +
+               ((static_cast<unsigned int>(content[start_pos + 1]) & 0xFF) << 8) +
+               ((static_cast<unsigned int>(content[start_pos + 2]) & 0xFF) << 16) +
+               ((static_cast<unsigned int>(content[start_pos + 3]) & 0xFF) << 24);
     return size;
-
 }
-QByteArray GetBytesFromFloat(float f){
+QByteArray GetBytesFromFloat(float f) {
     QByteArray array(reinterpret_cast<const char*>(&f), sizeof(f));
     return array;
 }
-bool isMultiple0x10(QString fun_name){
-    if ((fun_name == "PTN_TABLE")||(fun_name.startsWith("FC_auto"))||(fun_name.startsWith("_"))) return true; //||(fun_name.startsWith("ReactionTable"))
-    else return false;
+bool isMultiple0x10(QString fun_name) {
+    if ((fun_name == "PTN_TABLE") || (fun_name.startsWith("FC_auto")) || (fun_name.startsWith("_")))
+        return true; //||(fun_name.startsWith("ReactionTable"))
+    else
+        return false;
 }
-QByteArray GetBytesFromInt(int i){
+QByteArray GetBytesFromInt(int i) {
     QByteArray q_b;
     q_b.push_back(i & 0x000000ff);
     q_b.push_back((i & 0x0000ff00) >> 8);
@@ -53,31 +54,30 @@ QByteArray GetBytesFromInt(int i){
 
     return q_b;
 }
-QByteArray GetBytesFromShort(short i){
+QByteArray GetBytesFromShort(short i) {
     QByteArray q_b;
     q_b.push_back(i & 0x00ff);
     q_b.push_back((i & 0xff00) >> 8);
 
     return q_b;
 }
-float QByteArrayToFloat(QByteArray &arr) //thanks to jabk https://stackoverflow.com/questions/36859447/qbytearray-to-float
+float QByteArrayToFloat(QByteArray& arr) // thanks to jabk https://stackoverflow.com/questions/36859447/qbytearray-to-float
 {
     static_assert(std::numeric_limits<float>::is_iec559, "Only supports IEC 559 (IEEE 754) float");
 
-
-    quint32 temp = ((unsigned char)arr[3] << 24)|((unsigned char)arr[2] << 16)|((unsigned char)arr[1] << 8)|(unsigned char)arr[0]; // Big endian
+    quint32 temp =
+      ((unsigned char)arr[3] << 24) | ((unsigned char)arr[2] << 16) | ((unsigned char)arr[1] << 8) | (unsigned char)arr[0]; // Big endian
     float* out = reinterpret_cast<float*>(&temp);
 
     return *out;
 }
 
-short ReadShortFromByteArray(int start_pos, QByteArray &content){
-    short size = ((static_cast<short>(content[start_pos+0]) & 0xFF) << 0)
-             + ((static_cast<short>(content[start_pos+1]) & 0xFF) << 8);
+short ReadShortFromByteArray(int start_pos, QByteArray& content) {
+    short size = ((static_cast<short>(content[start_pos + 0]) & 0xFF) << 0) + ((static_cast<short>(content[start_pos + 1]) & 0xFF) << 8);
 
     return size;
 }
-QByteArray ReadSubByteArray(QByteArray &content, int &addr, int size){
+QByteArray ReadSubByteArray(QByteArray& content, int& addr, int size) {
     int start = addr;
     addr = start + size;
 

--- a/sources/utitilies.cpp
+++ b/sources/utitilies.cpp
@@ -1,63 +1,59 @@
 #include "headers/utilities.h"
 
-void display_text(QString text){
+void display_text(QString text) {
     QTextStream out(stdout);
     out << text << endl;
 }
-QString ConvertBytesToString(QByteArray Bytes){
+QString ConvertBytesToString(QByteArray Bytes) {
     QString DataAsString = QString::fromStdString(Bytes.toStdString());
     return DataAsString;
 }
-QString ReadStringFromByteArray(int start_pos, QByteArray &content){
+QString ReadStringFromByteArray(int start_pos, QByteArray& content) {
 
     QString filename = "";
-    while (content.at(start_pos)!=0) {
+    while (content.at(start_pos) != 0) {
         filename.push_back((char)content.at(start_pos));
         start_pos++;
     }
 
     return filename;
 }
-QByteArray ReadStringSubByteArray(QByteArray &content, int &addr){
+QByteArray ReadStringSubByteArray(QByteArray& content, int& addr) {
     QByteArray result;
-    while (content.at(addr)!=0) {
+    while (content.at(addr) != 0) {
         result.push_back(content.at(addr));
         addr++;
     }
-    //result.push_back(content.at(addr));
+    // result.push_back(content.at(addr));
     addr++;
     return result;
 }
-int ReadIntegerFromByteArray(int start_pos, QByteArray &content){
-    int size = ((static_cast<unsigned int>(content[start_pos+0]) & 0xFF) << 0)
-            + ((static_cast<unsigned int>(content[start_pos+1]) & 0xFF) << 8)
-            + ((static_cast<unsigned int>(content[start_pos+2]) & 0xFF) << 16)
-            + ((static_cast<unsigned int>(content[start_pos+3]) & 0xFF) << 24);
-    start_pos+=4;
+int ReadIntegerFromByteArray(int start_pos, QByteArray& content) {
+    int size = ((static_cast<unsigned int>(content[start_pos + 0]) & 0xFF) << 0) +
+               ((static_cast<unsigned int>(content[start_pos + 1]) & 0xFF) << 8) +
+               ((static_cast<unsigned int>(content[start_pos + 2]) & 0xFF) << 16) +
+               ((static_cast<unsigned int>(content[start_pos + 3]) & 0xFF) << 24);
+    start_pos += 4;
     return size;
-
 }
-float QByteArrayToFloat(QByteArray arr) //thanks to jabk https://stackoverflow.com/questions/36859447/qbytearray-to-float
+float QByteArrayToFloat(QByteArray arr) // thanks to jabk https://stackoverflow.com/questions/36859447/qbytearray-to-float
 {
     static_assert(std::numeric_limits<float>::is_iec559, "Only supports IEC 559 (IEEE 754) float");
 
-
-    quint32 temp = ((unsigned char)arr[3] << 24)|((unsigned char)arr[2] << 16)|((unsigned char)arr[1] << 8)|(unsigned char)arr[0]; // Big endian
+    quint32 temp =
+      ((unsigned char)arr[3] << 24) | ((unsigned char)arr[2] << 16) | ((unsigned char)arr[1] << 8) | (unsigned char)arr[0]; // Big endian
     float* out = reinterpret_cast<float*>(&temp);
 
     return *out;
 }
-float ReadFloatFromByteArray(int start_pos, QByteArray &content){
-    return QByteArrayToFloat(content);
-}
+float ReadFloatFromByteArray(int start_pos, QByteArray& content) { return QByteArrayToFloat(content); }
 
-short ReadShortFromByteArray(int start_pos, QByteArray &content){
-    short size = ((static_cast<short>(content[start_pos+0]) & 0xFF) << 0)
-             + ((static_cast<short>(content[start_pos+1]) & 0xFF) << 8);
-    start_pos+=2;
+short ReadShortFromByteArray(int start_pos, QByteArray& content) {
+    short size = ((static_cast<short>(content[start_pos + 0]) & 0xFF) << 0) + ((static_cast<short>(content[start_pos + 1]) & 0xFF) << 8);
+    start_pos += 2;
     return size;
 }
-QByteArray ReadSubByteArray(QByteArray &content, int &addr, int size){
+QByteArray ReadSubByteArray(QByteArray& content, int& addr, int size) {
     int start = addr;
     addr = start + size;
 


### PR DESCRIPTION
Please take a look at the potential formatting and see what you think about it.

Here's how to use it with qtcreator https://doc.qt.io/qtcreator/creator-indenting-code.html

Although, don't use the option to override the .clang-format configuration file

The .clang-format-ignore is used by the meson clang-format target, so it can be ignored.