### PR TITLE
Replace QFile for reading/write dat files with functions

### DIFF
--- a/headers/utilities.h
+++ b/headers/utilities.h
@@ -15,6 +15,11 @@
 
 #include "headers/exceptions.h"
 
+namespace ssd::utils {
+QByteArray read_file(const std::filesystem::path& filepath);
+void write_file(const std::filesystem::path& filepath, const QByteArray& content);
+} // namespace ssd::utils
+
 void display_text(const std::string& text);
 
 std::string ReadStringFromByteArray(int start_pos, const QByteArray& content);

--- a/sources/decompiler.cpp
+++ b/sources/decompiler.cpp
@@ -70,13 +70,7 @@ bool Decompiler::update_current_tf() {
     return true;
 }
 bool Decompiler::read_dat(const std::filesystem::path& filepath) {
-
-    QFile file(QString::fromStdString(filepath.string()));
-    if (!file.open(QIODevice::ReadOnly)) {
-        return false;
-    }
-
-    QByteArray content = file.readAll();
+    QByteArray content = ssd::utils::read_file(filepath);
 
     ib->CreateHeaderFromDAT(content);
     ib->ReadFunctionsDAT(content);
@@ -129,11 +123,9 @@ bool Decompiler::write_dat(const std::filesystem::path& output_dir) {
     if (!fs::exists(output_dir)) fs::create_directories(output_dir);
 
     fs::path output_path = output_dir / (current_tf.getName() += ".dat");
-    QFile file(QString::fromStdString(output_path.string()));
 
-    file.open(QIODevice::WriteOnly);
-    file.write(file_content);
-    file.close();
+    ssd::utils::write_file(output_path, file_content);
+
     display_text("File " + output_path.string() + " created.");
     return true;
 }
@@ -262,20 +254,10 @@ bool Decompiler::check_all_files(const std::filesystem::path& log_filename,
         qDebug() << "full done";
         qDebug() << "reading dat file" << QString::fromStdString(fs::path(local_dat_path).string());
         qDebug() << "reading dat file" << QString::fromStdString(reference_dat_path.string());
-        QFile file1(QString::fromStdString(fs::path(local_dat_path).string()));
-        QFile file2(QString::fromStdString(reference_dat_path.string()));
-        if (!file1.open(QIODevice::ReadOnly)) {
 
-            return false;
-        }
+        const QByteArray content1 = ssd::utils::read_file(local_dat_path);
+        const QByteArray content2 = ssd::utils::read_file(reference_dat_path);
 
-        const QByteArray content1 = file1.readAll();
-        if (!file2.open(QIODevice::ReadOnly)) {
-
-            return false;
-        }
-
-        const QByteArray content2 = file2.readAll();
         std::string msg = "Problème de taille avec " + file_stem;
 
         int length_header2 = ReadIntegerFromByteArray(0x18, content2);

--- a/sources/utilities.cpp
+++ b/sources/utilities.cpp
@@ -1,4 +1,33 @@
 #include "headers/utilities.h"
+#include <fstream>
+
+namespace ssd::utils {
+namespace fs = std::filesystem;
+QByteArray read_file(const std::filesystem::path& filepath) {
+    if (!fs::exists(filepath)) throw std::runtime_error("ERROR: File \"" + filepath.string() + "\" does not exist");
+    std::ifstream file;
+    file.exceptions(std::ifstream::badbit);
+    file.open(filepath, std::ios::in | std::ios::binary);
+
+    std::vector<char> temp_content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
+    file.close();
+
+    return QByteArray(reinterpret_cast<const char*>(temp_content.data()), (int)temp_content.size());
+}
+
+void write_file(const std::filesystem::path& filepath, const QByteArray& content) {
+    auto dir = filepath.parent_path();
+    if (!fs::exists(dir)) throw std::runtime_error("ERROR: Directory \"" + dir.string() + "\" does not exist");
+
+    std::ofstream file;
+    file.exceptions(std::ofstream::badbit);
+    file.open(filepath, std::ios::out | std::ios::binary);
+
+    file.write(reinterpret_cast<const char*>(content.data()), content.size());
+    file.close();
+}
+} // namespace ssd::utils
 
 void display_text(const std::string& text) {
     QTextStream out(stdout);


### PR DESCRIPTION
This introduces the ssd::utils namespace to avoid clashing with the Decompiler's read_file and
write_file. Also, exceptions are thrown, so read errors will be fatal and caught by the exception handler.