### PR TITLE
Support big objects for gcc on windows

### DIFF
--- a/SenScriptsDecompiler.pro
+++ b/SenScriptsDecompiler.pro
@@ -47,4 +47,7 @@ HEADERS += \
 win32-msvc* {
     QMAKE_CXXFLAGS += /bigobj
 }
+win32-g++:{
+  QMAKE_CXXFLAGS += -Wa,-mbig-obj
+}
 

--- a/meson.build
+++ b/meson.build
@@ -10,11 +10,12 @@ project('SenScriptsDecompiler',
 
 cpp_compiler = meson.get_compiler('cpp')
 
-if cpp_compiler.get_id() == 'msvc'
-    add_project_arguments(
-        '/bigobj',
-        language: 'cpp',
-    )
+if build_machine.system() == 'windows'
+    if cpp_compiler.get_id() == 'msvc'
+        add_project_arguments('/bigobj', language: 'cpp')
+    elif cpp_compiler.get_id() == 'gcc'
+        add_project_arguments('-Wa,-mbig-obj', language : 'cpp')
+    endif
 endif
 
 cpp_std_ver = ''


### PR DESCRIPTION
Both the .pro file and the meson-build file have -Wa,-mbigobj when
building with gcc on windows